### PR TITLE
[BE] 참여자별 정산 현황 조회 API 예외 메시지 추가

### DIFF
--- a/server/src/main/java/server/haengdong/application/ActionService.java
+++ b/server/src/main/java/server/haengdong/application/ActionService.java
@@ -12,6 +12,8 @@ import server.haengdong.domain.action.MemberActionRepository;
 import server.haengdong.domain.action.MemberBillReports;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @RequiredArgsConstructor
 @Service
@@ -23,7 +25,7 @@ public class ActionService {
 
     public List<MemberBillReportAppResponse> getMemberBillReports(String token) {
         Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("event not found"));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
         List<BillAction> billActions = billActionRepository.findByAction_Event(event);
         List<MemberAction> memberActions = memberActionRepository.findAllByEvent(event);
 

--- a/server/src/test/java/server/haengdong/application/ActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/ActionServiceTest.java
@@ -1,6 +1,7 @@
 package server.haengdong.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static server.haengdong.domain.action.MemberActionStatus.IN;
 import static server.haengdong.domain.action.MemberActionStatus.OUT;
@@ -18,6 +19,8 @@ import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @SpringBootTest
 class ActionServiceTest {
@@ -64,5 +67,13 @@ class ActionServiceTest {
                         tuple("쿠키", 50_000L),
                         tuple("소하", 50_000L)
                 );
+    }
+
+    @DisplayName("존재하지 않는 이벤트의 참여자별 정산 현황을 조회하는 경우 예외가 발생한다.")
+    @Test
+    void getMemberBillReports1() {
+        assertThatThrownBy(() -> actionService.getMemberBillReports("invalid token"))
+                .isInstanceOf(HaengdongException.class)
+                .hasMessage(HaengdongErrorCode.NOT_FOUND_EVENT.getMessage());
     }
 }


### PR DESCRIPTION
## issue
- close #105 

## 구현 사항
참여자별 정산 현황 조회 API에서 발생하는 예외에 대한 구체적인 메시지를 추가했습니다.

#### 추가된 예외 메시지
- 존재하지 않는 eventId로 정산 현황 조회 - `존재하지 않는 행사입니다.`
