### PR TITLE
[BE] 현재 참여 인원 조회

### DIFF
--- a/server/src/main/java/server/haengdong/application/MemberActionService.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionService.java
@@ -5,12 +5,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.haengdong.application.request.MemberActionsSaveAppRequest;
+import server.haengdong.application.response.CurrentMemberAppResponse;
 import server.haengdong.domain.action.Action;
-import server.haengdong.domain.event.Event;
-import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.ActionRepository;
-import server.haengdong.domain.event.EventRepository;
+import server.haengdong.domain.action.CurrentMembers;
+import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
+import server.haengdong.domain.event.Event;
+import server.haengdong.domain.event.EventRepository;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -24,8 +26,7 @@ public class MemberActionService {
 
     @Transactional
     public void saveMemberAction(String token, MemberActionsSaveAppRequest request) {
-        Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("event not found"));
+        Event event = findEvent(token);
 
         List<MemberAction> findMemberActions = memberActionRepository.findAllByEvent(event);
         Action action = createStartAction(event);
@@ -37,5 +38,21 @@ public class MemberActionService {
         return actionRepository.findLastByEvent(event)
                 .map(Action::next)
                 .orElse(Action.createFirst(event));
+    }
+
+    public List<CurrentMemberAppResponse> getCurrentMembers(String token) {
+        Event event = findEvent(token);
+        List<MemberAction> findMemberActions = memberActionRepository.findAllByEvent(event);
+        CurrentMembers currentMembers = CurrentMembers.of(findMemberActions);
+
+        return currentMembers.getMembers()
+                .stream()
+                .map(CurrentMemberAppResponse::new)
+                .toList();
+    }
+
+    private Event findEvent(String token) {
+        return eventRepository.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("event not found"));
     }
 }

--- a/server/src/main/java/server/haengdong/application/response/CurrentMemberAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/CurrentMemberAppResponse.java
@@ -1,0 +1,10 @@
+package server.haengdong.application.response;
+
+import server.haengdong.domain.action.MemberAction;
+
+public record CurrentMemberAppResponse(String name) {
+
+    public static CurrentMemberAppResponse of(MemberAction memberAction) {
+        return new CurrentMemberAppResponse(memberAction.getMemberName());
+    }
+}

--- a/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
+++ b/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
@@ -1,0 +1,37 @@
+package server.haengdong.domain.action;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CurrentMembers {
+
+    private final Set<String> members;
+
+    public static CurrentMembers of(List<MemberAction> memberActions) {
+        List<MemberAction> sortedMemberActions = getSortedMemberActions(memberActions);
+        Set<String> members = new HashSet<>();
+        for (MemberAction memberAction : sortedMemberActions) {
+            String member = memberAction.getMemberName();
+            if (memberAction.isSameStatus(MemberActionStatus.IN)) {
+                members.add(member);
+                continue;
+            }
+            members.remove(member);
+        }
+
+        return new CurrentMembers(members);
+    }
+
+    private static List<MemberAction> getSortedMemberActions(List<MemberAction> memberActions) {
+        return memberActions.stream()
+                .sorted(Comparator.comparing(MemberAction::getSequence))
+                .toList();
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/MemberActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/MemberActionController.java
@@ -1,13 +1,17 @@
 package server.haengdong.presentation;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.MemberActionService;
+import server.haengdong.application.response.CurrentMemberAppResponse;
 import server.haengdong.presentation.request.MemberActionsSaveRequest;
+import server.haengdong.presentation.response.CurrentMembersResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,5 +27,13 @@ public class MemberActionController {
         memberActionService.saveMemberAction(token, request.toAppRequest());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/events/{token}/members/current")
+    public ResponseEntity<CurrentMembersResponse> getCurrentMembers(@PathVariable("token") String token) {
+        List<CurrentMemberAppResponse> currentMembers = memberActionService.getCurrentMembers(token);
+
+        return ResponseEntity.ok()
+                .body(CurrentMembersResponse.of(currentMembers));
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/CurrentMemberResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/CurrentMemberResponse.java
@@ -1,0 +1,10 @@
+package server.haengdong.presentation.response;
+
+import server.haengdong.application.response.CurrentMemberAppResponse;
+
+public record CurrentMemberResponse(String name) {
+
+    public static CurrentMemberResponse of(CurrentMemberAppResponse response) {
+        return new CurrentMemberResponse(response.name());
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/response/CurrentMembersResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/CurrentMembersResponse.java
@@ -1,0 +1,15 @@
+package server.haengdong.presentation.response;
+
+import java.util.List;
+import server.haengdong.application.response.CurrentMemberAppResponse;
+
+public record CurrentMembersResponse(List<CurrentMemberResponse> members) {
+
+    public static CurrentMembersResponse of(List<CurrentMemberAppResponse> currentMembers) {
+        List<CurrentMemberResponse> responses = currentMembers.stream()
+                .map(CurrentMemberResponse::of)
+                .toList();
+
+        return new CurrentMembersResponse(responses);
+    }
+}

--- a/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
@@ -1,0 +1,30 @@
+package server.haengdong.domain.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static server.haengdong.domain.action.MemberActionStatus.IN;
+import static server.haengdong.domain.action.MemberActionStatus.OUT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.haengdong.domain.event.Event;
+
+class CurrentMembersTest {
+
+    @DisplayName("인원 변동 이력으로 현재 참여 인원을 계산한다.")
+    @Test
+    void of() {
+        Event event = new Event("test", "TOKEN");
+        List<MemberAction> memberActions = List.of(
+                new MemberAction(new Action(event, 1L), "망쵸", IN, 1L),
+                new MemberAction(new Action(event, 2L), "백호", IN, 1L),
+                new MemberAction(new Action(event, 3L), "백호", OUT, 1L),
+                new MemberAction(new Action(event, 4L), "웨디", IN, 1L)
+        );
+
+        CurrentMembers currentMembers = CurrentMembers.of(memberActions);
+
+        assertThat(currentMembers.getMembers())
+                .containsExactlyInAnyOrder("망쵸", "웨디");
+    }
+}

--- a/server/src/test/java/server/haengdong/presentation/MemberActionControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/MemberActionControllerTest.java
@@ -1,5 +1,9 @@
 package server.haengdong.presentation;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,7 +17,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import server.haengdong.application.MemberActionService;
+import server.haengdong.application.response.CurrentMemberAppResponse;
 import server.haengdong.presentation.request.MemberActionSaveRequest;
 import server.haengdong.presentation.request.MemberActionsSaveRequest;
 
@@ -45,5 +51,20 @@ class MemberActionControllerTest {
                         .content(requestBody))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @DisplayName("현재 참여 인원을 조회합니다.")
+    @Test
+    void getCurrentMembers() throws Exception {
+        List<CurrentMemberAppResponse> currentMemberAppResponses = List.of(new CurrentMemberAppResponse("소하"), new CurrentMemberAppResponse("토다리"));
+
+        given(memberActionService.getCurrentMembers(any())).willReturn(currentMemberAppResponses);
+
+        mockMvc.perform(get("/api/events/{token}/members/current", "token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.members[0].name").value(equalTo("소하")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.members[1].name").value(equalTo("토다리")));
     }
 }


### PR DESCRIPTION
## issue
- close #65 

## 구현 사항
행사에 현재 IN 상태인 모든 인원 목록을 조회하는 기능을 구현했습니다.

## 논의하고 싶은 부분(선택)
현재 참여 중인 인원 목록(CurrentMembers)으로 인원 변동 생성 검증을 하는 것은 어떨까요?
CurrentMembers가 추가하려는 MemberAction을 검증해도 괜찮을 것 같아요.

