### PR TITLE
[BE] 액션 이력 조회 기능 구현

### DIFF
--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -54,32 +54,34 @@ public class EventService {
         return getActionAppResponses(billActions, memberActions);
     }
 
-    private static List<ActionAppResponse> getActionAppResponses(List<BillAction> billActions,
-                                                                 List<MemberAction> memberActions) {
+    private List<ActionAppResponse> getActionAppResponses(
+            List<BillAction> billActions,
+            List<MemberAction> memberActions
+    ) {
         int billActionIndex = 0;
         int memberActionIndex = 0;
+        List<ActionAppResponse> actionAppResponses = new ArrayList<>();
 
-        List<ActionAppResponse> result = new ArrayList<>();
         while (billActionIndex < billActions.size() && memberActionIndex < memberActions.size()) {
             BillAction billAction = billActions.get(billActionIndex);
             MemberAction memberAction = memberActions.get(memberActionIndex);
             if (billAction.getSequence() < memberAction.getSequence()) {
-                result.add(ActionAppResponse.of(billAction));
+                actionAppResponses.add(ActionAppResponse.of(billAction));
                 billActionIndex++;
             } else {
-                result.add(ActionAppResponse.of(memberAction));
+                actionAppResponses.add(ActionAppResponse.of(memberAction));
                 memberActionIndex++;
             }
         }
         while (billActionIndex < billActions.size()) {
             BillAction billAction = billActions.get(billActionIndex++);
-            result.add(ActionAppResponse.of(billAction));
+            actionAppResponses.add(ActionAppResponse.of(billAction));
         }
         while (memberActionIndex < memberActions.size()) {
             MemberAction memberAction = memberActions.get(memberActionIndex++);
-            result.add(ActionAppResponse.of(memberAction));
+            actionAppResponses.add(ActionAppResponse.of(memberAction));
         }
 
-        return result;
+        return actionAppResponses;
     }
 }

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -1,10 +1,18 @@
 package server.haengdong.application;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.BillActionRepository;
+import server.haengdong.domain.action.MemberAction;
+import server.haengdong.domain.action.MemberActionRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.domain.event.EventTokenProvider;
@@ -17,6 +25,8 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final EventTokenProvider eventTokenProvider;
+    private final BillActionRepository billActionRepository;
+    private final MemberActionRepository memberActionRepository;
 
     public EventAppResponse saveEvent(EventAppRequest request) {
         String token = eventTokenProvider.createToken();
@@ -31,5 +41,45 @@ public class EventService {
                 .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
 
         return EventDetailAppResponse.of(event);
+    }
+
+    public List<ActionAppResponse> findActions(String token) {
+        Event event = eventRepository.findByToken(token).orElseThrow(() -> new IllegalArgumentException(""));
+
+        List<BillAction> billActions = billActionRepository.findByAction_Event(event).stream()
+                .sorted(Comparator.comparing(BillAction::getSequence)).toList();
+        List<MemberAction> memberActions = memberActionRepository.findAllByEvent(event).stream()
+                .sorted(Comparator.comparing(MemberAction::getSequence)).toList();
+
+        return getActionAppResponses(billActions, memberActions);
+    }
+
+    private static List<ActionAppResponse> getActionAppResponses(List<BillAction> billActions,
+                                                                 List<MemberAction> memberActions) {
+        int billActionIndex = 0;
+        int memberActionIndex = 0;
+
+        List<ActionAppResponse> result = new ArrayList<>();
+        while (billActionIndex < billActions.size() && memberActionIndex < memberActions.size()) {
+            BillAction billAction = billActions.get(billActionIndex);
+            MemberAction memberAction = memberActions.get(memberActionIndex);
+            if (billAction.getSequence() < memberAction.getSequence()) {
+                result.add(ActionAppResponse.of(billAction));
+                billActionIndex++;
+            } else {
+                result.add(ActionAppResponse.of(memberAction));
+                memberActionIndex++;
+            }
+        }
+        while (billActionIndex < billActions.size()) {
+            BillAction billAction = billActions.get(billActionIndex++);
+            result.add(ActionAppResponse.of(billAction));
+        }
+        while (memberActionIndex < memberActions.size()) {
+            MemberAction memberAction = memberActions.get(memberActionIndex++);
+            result.add(ActionAppResponse.of(memberAction));
+        }
+
+        return result;
     }
 }

--- a/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
@@ -1,0 +1,52 @@
+package server.haengdong.application.response;
+
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.MemberAction;
+import server.haengdong.domain.action.MemberActionStatus;
+
+public record ActionAppResponse(
+        Long actionId,
+        String name,
+        Long price,
+        Long sequence,
+        ActionType actionType
+) {
+
+    public static ActionAppResponse of(BillAction billAction) {
+        return new ActionAppResponse(billAction.getAction().getId(),
+                billAction.getTitle(),
+                billAction.getPrice(),
+                billAction.getSequence(),
+                ActionType.BILL
+        );
+    }
+
+    public static ActionAppResponse of(MemberAction memberAction) {
+        MemberActionStatus status = memberAction.getStatus();
+
+        return new ActionAppResponse(memberAction.getAction().getId(),
+                memberAction.getMemberName(),
+                null,
+                memberAction.getSequence(),
+                ActionType.of(status)
+        );
+    }
+
+    public String actionTypeName() {
+        return actionType.name();
+    }
+
+    private enum ActionType {
+        BILL,
+        IN,
+        OUT,
+        ;
+
+        public static ActionType of(MemberActionStatus memberActionStatus) {
+            if (memberActionStatus.name().equals("IN")) {
+                return IN;
+            }
+            return OUT;
+        }
+    }
+}

--- a/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
@@ -13,7 +13,8 @@ public record ActionAppResponse(
 ) {
 
     public static ActionAppResponse of(BillAction billAction) {
-        return new ActionAppResponse(billAction.getAction().getId(),
+        return new ActionAppResponse(
+                billAction.getAction().getId(),
                 billAction.getTitle(),
                 billAction.getPrice(),
                 billAction.getSequence(),
@@ -24,7 +25,8 @@ public record ActionAppResponse(
     public static ActionAppResponse of(MemberAction memberAction) {
         MemberActionStatus status = memberAction.getStatus();
 
-        return new ActionAppResponse(memberAction.getAction().getId(),
+        return new ActionAppResponse(
+                memberAction.getAction().getId(),
                 memberAction.getMemberName(),
                 null,
                 memberAction.getSequence(),
@@ -36,14 +38,14 @@ public record ActionAppResponse(
         return actionType.name();
     }
 
-    private enum ActionType {
+    public enum ActionType {
         BILL,
         IN,
         OUT,
         ;
 
-        public static ActionType of(MemberActionStatus memberActionStatus) {
-            if (memberActionStatus.name().equals("IN")) {
+        private static ActionType of(MemberActionStatus memberActionStatus) {
+            if (MemberActionStatus.IN == memberActionStatus) {
                 return IN;
             }
             return OUT;

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.EventService;
 import server.haengdong.presentation.request.EventSaveRequest;
+import server.haengdong.presentation.response.ActionsResponse;
 import server.haengdong.presentation.response.EventDetailResponse;
 import server.haengdong.presentation.response.EventResponse;
 
@@ -31,5 +32,12 @@ public class EventController {
         EventDetailResponse eventDetailResponse = EventDetailResponse.of(eventService.findEvent(token));
 
         return ResponseEntity.ok(eventDetailResponse);
+    }
+
+    @GetMapping("/api/events/{token}/actions")
+    public ResponseEntity<ActionsResponse> findActions(@PathVariable("token") String token) {
+        ActionsResponse actionsResponse = ActionsResponse.of(eventService.findActions(token));
+
+        return ResponseEntity.ok(actionsResponse);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.EventService;
 import server.haengdong.presentation.request.EventSaveRequest;
-import server.haengdong.presentation.response.ActionsResponse;
 import server.haengdong.presentation.response.EventDetailResponse;
 import server.haengdong.presentation.response.EventResponse;
+import server.haengdong.presentation.response.StepResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -34,10 +34,10 @@ public class EventController {
         return ResponseEntity.ok(eventDetailResponse);
     }
 
-    @GetMapping("/api/events/{token}/actions")
-    public ResponseEntity<ActionsResponse> findActions(@PathVariable("token") String token) {
-        ActionsResponse actionsResponse = ActionsResponse.of(eventService.findActions(token));
+    @GetMapping("/api/events/{eventId}/actions")
+    public ResponseEntity<StepResponse> findActions(@PathVariable("eventId") String token) {
+        StepResponse stepResponse = StepResponse.of(eventService.findActions(token));
 
-        return ResponseEntity.ok(actionsResponse);
+        return ResponseEntity.ok(stepResponse);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
@@ -6,16 +6,15 @@ public record ActionResponse(
         Long actionId,
         String name,
         Long price,
-        Long sequence,
-        String type
+        Long sequence
 ) {
 
     public static ActionResponse of(ActionAppResponse actionAppResponse) {
-        return new ActionResponse(actionAppResponse.actionId(),
+        return new ActionResponse(
+                actionAppResponse.actionId(),
                 actionAppResponse.name(),
                 actionAppResponse.price(),
-                actionAppResponse.sequence(),
-                actionAppResponse.actionTypeName()
+                actionAppResponse.sequence()
         );
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
@@ -1,0 +1,21 @@
+package server.haengdong.presentation.response;
+
+import server.haengdong.application.response.ActionAppResponse;
+
+public record ActionResponse(
+        Long actionId,
+        String name,
+        Long price,
+        Long sequence,
+        String type
+) {
+
+    public static ActionResponse of(ActionAppResponse actionAppResponse) {
+        return new ActionResponse(actionAppResponse.actionId(),
+                actionAppResponse.name(),
+                actionAppResponse.price(),
+                actionAppResponse.sequence(),
+                actionAppResponse.actionTypeName()
+        );
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
@@ -1,0 +1,12 @@
+package server.haengdong.presentation.response;
+
+import java.util.List;
+import server.haengdong.application.response.ActionAppResponse;
+
+public record ActionsResponse(List<ActionResponse> actions) {
+
+    public static ActionsResponse of(List<ActionAppResponse> actions) {
+        List<ActionResponse> actionResponses = actions.stream().map(ActionResponse::of).toList();
+        return new ActionsResponse(actionResponses);
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
@@ -1,12 +1,28 @@
 package server.haengdong.presentation.response;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import server.haengdong.application.response.ActionAppResponse;
 
-public record ActionsResponse(List<ActionResponse> actions) {
+public record ActionsResponse(
+        String type,
+        String stepName,
+        Set<String> members,
+        List<ActionResponse> actions
+) {
 
-    public static ActionsResponse of(List<ActionAppResponse> actions) {
-        List<ActionResponse> actionResponses = actions.stream().map(ActionResponse::of).toList();
-        return new ActionsResponse(actionResponses);
+    public static ActionsResponse of(List<ActionAppResponse> actions, Set<String> members) {
+        List<ActionResponse> actionResponses = actions.stream()
+                .map(ActionResponse::of)
+                .toList();
+
+        String actionType = actions.get(0).actionTypeName();
+        return new ActionsResponse(
+                actionType,
+                null,
+                new HashSet<>(members),
+                actionResponses
+        );
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/StepResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/StepResponse.java
@@ -1,0 +1,63 @@
+package server.haengdong.presentation.response;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import server.haengdong.application.response.ActionAppResponse;
+
+public record StepResponse(
+        List<ActionsResponse> steps
+) {
+
+    public static StepResponse of(List<ActionAppResponse> actions) {
+        List<ActionsResponse> actionsResponse = new ArrayList<>();
+        Set<String> members = new HashSet<>();
+        ActionAppResponse firstAction = getFirstAction(actions);
+        List<ActionAppResponse> group = new ArrayList<>();
+        group.add(firstAction);
+        String currentActionType = firstAction.actionTypeName();
+        members.add(firstAction.name());
+
+        for (int i = 1; i < actions.size(); i++) {
+            ActionAppResponse action = actions.get(i);
+            String typeName = action.actionTypeName();
+            if (currentActionType.equals(typeName)) {
+                if (typeName.equals("IN")) {
+                    members.add(action.name());
+                }
+                if (typeName.equals("OUT")) {
+                    members.remove(action.name());
+                }
+                group.add(action);
+                continue;
+            }
+            if (currentActionType.equals("BILL")) {
+                actionsResponse.add(ActionsResponse.of(group, members));
+            } else {
+                actionsResponse.add(ActionsResponse.of(group, Set.of()));
+            }
+            currentActionType = typeName;
+            group.clear();
+            if (typeName.equals("IN")) {
+                members.add(action.name());
+            }
+            if (typeName.equals("OUT")) {
+                members.remove(action.name());
+            }
+            group.add(action);
+        }
+
+        if (currentActionType.equals("BILL")) {
+            actionsResponse.add(ActionsResponse.of(group, members));
+        } else {
+            actionsResponse.add(ActionsResponse.of(group, null));
+        }
+
+        return new StepResponse(actionsResponse);
+    }
+
+    private static ActionAppResponse getFirstAction(List<ActionAppResponse> actions) {
+        return actions.get(0);
+    }
+}

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -2,8 +2,10 @@ package server.haengdong.application;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,8 +13,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.domain.action.Action;
+import server.haengdong.domain.action.ActionRepository;
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.BillActionRepository;
+import server.haengdong.domain.action.MemberAction;
+import server.haengdong.domain.action.MemberActionRepository;
+import server.haengdong.domain.action.MemberActionStatus;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.domain.event.EventTokenProvider;
@@ -29,8 +39,20 @@ class EventServiceTest {
     @Autowired
     private EventRepository eventRepository;
 
+    @Autowired
+    private ActionRepository actionRepository;
+
+    @Autowired
+    private BillActionRepository billActionRepository;
+
+    @Autowired
+    private MemberActionRepository memberActionRepository;
+
     @AfterEach
     void tearDown() {
+        billActionRepository.deleteAllInBatch();
+        memberActionRepository.deleteAllInBatch();
+        actionRepository.deleteAllInBatch();
         eventRepository.deleteAllInBatch();
     }
 
@@ -55,5 +77,34 @@ class EventServiceTest {
         EventDetailAppResponse eventDetailAppResponse = eventService.findEvent(token);
 
         assertThat(eventDetailAppResponse.eventName()).isEqualTo("행동대장 회식");
+    }
+
+    @DisplayName("행사에 속한 모든 액션을 조회한다.")
+    @Test
+    void findActionsTest() {
+        Event event = new Event("행동대장 회식", "웨디_토큰");
+        Action action = new Action(event, 1L);
+        MemberAction memberAction = new MemberAction(action, "토다리", MemberActionStatus.IN, 1L);
+        Action action1 = new Action(event, 2L);
+        MemberAction memberAction1 = new MemberAction(action1, "쿠키", MemberActionStatus.IN, 1L);
+        Action action2 = new Action(event, 3L);
+        BillAction billAction = new BillAction(action2, "뽕나무쟁이족발", 30000L);
+        eventRepository.save(event);
+        memberActionRepository.saveAll(List.of(memberAction, memberAction1));
+        billActionRepository.save(billAction);
+
+        List<ActionAppResponse> actionAppResponses = eventService.findActions("웨디_토큰");
+
+        assertThat(actionAppResponses).hasSize(3)
+                .extracting(ActionAppResponse::actionId,
+                        ActionAppResponse::name,
+                        ActionAppResponse::price,
+                        ActionAppResponse::sequence,
+                        ActionAppResponse::actionTypeName)
+                .containsExactly(
+                        tuple(1L, "토다리", null, 1L, "IN"),
+                        tuple(2L, "쿠키", null, 2L, "IN"),
+                        tuple(3L, "뽕나무쟁이족발", 30000L, 3L, "BILL")
+                );
     }
 }

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -96,4 +96,6 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.actions[1].sequence").value(2L))
                 .andExpect(jsonPath("$.actions[1].type").value("BILL"));
     }
+
+    
 }

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +18,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import server.haengdong.application.EventService;
 import server.haengdong.application.request.EventAppRequest;
-import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
-import server.haengdong.domain.action.Action;
-import server.haengdong.domain.action.BillAction;
-import server.haengdong.domain.action.MemberAction;
-import server.haengdong.domain.action.MemberActionStatus;
-import server.haengdong.domain.event.Event;
 import server.haengdong.presentation.request.EventSaveRequest;
 
 @WebMvcTest(EventController.class)
@@ -70,32 +63,4 @@ class EventControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.eventName").value("행동대장 회식"));
     }
-
-    @DisplayName("토큰으로 행사의 모든 액션을 조회한다.")
-    @Test
-    void findActionsTest() throws Exception {
-        String token = "TOKEN";
-        Event event = new Event("행동대장 회식", token);
-        Action action1 = new Action(event, 1L);
-        MemberAction memberAction = new MemberAction(action1, "소하", MemberActionStatus.IN, 1L);
-        Action action2 = new Action(event, 2L);
-        BillAction billAction = new BillAction(action2, "뽕나무쟁이족발", 30000L);
-        given(eventService.findActions(token)).willReturn(
-                List.of(ActionAppResponse.of(memberAction), ActionAppResponse.of(billAction)));
-
-        mockMvc.perform(get("/api/events/" + token + "/actions"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.actions").isArray())
-                .andExpect(jsonPath("$.actions[0].name").value("소하"))
-                .andExpect(jsonPath("$.actions[0].price").isEmpty())
-                .andExpect(jsonPath("$.actions[0].sequence").value(1L))
-                .andExpect(jsonPath("$.actions[0].type").value("IN"))
-                .andExpect(jsonPath("$.actions[1].name").value("뽕나무쟁이족발"))
-                .andExpect(jsonPath("$.actions[1].price").value(30000L))
-                .andExpect(jsonPath("$.actions[1].sequence").value(2L))
-                .andExpect(jsonPath("$.actions[1].type").value("BILL"));
-    }
-
-    
 }

--- a/server/src/test/java/server/haengdong/presentation/response/StepResponseTest.java
+++ b/server/src/test/java/server/haengdong/presentation/response/StepResponseTest.java
@@ -1,0 +1,57 @@
+package server.haengdong.presentation.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import server.haengdong.application.response.ActionAppResponse;
+import server.haengdong.application.response.ActionAppResponse.ActionType;
+
+@SpringBootTest
+class StepResponseTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("")
+    @Test
+    void test() throws JsonProcessingException {
+        List<ActionAppResponse> actionAppResponse = new ArrayList<>();
+
+        // IN actions
+        ActionAppResponse actionAppResponse1 = new ActionAppResponse(3L, "망쵸", null, 3L, ActionType.IN);
+        actionAppResponse.add(actionAppResponse1);
+        ActionAppResponse actionAppResponse2 = new ActionAppResponse(4L, "백호", null, 4L, ActionType.IN);
+        actionAppResponse.add(actionAppResponse2);
+
+        // BILL step 1
+        ActionAppResponse actionAppResponse3 = new ActionAppResponse(1L, "감자탕", 10000L, 1L, ActionType.BILL);
+        actionAppResponse.add(actionAppResponse3);
+        ActionAppResponse actionAppResponse4 = new ActionAppResponse(2L, "인생네컷", 10000L, 2L, ActionType.BILL);
+        actionAppResponse.add(actionAppResponse4);
+
+        // IN actions
+        ActionAppResponse actionAppResponse5 = new ActionAppResponse(5L, "소하", null, 5L, ActionType.IN);
+        actionAppResponse.add(actionAppResponse5);
+        ActionAppResponse actionAppResponse6 = new ActionAppResponse(6L, "웨디", null, 6L, ActionType.IN);
+        actionAppResponse.add(actionAppResponse6);
+
+        // OUT actions
+        ActionAppResponse actionAppResponse7 = new ActionAppResponse(7L, "망쵸", null, 7L, ActionType.OUT);
+        actionAppResponse.add(actionAppResponse7);
+        ActionAppResponse actionAppResponse8 = new ActionAppResponse(8L, "백호", null, 8L, ActionType.OUT);
+        actionAppResponse.add(actionAppResponse8);
+
+        // BILL step 2
+        ActionAppResponse actionAppResponse9 = new ActionAppResponse(9L, "노래방", 20000L, 10L, ActionType.BILL);
+        actionAppResponse.add(actionAppResponse9);
+
+        // StepResponse creation
+        StepResponse stepResponse = StepResponse.of(actionAppResponse);
+        System.out.println("stepResponse = " + stepResponse);
+    }
+}


### PR DESCRIPTION
## issue
- close #20 

## 구현 사항
- 토큰으로 이벤트를 조회한다.
- 해당 이벤트에 속한 지출 내역과, 인원 변동 내역을 모두 조회한다.
- two pointer 알고리즘을 통해 지출 내역과 인원 변동 내역의 순서를 정렬하여 반환한다.

## 중점적으로 리뷰받고 싶은 부분(선택)


## 논의하고 싶은 부분(선택)


## 🫡 참고사항
