### PR TITLE
[BE] 행사 생성 API 예외 메세지 및 DTO 검증 애너테이션 추가

### DIFF
--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +17,7 @@ public class Event {
 
     private static final int MIN_NAME_LENGTH = 2;
     private static final int MAX_NAME_LENGTH = 20;
-    private static final char BLANK_CHARACTER = ' ';
+    private static final String SPACES = "  ";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +37,10 @@ public class Event {
         int nameLength = name.length();
         if (nameLength < MIN_NAME_LENGTH || MAX_NAME_LENGTH < nameLength) {
             throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
-                    String.format("행사 이름은 2자 이상 20자 이하만 입력 가능합니다. 입력한 이름 길이 : %d", name.length()));
+                    String.format("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다. 입력한 이름 길이 : %d",
+                            MIN_NAME_LENGTH,
+                            MAX_NAME_LENGTH,
+                            name.length()));
         }
         if (isBlankContinuous(name)) {
             throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
@@ -47,7 +49,6 @@ public class Event {
     }
 
     private boolean isBlankContinuous(String name) {
-        return IntStream.range(0, name.length() - 1)
-                .anyMatch(index -> name.charAt(index) == BLANK_CHARACTER && name.charAt(index + 1) == BLANK_CHARACTER);
+        return name.contains(SPACES);
     }
 }

--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -4,14 +4,21 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Event {
+
+    private static final int MIN_NAME_LENGTH = 2;
+    private static final int MAX_NAME_LENGTH = 20;
+    private static final char BLANK_CHARACTER = ' ';
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,7 +29,25 @@ public class Event {
     private String token;
 
     public Event(String name, String token) {
+        validateName(name);
         this.name = name;
         this.token = token;
+    }
+
+    private void validateName(String name) {
+        int nameLength = name.length();
+        if (nameLength < MIN_NAME_LENGTH || MAX_NAME_LENGTH < nameLength) {
+            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+                    String.format("행사 이름은 2자 이상 20자 이하만 입력 가능합니다. 입력한 이름 길이 : %d", name.length()));
+        }
+        if (isBlankContinuous(name)) {
+            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+                    String.format("행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : %s", name));
+        }
+    }
+
+    private boolean isBlankContinuous(String name) {
+        return IntStream.range(0, name.length() - 1)
+                .anyMatch(index -> name.charAt(index) == BLANK_CHARACTER && name.charAt(index + 1) == BLANK_CHARACTER);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -1,5 +1,6 @@
 package server.haengdong.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +20,7 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping("/api/events")
-    public ResponseEntity<EventResponse> saveEvent(@RequestBody EventSaveRequest request) {
+    public ResponseEntity<EventResponse> saveEvent(@Valid @RequestBody EventSaveRequest request) {
         EventResponse eventResponse = EventResponse.of(eventService.saveEvent(request.toAppRequest()));
 
         return ResponseEntity.ok(eventResponse);

--- a/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
@@ -8,10 +8,10 @@ public record EventSaveRequest(
 
         @NotBlank
         @Size(min = 2, max = 20)
-        String name
+        String eventName
 ) {
 
     public EventAppRequest toAppRequest() {
-        return new EventAppRequest(name);
+        return new EventAppRequest(eventName);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
@@ -1,13 +1,11 @@
 package server.haengdong.presentation.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import server.haengdong.application.request.EventAppRequest;
 
 public record EventSaveRequest(
 
         @NotBlank
-        @Size(min = 2, max = 20)
         String eventName
 ) {
 

--- a/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
@@ -1,8 +1,15 @@
 package server.haengdong.presentation.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import server.haengdong.application.request.EventAppRequest;
 
-public record EventSaveRequest(String name) {
+public record EventSaveRequest(
+
+        @NotBlank
+        @Size(min = 2, max = 20)
+        String name
+) {
 
     public EventAppRequest toAppRequest() {
         return new EventAppRequest(name);

--- a/server/src/test/java/server/haengdong/domain/event/EventTest.java
+++ b/server/src/test/java/server/haengdong/domain/event/EventTest.java
@@ -1,0 +1,37 @@
+package server.haengdong.domain.event;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import server.haengdong.exception.HaengdongException;
+
+class EventTest {
+
+    @DisplayName("공백 문자가 연속되지 않고, 이름이 2자 이상 20자 이하인 행사를 생성하면 예외가 발생하지 않는다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"12", "12345678901234567890", "공 백", " 공백", "공백 ", " 공 백 "})
+    void createSuccessTest(String eventName) {
+        assertThatCode(() -> new Event(eventName, "TEST_TOKEN"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("공백 문자가 연속되면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"  공백", "공백  ", "공백  연속", "공    백"})
+    void createFailTest1(String eventName) {
+        assertThatCode(() -> new Event(eventName, "TEST_TOKEN"))
+                .isInstanceOf(HaengdongException.class)
+                .hasMessage(String.format("행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : %s", eventName));
+    }
+
+    @DisplayName("이름이 2자 미만이거나 20자 초과인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "123456789012345678901"})
+    void createFilTest2(String eventName) {
+        assertThatCode(() -> new Event(eventName, "TEST_TOKEN"))
+                .isInstanceOf(HaengdongException.class)
+                .hasMessage(String.format("행사 이름은 2자 이상 20자 이하만 입력 가능합니다. 입력한 이름 길이 : %d", eventName.length()));
+    }
+}


### PR DESCRIPTION
## issue
- close #99 

## 구현 사항
행사 생성 API 
POST /api/events
`EventSaveRequest` 객체의 속성 `name`을 `eventName`으로 변경했습니다.
검증 애너테이션 `@NotBlank`, `@Size(min = 2, max = 20)`를 추가하여 행사 이름이 null과 공백 문자인지 검증하고,
행사 이름이 2자 이상 20자 이하인지 검증합니다.