### PR TITLE
[BE] 지출 내역 생성 및 현재 참여 인원 조회 예외 메시지 변경

### DIFF
--- a/server/src/main/java/server/haengdong/application/MemberActionService.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionService.java
@@ -13,6 +13,8 @@ import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -53,6 +55,6 @@ public class MemberActionService {
 
     private Event findEvent(String token) {
         return eventRepository.findByToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("event not found"));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -47,13 +47,15 @@ public class BillAction implements Comparable<BillAction> {
     private void validateTitle(String title) {
         int titleLength = title.trim().length();
         if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.INVALID_BILL_ACTION_SIZE);
+            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+                    String.format("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다.", MIN_TITLE_LENGTH, MAX_TITLE_LENGTH));
         }
     }
 
     private void validatePrice(Long price) {
         if (price < MIN_PRICE || price > MAX_PRICE) {
-            throw new HaengdongException(HaengdongErrorCode.INVALID_PRICE_SIZE);
+            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+                    String.format("지출 금액은 %,d 이하의 자연수여야 합니다.", MAX_PRICE));
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -11,6 +11,8 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,13 +47,13 @@ public class BillAction implements Comparable<BillAction> {
     private void validateTitle(String title) {
         int titleLength = title.trim().length();
         if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException("앞뒤 공백을 제거한 지출 내역 제목은 2 ~ 30자여야 합니다.");
+            throw new HaengdongException(HaengdongErrorCode.INVALID_BILL_ACTION_SIZE);
         }
     }
 
     private void validatePrice(Long price) {
         if (price < MIN_PRICE || price > MAX_PRICE) {
-            throw new IllegalArgumentException("지출 금액은 10,000,000 이하의 자연수여야 합니다.");
+            throw new HaengdongException(HaengdongErrorCode.INVALID_PRICE_SIZE);
         }
     }
 

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -8,6 +8,8 @@ public enum HaengdongErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     DUPLICATED_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "올바르지 않은 인원 요청입니다."),
     INVALID_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "잘못된 맴버 액션입니다."),
+    INVALID_BILL_ACTION_SIZE(HttpStatus.BAD_REQUEST, "앞뒤 공백을 제거한 지출 내역 제목은 2 ~ 30자여야 합니다."),
+    INVALID_PRICE_SIZE(HttpStatus.BAD_REQUEST, "지출 금액은 10,000,000 이하의 자연수여야 합니다."),
 
     NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "존재하지 않는 행사입니다."),
 

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -8,8 +8,6 @@ public enum HaengdongErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     DUPLICATED_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "올바르지 않은 인원 요청입니다."),
     INVALID_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "잘못된 맴버 액션입니다."),
-    INVALID_BILL_ACTION_SIZE(HttpStatus.BAD_REQUEST, "앞뒤 공백을 제거한 지출 내역 제목은 2 ~ 30자여야 합니다."),
-    INVALID_PRICE_SIZE(HttpStatus.BAD_REQUEST, "지출 금액은 10,000,000 이하의 자연수여야 합니다."),
 
     NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "존재하지 않는 행사입니다."),
 

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
@@ -1,12 +1,12 @@
 package server.haengdong.presentation.request;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import server.haengdong.application.request.BillActionAppRequest;
 
 public record BillActionSaveRequest(
 
-        @NotEmpty
+        @NotBlank
         String title,
 
         @NotNull

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
@@ -1,18 +1,15 @@
 package server.haengdong.presentation.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
 import server.haengdong.application.request.BillActionAppRequest;
 
 public record BillActionSaveRequest(
 
-        @NotNull
-        @Size(min = 2, max = 30)
+        @NotEmpty
         String title,
 
         @NotNull
-        @Positive
         Long price
 ) {
 

--- a/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
@@ -19,6 +19,7 @@ import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
+import server.haengdong.exception.HaengdongException;
 
 @SpringBootTest
 class MemberActionServiceTest {
@@ -79,13 +80,13 @@ class MemberActionServiceTest {
                 List.of(new MemberActionSaveAppRequest("TOKEN", "OUT")));
 
         assertThatCode(() -> memberActionService.saveMemberAction("TOKEN", appRequest))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(HaengdongException.class);
     }
 
     @DisplayName("이벤트가 없으면 현재 참여 인원을 조회할 수 없다.")
     @Test
     void getCurrentMembers() {
         assertThatThrownBy(() -> memberActionService.getCurrentMembers("token"))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(HaengdongException.class);
     }
 }

--- a/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import server.haengdong.domain.event.Event;
+import server.haengdong.exception.HaengdongException;
 
 class BillActionTest {
 
@@ -21,7 +22,7 @@ class BillActionTest {
         Long price = 100L;
 
         assertThatThrownBy(() -> new BillAction(action, title, price))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(HaengdongException.class)
                 .hasMessage("앞뒤 공백을 제거한 지출 내역 제목은 2 ~ 30자여야 합니다.");
     }
 
@@ -34,7 +35,7 @@ class BillActionTest {
         String title = "title";
 
         assertThatThrownBy(() -> new BillAction(action, title, price))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(HaengdongException.class)
                 .hasMessage("지출 금액은 10,000,000 이하의 자연수여야 합니다.");
     }
 


### PR DESCRIPTION
## issue
- close #96 

## 구현 사항
지출 내역 생성 및 현재 참여 인원 조회 예외 메시지 변경

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
