### PR TITLE
[BE] 행사 생성 기능 구현

### DIFF
--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -1,0 +1,25 @@
+package server.haengdong.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.EventAppResponse;
+import server.haengdong.domain.Event;
+import server.haengdong.domain.EventTokenProvider;
+import server.haengdong.persistence.EventRepository;
+
+@RequiredArgsConstructor
+@Service
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final EventTokenProvider eventTokenProvider;
+
+    public EventAppResponse saveEvent(EventAppRequest request) {
+        String token = eventTokenProvider.createToken();
+        Event event = request.toEvent(token);
+        eventRepository.save(event);
+
+         return EventAppResponse.of(event);
+    }
+}

--- a/server/src/main/java/server/haengdong/application/request/EventAppRequest.java
+++ b/server/src/main/java/server/haengdong/application/request/EventAppRequest.java
@@ -1,0 +1,10 @@
+package server.haengdong.application.request;
+
+import server.haengdong.domain.Event;
+
+public record EventAppRequest(String name) {
+
+    public Event toEvent(String token) {
+        return new Event(name, token);
+    }
+}

--- a/server/src/main/java/server/haengdong/application/response/EventAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/EventAppResponse.java
@@ -1,0 +1,10 @@
+package server.haengdong.application.response;
+
+import server.haengdong.domain.Event;
+
+public record EventAppResponse(String token) {
+
+    public static EventAppResponse of(Event event) {
+        return new EventAppResponse(event.getToken());
+    }
+}

--- a/server/src/main/java/server/haengdong/domain/Event.java
+++ b/server/src/main/java/server/haengdong/domain/Event.java
@@ -20,4 +20,9 @@ public class Event {
     private String name;
 
     private String token;
+
+    public Event(String name, String token) {
+        this.name = name;
+        this.token = token;
+    }
 }

--- a/server/src/main/java/server/haengdong/domain/EventTokenProvider.java
+++ b/server/src/main/java/server/haengdong/domain/EventTokenProvider.java
@@ -1,0 +1,12 @@
+package server.haengdong.domain;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventTokenProvider {
+
+    public String createToken() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/server/src/main/java/server/haengdong/persistence/EventRepository.java
+++ b/server/src/main/java/server/haengdong/persistence/EventRepository.java
@@ -1,0 +1,9 @@
+package server.haengdong.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import server.haengdong.domain.Event;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -1,0 +1,26 @@
+package server.haengdong.presentation;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.haengdong.application.EventService;
+import server.haengdong.application.response.EventAppResponse;
+import server.haengdong.presentation.request.EventSaveRequest;
+
+@RequiredArgsConstructor
+@RestController
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping("/api/events")
+    public ResponseEntity<Void> saveEvent(EventSaveRequest request) {
+        EventAppResponse eventAppResponse = eventService.saveEvent(request.toAppRequest());
+
+        return ResponseEntity.ok()
+                .location(URI.create("events/" + eventAppResponse.token()))
+                .build();
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
@@ -1,0 +1,10 @@
+package server.haengdong.presentation.request;
+
+import server.haengdong.application.request.EventAppRequest;
+
+public record EventSaveRequest(String name) {
+
+    public EventAppRequest toAppRequest() {
+        return new EventAppRequest(name);
+    }
+}

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -1,0 +1,35 @@
+package server.haengdong.application;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.EventAppResponse;
+import server.haengdong.domain.EventTokenProvider;
+
+@SpringBootTest
+class EventServiceTest {
+
+    @Autowired
+    private EventService eventService;
+
+    @MockBean
+    private EventTokenProvider eventTokenProvider;
+
+    @DisplayName("행사를 생성한다")
+    @Test
+    void saveEventTest() {
+        EventAppRequest request = new EventAppRequest("test");
+        given(eventTokenProvider.createToken()).willReturn("TOKEN");
+
+        EventAppResponse response = eventService.saveEvent(request);
+
+        assertThat(response.token()).isEqualTo("TOKEN");
+    }
+}

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -1,0 +1,51 @@
+package server.haengdong.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import server.haengdong.application.EventService;
+import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.EventAppResponse;
+import server.haengdong.presentation.request.EventSaveRequest;
+
+@WebMvcTest(EventController.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private EventService eventService;
+
+    @DisplayName("이벤트를 생성한다")
+    @Test
+    void saveEvent() throws Exception {
+        EventSaveRequest eventSaveRequest = new EventSaveRequest("test");
+        String requestBody = objectMapper.writeValueAsString(eventSaveRequest);
+        String token = "TOKEN";
+        EventAppResponse eventAppResponse = new EventAppResponse(token);
+        given(eventService.saveEvent(any(EventAppRequest.class))).willReturn(eventAppResponse);
+
+        mockMvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.redirectedUrl("events/" + token));
+    }
+}


### PR DESCRIPTION
## issue
- close #15 

## 구현 사항
행사 생성 API 구현

## 중점적으로 리뷰받고 싶은 부분(선택)
리뷰 시에 커밋의 규모가 적당했는지 궁금합니다. 

## 논의하고 싶은 부분(선택)
행사 token 생성 전략에 대하여, 임의로 UUID를 선택했습니다. 이후, 변경을 고려하여 EventTokenProvider.class로 분리했습니다. 추후 논의가 필요할 것 같습니다. 
