### PR TITLE
[BE] api 명세에서 행사 url을 표현하는 용어와 전달 방식 수정

### DIFF
--- a/server/src/main/java/server/haengdong/presentation/ActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/ActionController.java
@@ -16,8 +16,8 @@ public class ActionController {
 
     private final ActionService actionService;
 
-    @GetMapping("/api/events/{token}/actions/reports")
-    public ResponseEntity<MemberBillReportsResponse> getMemberBillReports(@PathVariable("token") String token) {
+    @GetMapping("/api/events/{eventId}/actions/reports")
+    public ResponseEntity<MemberBillReportsResponse> getMemberBillReports(@PathVariable("eventId") String token) {
         List<MemberBillReportAppResponse> memberBillReports = actionService.getMemberBillReports(token);
 
         return ResponseEntity.ok()

--- a/server/src/main/java/server/haengdong/presentation/BillActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillActionController.java
@@ -16,9 +16,9 @@ public class BillActionController {
 
     private final BillActionService billActionService;
 
-    @PostMapping("/api/events/{token}/actions/bills")
+    @PostMapping("/api/events/{eventId}/actions/bills")
     public ResponseEntity<Void> saveAllBillAction(
-            @PathVariable String token,
+            @PathVariable("eventId") String token,
             @RequestBody @Valid BillActionsSaveRequest request
     ) {
         billActionService.saveAllBillAction(token, request.toAppRequests());

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -28,8 +28,8 @@ public class EventController {
                 .build();
     }
 
-    @GetMapping("/api/events/{token}")
-    public ResponseEntity<EventDetailResponse> findEvent(@PathVariable("token") String token) {
+    @GetMapping("/api/events/{eventId}")
+    public ResponseEntity<EventDetailResponse> findEvent(@PathVariable("eventId") String token) {
         EventDetailResponse eventDetailResponse = EventDetailResponse.of(eventService.findEvent(token));
 
         return ResponseEntity.ok(eventDetailResponse);

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -1,6 +1,5 @@
 package server.haengdong.presentation;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,9 +8,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.EventService;
-import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.presentation.request.EventSaveRequest;
 import server.haengdong.presentation.response.EventDetailResponse;
+import server.haengdong.presentation.response.EventResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,12 +19,10 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping("/api/events")
-    public ResponseEntity<Void> saveEvent(@RequestBody EventSaveRequest request) {
-        EventAppResponse eventAppResponse = eventService.saveEvent(request.toAppRequest());
+    public ResponseEntity<EventResponse> saveEvent(@RequestBody EventSaveRequest request) {
+        EventResponse eventResponse = EventResponse.of(eventService.saveEvent(request.toAppRequest()));
 
-        return ResponseEntity.ok()
-                .location(URI.create("events/" + eventAppResponse.token()))
-                .build();
+        return ResponseEntity.ok(eventResponse);
     }
 
     @GetMapping("/api/events/{eventId}")

--- a/server/src/main/java/server/haengdong/presentation/MemberActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/MemberActionController.java
@@ -19,9 +19,9 @@ public class MemberActionController {
 
     private final MemberActionService memberActionService;
 
-    @PostMapping("/api/events/{token}/actions/members")
+    @PostMapping("/api/events/{eventId}/actions/members")
     public ResponseEntity<Void> saveMemberAction(
-            @PathVariable("token") String token,
+            @PathVariable("eventId") String token,
             @RequestBody MemberActionsSaveRequest request
     ) {
         memberActionService.saveMemberAction(token, request.toAppRequest());
@@ -29,8 +29,8 @@ public class MemberActionController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/api/events/{token}/members/current")
-    public ResponseEntity<CurrentMembersResponse> getCurrentMembers(@PathVariable("token") String token) {
+    @GetMapping("/api/events/{eventId}/members/current")
+    public ResponseEntity<CurrentMembersResponse> getCurrentMembers(@PathVariable("eventId") String token) {
         List<CurrentMemberAppResponse> currentMembers = memberActionService.getCurrentMembers(token);
 
         return ResponseEntity.ok()

--- a/server/src/main/java/server/haengdong/presentation/response/EventResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/EventResponse.java
@@ -2,7 +2,7 @@ package server.haengdong.presentation.response;
 
 import server.haengdong.application.response.EventAppResponse;
 
-public record EventResponse(String url) {
+public record EventResponse(String eventId) {
 
     public static EventResponse of(EventAppResponse eventAppResponse) {
         return new EventResponse(eventAppResponse.token());

--- a/server/src/main/java/server/haengdong/presentation/response/EventResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/EventResponse.java
@@ -1,0 +1,10 @@
+package server.haengdong.presentation.response;
+
+import server.haengdong.application.response.EventAppResponse;
+
+public record EventResponse(String url) {
+
+    public static EventResponse of(EventAppResponse eventAppResponse) {
+        return new EventResponse(eventAppResponse.token());
+    }
+}

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import server.haengdong.application.EventService;
 import server.haengdong.application.request.EventAppRequest;
 import server.haengdong.application.response.EventAppResponse;
@@ -49,7 +48,7 @@ class EventControllerTest {
                         .content(requestBody))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.redirectedUrl("events/" + token));
+                .andExpect(jsonPath("$.url").value("TOKEN"));
     }
 
     @DisplayName("토큰으로 행사를 조회한다.")

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -48,7 +48,7 @@ class EventControllerTest {
                         .content(requestBody))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.url").value("TOKEN"));
+                .andExpect(jsonPath("$.eventId").value("TOKEN"));
     }
 
     @DisplayName("토큰으로 행사를 조회한다.")


### PR DESCRIPTION
## issue
- close #97 

## 구현 사항

- 기존에 URL Path에서 `token`이라는 이름으로 전달하던 행사 URL을 `eventId`로 수정했습니다. 
- 응답 Header로 전달하던 행사 URL을 응답 Body에 `"{url: 550e8400-e29b-41d4-a716-446655440000}"` 형식으로 전달합니다. 
- 노션 api 문서 업데이트 완료

## 중점적으로 리뷰받고 싶은 부분

행사 URL을 응답 Body에 `url`이라는 이름의 필드로 전달하는 것이 괜찮은가요? 다른 제안을 해주시면 적극 반영해 볼게요! 
