### PR TITLE
[BE] 참여자 정산 현황 로직 리펙토링

### DIFF
--- a/server/src/main/java/server/haengdong/application/ActionService.java
+++ b/server/src/main/java/server/haengdong/application/ActionService.java
@@ -1,6 +1,5 @@
 package server.haengdong.application;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,10 +30,8 @@ public class ActionService {
 
         MemberBillReport memberBillReport = MemberBillReport.createByActions(billActions, memberActions);
 
-        List<MemberBillReportAppResponse> memberBillReportResponses = new ArrayList<>();
-        memberBillReport.getReports().forEach(
-                (member, price) -> memberBillReportResponses.add(new MemberBillReportAppResponse(member, price))
-        );
-        return memberBillReportResponses;
+        return memberBillReport.getReports().entrySet().stream()
+                .map(entry -> new MemberBillReportAppResponse(entry.getKey(), entry.getValue()))
+                .toList();
     }
 }

--- a/server/src/main/java/server/haengdong/application/ActionService.java
+++ b/server/src/main/java/server/haengdong/application/ActionService.java
@@ -9,7 +9,7 @@ import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionRepository;
 import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
-import server.haengdong.domain.action.MemberBillReports;
+import server.haengdong.domain.action.MemberBillReport;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.exception.HaengdongErrorCode;
@@ -29,10 +29,10 @@ public class ActionService {
         List<BillAction> billActions = billActionRepository.findByAction_Event(event);
         List<MemberAction> memberActions = memberActionRepository.findAllByEvent(event);
 
-        MemberBillReports memberBillReports = MemberBillReports.createByActions(billActions, memberActions);
+        MemberBillReport memberBillReport = MemberBillReport.createByActions(billActions, memberActions);
 
         List<MemberBillReportAppResponse> memberBillReportResponses = new ArrayList<>();
-        memberBillReports.getReports().forEach(
+        memberBillReport.getReports().forEach(
                 (member, price) -> memberBillReportResponses.add(new MemberBillReportAppResponse(member, price))
         );
         return memberBillReportResponses;

--- a/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
+++ b/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
@@ -1,18 +1,22 @@
 package server.haengdong.domain.action;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class CurrentMembers {
 
     private final Set<String> members;
+
+    public CurrentMembers() {
+        this(new HashSet<>());
+    }
+
+    private CurrentMembers(Set<String> members) {
+        this.members = members;
+    }
 
     public static CurrentMembers of(List<MemberAction> memberActions) {
         List<MemberAction> sortedMemberActions = getSortedMemberActions(memberActions);
@@ -33,5 +37,30 @@ public class CurrentMembers {
         return memberActions.stream()
                 .sorted(Comparator.comparing(MemberAction::getSequence))
                 .toList();
+    }
+
+    public CurrentMembers addMemberAction(MemberAction memberAction) {
+        String memberName = memberAction.getMemberName();
+
+        Set<String> currentMembers = new HashSet<>(members);
+
+        if (memberAction.isIn()) {
+            currentMembers.add(memberName);
+        } else {
+            currentMembers.remove(memberName);
+        }
+        return new CurrentMembers(currentMembers);
+    }
+
+    public boolean isEmpty() {
+        return members.isEmpty();
+    }
+
+    public int size() {
+        return members.size();
+    }
+
+    public Set<String> getMembers() {
+        return Collections.unmodifiableSet(members);
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/MemberAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberAction.java
@@ -43,6 +43,10 @@ public class MemberAction implements Comparable<MemberAction> {
         return memberName.equals(name);
     }
 
+    public boolean isIn() {
+        return status == MemberActionStatus.IN;
+    }
+
     public boolean isSameStatus(MemberActionStatus memberActionStatus) {
         return status == memberActionStatus;
     }

--- a/server/src/main/java/server/haengdong/domain/action/MemberBillReport.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberBillReport.java
@@ -2,33 +2,31 @@ package server.haengdong.domain.action;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Set;
 import java.util.function.Function;
 import lombok.Getter;
 
 @Getter
-public class MemberBillReports {
+public class MemberBillReport {
 
     private final Map<String, Long> reports;
 
-    private MemberBillReports(Map<String, Long> reports) {
+    private MemberBillReport(Map<String, Long> reports) {
         this.reports = reports;
     }
 
-    public static MemberBillReports createByActions(List<BillAction> billActions, List<MemberAction> memberActions) {
+    public static MemberBillReport createByActions(List<BillAction> billActions, List<MemberAction> memberActions) {
         PriorityQueue<BillAction> sortedBillActions = new PriorityQueue<>(billActions);
         PriorityQueue<MemberAction> sortedMemberActions = new PriorityQueue<>(memberActions);
 
         Map<String, Long> memberBillReports = initReports(memberActions);
-        Set<String> currentMembers = new HashSet<>();
-
+        CurrentMembers currentMembers = new CurrentMembers();
         while (!sortedBillActions.isEmpty() && !sortedMemberActions.isEmpty()) {
             if (isMemberActionTurn(sortedMemberActions, sortedBillActions)) {
-                addMemberAction(sortedMemberActions, currentMembers);
+                MemberAction memberAction = sortedMemberActions.poll();
+                currentMembers = currentMembers.addMemberAction(memberAction);
                 continue;
             }
             addBillAction(sortedBillActions, currentMembers, memberBillReports);
@@ -38,7 +36,7 @@ public class MemberBillReports {
             addBillAction(sortedBillActions, currentMembers, memberBillReports);
         }
 
-        return new MemberBillReports(memberBillReports);
+        return new MemberBillReport(memberBillReports);
     }
 
     private static Map<String, Long> initReports(List<MemberAction> memberActions) {
@@ -58,25 +56,19 @@ public class MemberBillReports {
         return memberAction.getSequence() < billAction.getSequence();
     }
 
-    private static void addMemberAction(PriorityQueue<MemberAction> sortedMemberActions, Set<String> currentMembers) {
-        MemberAction memberAction = sortedMemberActions.poll();
-        String memberName = memberAction.getMemberName();
-        if (memberAction.isSameStatus(MemberActionStatus.IN)) {
-            currentMembers.add(memberName);
-            return;
-        }
-        currentMembers.remove(memberAction.getMemberName());
-    }
-
     private static void addBillAction(
             PriorityQueue<BillAction> sortedBillActions,
-            Set<String> currentMembers,
+            CurrentMembers currentMembers,
             Map<String, Long> memberBillReports
     ) {
         BillAction billAction = sortedBillActions.poll();
+        if (currentMembers.isEmpty()) {
+            return;
+        }
+
         Long pricePerMember = billAction.getPrice() / currentMembers.size();
-        for (String currentMember : currentMembers) {
-            Long price = memberBillReports.getOrDefault(currentMember, 0L) + pricePerMember;
+        for (String currentMember : currentMembers.getMembers()) {
+            Long price = memberBillReports.get(currentMember) + pricePerMember;
             memberBillReports.put(currentMember, price);
         }
     }

--- a/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
@@ -5,6 +5,7 @@ import static server.haengdong.domain.action.MemberActionStatus.IN;
 import static server.haengdong.domain.action.MemberActionStatus.OUT;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import server.haengdong.domain.event.Event;
@@ -26,5 +27,32 @@ class CurrentMembersTest {
 
         assertThat(currentMembers.getMembers())
                 .containsExactlyInAnyOrder("망쵸", "웨디");
+    }
+
+    @DisplayName("인원 변동 액션의 상태가 IN이면 현재 인원에 추가한다.")
+    @Test
+    void addMemberAction1() {
+        CurrentMembers currentMembers = new CurrentMembers();
+        Event event = new Event("이벤트", "token");
+        MemberAction memberAction = new MemberAction(new Action(event, 1L), "웨디", IN, 1L);
+
+        CurrentMembers addedCurrentMembers = currentMembers.addMemberAction(memberAction);
+        Set<String> members = addedCurrentMembers.getMembers();
+
+        assertThat(members).hasSize(1)
+                .containsExactly("웨디");
+    }
+
+    @DisplayName("인원 변동 액션의 상태가 OUT이면 현재 인원에서 제외한다.")
+    @Test
+    void addMemberAction2() {
+        Event event = new Event("이벤트", "token");
+        MemberAction memberAction1 = new MemberAction(new Action(event, 1L), "웨디", IN, 1L);
+        CurrentMembers currentMembers = new CurrentMembers().addMemberAction(memberAction1);
+        MemberAction memberAction2 = new MemberAction(new Action(event, 1L), "웨디", OUT, 1L);
+
+        CurrentMembers addedCurrentMembers = currentMembers.addMemberAction(memberAction2);
+
+        assertThat(addedCurrentMembers.getMembers()).hasSize(0);
     }
 }

--- a/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import server.haengdong.domain.event.Event;
 
-class MemberBillReportsTest {
+class MemberBillReportTest {
 
     @DisplayName("액션 목록으로 참가자 정산 리포트를 생성한다.")
     @Test
@@ -29,9 +29,9 @@ class MemberBillReportsTest {
                 new MemberAction(new Action(event, 5L), "감자", OUT, 2L)
         );
 
-        MemberBillReports memberBillReports = MemberBillReports.createByActions(billActions, memberActions);
+        MemberBillReport memberBillReport = MemberBillReport.createByActions(billActions, memberActions);
 
-        assertThat(memberBillReports.getReports())
+        assertThat(memberBillReport.getReports())
                 .containsAllEntriesOf(
                         Map.of(
                                 "감자", 20_000L,


### PR DESCRIPTION
## issue
- close #95

## 구현 사항
MemberAction의 status에 따라 현재 참여인원을 추가 또는 삭제하는 로직의 역할을 MemberBillReport가 아닌 CurrentMembers 로 변경했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
1. CurrentMembers를 불변 객체로 변경했는데 가변 객체를 사용하는 방법도 있을 것 같습니다. 어떻게 생각하시나요?
2. CurrentMembers는 `List<MemberAction>`로 만들어지는데 현재 MemberAction을 검증하고 있지는 않습니다. DB에서 읽어온 MemberAction 리스트를 검증을 하는 것이 좋을까요?
3. 인원 변동 추가 기능에서 검증을 CurrentMembers가 해도 괜찮을 것 같습니다. 어떻게 생각하시나요?

## 🫡 참고사항
