### PR TITLE
[BE] 예외에서 정의한 메세지를 꺼내지 못하는 오류 해결

### DIFF
--- a/server/src/main/java/server/haengdong/exception/ErrorResponse.java
+++ b/server/src/main/java/server/haengdong/exception/ErrorResponse.java
@@ -4,7 +4,7 @@ public record ErrorResponse(
         String message
 ) {
 
-    public static ErrorResponse of(HaengdongErrorCode errorCode) {
-        return new ErrorResponse(errorCode.getMessage());
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
     }
 }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> haengdongException() {
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HaengdongErrorCode.BAD_REQUEST));
+                .body(ErrorResponse.of(HaengdongErrorCode.BAD_REQUEST.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -25,19 +25,19 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest()
-                .body(new ErrorResponse(errorMessage));
+                .body(ErrorResponse.of(errorMessage));
     }
 
     @ExceptionHandler(HaengdongException.class)
     public ResponseEntity<ErrorResponse> haengdongException(HaengdongException e) {
         return ResponseEntity.status(e.getStatusCode())
-                .body(ErrorResponse.of(e.getErrorCode()));
+                .body(ErrorResponse.of(e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.internalServerError()
-                .body(ErrorResponse.of(HaengdongErrorCode.INTERNAL_SERVER_ERROR));
+                .body(ErrorResponse.of(HaengdongErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 }


### PR DESCRIPTION
## issue
- close #108 

## 구현 사항
HaengdongException을 생성시 HaengdongErrorCode과 예외 메세지를 넣어서 생성하고 던지는데, GlobalExceptionHandler 에서 catch 할 때 ErrorResponse.of()메서드에 HaengdongErrorCode의 getMessage() 메서드를 호출하여 예외 생성시 직접 정의한 메세지를 반환하지 않는 버그 해결.