### PR TITLE
[BE] 예외메시지 구체화

### DIFF
--- a/server/src/main/java/server/haengdong/application/MemberActionService.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionService.java
@@ -31,8 +31,9 @@ public class MemberActionService {
         Event event = findEvent(token);
 
         List<MemberAction> findMemberActions = memberActionRepository.findAllByEvent(event);
+        CurrentMembers currentMembers = CurrentMembers.of(findMemberActions);
         Action action = createStartAction(event);
-        List<MemberAction> memberActions = memberActionFactory.createMemberActions(request, findMemberActions, action);
+        List<MemberAction> memberActions = memberActionFactory.createMemberActions(request, currentMembers, action);
         memberActionRepository.saveAll(memberActions);
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
+++ b/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
@@ -5,6 +5,8 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 public class CurrentMembers {
 
@@ -14,7 +16,7 @@ public class CurrentMembers {
         this(new HashSet<>());
     }
 
-    private CurrentMembers(Set<String> members) {
+    protected CurrentMembers(Set<String> members) {
         this.members = members;
     }
 
@@ -50,6 +52,21 @@ public class CurrentMembers {
             currentMembers.remove(memberName);
         }
         return new CurrentMembers(currentMembers);
+    }
+
+    public void validate(String memberName, MemberActionStatus memberActionStatus) {
+        if (memberActionStatus == MemberActionStatus.IN && members.contains(memberName)) {
+            throw new HaengdongException(
+                    HaengdongErrorCode.INVALID_MEMBER_ACTION,
+                    String.format("%s은 이미 참여하고 있습니다.", memberName)
+            );
+        }
+        if (memberActionStatus == MemberActionStatus.OUT && !members.contains(memberName)) {
+            throw new HaengdongException(
+                    HaengdongErrorCode.INVALID_MEMBER_ACTION,
+                    String.format("%s은 현재 참여하고 있지 않습니다.", memberName)
+            );
+        }
     }
 
     public boolean isEmpty() {

--- a/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
+++ b/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
@@ -56,16 +56,10 @@ public class CurrentMembers {
 
     public void validate(String memberName, MemberActionStatus memberActionStatus) {
         if (memberActionStatus == MemberActionStatus.IN && members.contains(memberName)) {
-            throw new HaengdongException(
-                    HaengdongErrorCode.INVALID_MEMBER_ACTION,
-                    String.format("%s은 이미 참여하고 있습니다.", memberName)
-            );
+            throw new HaengdongException(HaengdongErrorCode.INVALID_MEMBER_IN_ACTION);
         }
         if (memberActionStatus == MemberActionStatus.OUT && !members.contains(memberName)) {
-            throw new HaengdongException(
-                    HaengdongErrorCode.INVALID_MEMBER_ACTION,
-                    String.format("%s은 현재 참여하고 있지 않습니다.", memberName)
-            );
+            throw new HaengdongException(HaengdongErrorCode.INVALID_MEMBER_OUT_ACTION);
         }
     }
 

--- a/server/src/main/java/server/haengdong/exception/ErrorResponse.java
+++ b/server/src/main/java/server/haengdong/exception/ErrorResponse.java
@@ -1,10 +1,15 @@
 package server.haengdong.exception;
 
 public record ErrorResponse(
+        String code,
         String message
 ) {
 
-    public static ErrorResponse of(String message) {
-        return new ErrorResponse(message);
+    public static ErrorResponse of(HaengdongErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public static ErrorResponse of(HaengdongErrorCode errorCode, String message){
+        return new ErrorResponse(errorCode.getCode(), message);
     }
 }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -28,6 +28,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.info(e.getMessage(), e);
         String errorMessage = e.getFieldErrors().stream()
                 .map(error -> error.getField() + " " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
@@ -38,6 +39,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HaengdongException.class)
     public ResponseEntity<ErrorResponse> haengdongException(HaengdongException e) {
+        log.info(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(e.getErrorCode()));
     }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -17,13 +17,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class})
     public ResponseEntity<ErrorResponse> noResourceException() {
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HaengdongErrorCode.NO_RESOURCE_REQUEST.getMessage()));
+                .body(ErrorResponse.of(HaengdongErrorCode.NO_RESOURCE_REQUEST));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> httpMessageNotReadableException() {
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HaengdongErrorCode.MESSAGE_NOT_READABLE.getMessage()));
+                .body(ErrorResponse.of(HaengdongErrorCode.MESSAGE_NOT_READABLE));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -33,19 +33,19 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(errorMessage));
+                .body(ErrorResponse.of(HaengdongErrorCode.BAD_REQUEST, errorMessage));
     }
 
     @ExceptionHandler(HaengdongException.class)
     public ResponseEntity<ErrorResponse> haengdongException(HaengdongException e) {
-        return ResponseEntity.status(e.getStatusCode())
-                .body(ErrorResponse.of(e.getMessage()));
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(e.getErrorCode()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.internalServerError()
-                .body(ErrorResponse.of(HaengdongErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+                .body(ErrorResponse.of(HaengdongErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -3,19 +3,27 @@ package server.haengdong.exception;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> haengdongException() {
+    @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class})
+    public ResponseEntity<ErrorResponse> noResourceException() {
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HaengdongErrorCode.BAD_REQUEST.getMessage()));
+                .body(ErrorResponse.of(HaengdongErrorCode.NO_RESOURCE_REQUEST.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> httpMessageNotReadableException() {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(HaengdongErrorCode.MESSAGE_NOT_READABLE.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -1,26 +1,25 @@
 package server.haengdong.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public enum HaengdongErrorCode {
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    NO_RESOURCE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 엔드포인트입니다."),
-    MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "읽을 수 없는 요청 형식입니다."),
-    DUPLICATED_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "중복된 인원이 존재합니다."),
-    INVALID_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "잘못된 맴버 액션입니다."),
+    BAD_REQUEST("R_001", "잘못된 요청입니다."),
+    NO_RESOURCE_REQUEST("R_002", "잘못된 엔드포인트입니다."),
+    MESSAGE_NOT_READABLE("R_003", "읽을 수 없는 요청 형식입니다."),
+    DUPLICATED_MEMBER_ACTION("MA_001", "중복된 인원이 존재합니다."),
+    INVALID_MEMBER_ACTION("MA_002", "잘못된 맴버 액션입니다."),
 
-    NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "존재하지 않는 행사입니다."),
+    NOT_FOUND_EVENT("EV_400", "존재하지 않는 행사입니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생했습니다."),
+    INTERNAL_SERVER_ERROR("S_001", "서버 내부에서 에러가 발생했습니다."),
     ;
 
-    private final HttpStatus httpStatus;
+    private final String code;
     private final String message;
 
-    HaengdongErrorCode(HttpStatus httpStatus, String message) {
-        this.httpStatus = httpStatus;
+    HaengdongErrorCode(String code, String message) {
+        this.code = code;
         this.message = message;
     }
 }

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum HaengdongErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    DUPLICATED_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "올바르지 않은 인원 요청입니다."),
+    NO_RESOURCE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 엔드포인트입니다."),
+    MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "읽을 수 없는 요청 형식입니다."),
+    DUPLICATED_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "중복된 인원이 존재합니다."),
     INVALID_MEMBER_ACTION(HttpStatus.BAD_REQUEST, "잘못된 맴버 액션입니다."),
 
     NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "존재하지 않는 행사입니다."),

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -8,7 +8,8 @@ public enum HaengdongErrorCode {
     NO_RESOURCE_REQUEST("R_002", "잘못된 엔드포인트입니다."),
     MESSAGE_NOT_READABLE("R_003", "읽을 수 없는 요청 형식입니다."),
     DUPLICATED_MEMBER_ACTION("MA_001", "중복된 인원이 존재합니다."),
-    INVALID_MEMBER_ACTION("MA_002", "잘못된 맴버 액션입니다."),
+    INVALID_MEMBER_IN_ACTION("MA_002", "현재 참여하고 있는 인원이 존재합니다."),
+    INVALID_MEMBER_OUT_ACTION("MA_003", "현재 참여하고 있지 않는 인원이 존재합니다."),
     NOT_FOUND_EVENT("EV_400", "존재하지 않는 행사입니다."),
     INTERNAL_SERVER_ERROR("S_001", "서버 내부에서 에러가 발생했습니다."),
     ;

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -9,9 +9,7 @@ public enum HaengdongErrorCode {
     MESSAGE_NOT_READABLE("R_003", "읽을 수 없는 요청 형식입니다."),
     DUPLICATED_MEMBER_ACTION("MA_001", "중복된 인원이 존재합니다."),
     INVALID_MEMBER_ACTION("MA_002", "잘못된 맴버 액션입니다."),
-
     NOT_FOUND_EVENT("EV_400", "존재하지 않는 행사입니다."),
-
     INTERNAL_SERVER_ERROR("S_001", "서버 내부에서 에러가 발생했습니다."),
     ;
 

--- a/server/src/main/java/server/haengdong/exception/HaengdongException.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongException.java
@@ -1,7 +1,6 @@
 package server.haengdong.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatusCode;
 
 @Getter
 public class HaengdongException extends RuntimeException {
@@ -16,10 +15,6 @@ public class HaengdongException extends RuntimeException {
     public HaengdongException(HaengdongErrorCode errorCode, String message) {
         this.errorCode = errorCode;
         this.message = message;
-    }
-
-    public HttpStatusCode getStatusCode() {
-        return errorCode.getHttpStatus();
     }
 
     @Override

--- a/server/src/test/java/server/haengdong/application/MemberActionFactoryTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberActionFactoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import server.haengdong.application.request.MemberActionSaveAppRequest;
 import server.haengdong.application.request.MemberActionsSaveAppRequest;
 import server.haengdong.domain.action.Action;
+import server.haengdong.domain.action.CurrentMembers;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionStatus;
@@ -56,10 +57,12 @@ class MemberActionFactoryTest {
 
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("토다리", "OUT")));
+
         List<MemberAction> unorderedMemberActions = List.of(memberAction2, memberAction1);
+        CurrentMembers currentMembers = CurrentMembers.of(unorderedMemberActions);
         Action startAction = new Action(event, 3L);
 
-        assertThatThrownBy(() -> memberActionFactory.createMemberActions(request, unorderedMemberActions, startAction))
+        assertThatThrownBy(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 
@@ -75,8 +78,10 @@ class MemberActionFactoryTest {
                 List.of(new MemberActionSaveAppRequest("토다리", "OUT")));
         Action startAction = new Action(event, 2L);
 
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
         List<MemberAction> memberActions = memberActionFactory.createMemberActions(memberActionsSaveAppRequest,
-                                                                                   List.of(memberAction), startAction);
+                currentMembers, startAction
+        );
 
         assertThat(memberActions).hasSize(1)
                 .extracting(MemberAction::getAction, MemberAction::getMemberName, MemberAction::getStatus)
@@ -96,8 +101,9 @@ class MemberActionFactoryTest {
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("토다리", "OUT")));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(memberAction), startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .doesNotThrowAnyException();
     }
 
@@ -115,10 +121,9 @@ class MemberActionFactoryTest {
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("토다리", "IN")));
         Action startAction = new Action(event, 3L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction1, memberAction2));
 
-        assertThatCode(
-                () -> memberActionFactory.createMemberActions(request, List.of(memberAction1, memberAction2),
-                                                              startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .doesNotThrowAnyException();
     }
 
@@ -133,8 +138,9 @@ class MemberActionFactoryTest {
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("쿠키", "IN")));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(memberAction), startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .doesNotThrowAnyException();
     }
 
@@ -146,8 +152,10 @@ class MemberActionFactoryTest {
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("쿠키", "OUT")));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of());
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(), startAction))
+        assertThatCode(
+                () -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 
@@ -162,8 +170,9 @@ class MemberActionFactoryTest {
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
                 List.of(new MemberActionSaveAppRequest("쿠키", "IN")));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(memberAction), startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 
@@ -173,11 +182,15 @@ class MemberActionFactoryTest {
         Event event = eventRepository.save(new Event("test", "TOKEN"));
 
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
-                List.of(new MemberActionSaveAppRequest("쿠키", "IN"),
-                        new MemberActionSaveAppRequest("쿠키", "IN")));
+                List.of(
+                        new MemberActionSaveAppRequest("쿠키", "IN"),
+                        new MemberActionSaveAppRequest("쿠키", "IN")
+                ));
         Action startAction = new Action(event, 1L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of());
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(), startAction))
+        assertThatCode(
+                () -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 
@@ -190,11 +203,14 @@ class MemberActionFactoryTest {
         memberActionRepository.save(memberAction);
 
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
-                List.of(new MemberActionSaveAppRequest("쿠키", "OUT"),
-                        new MemberActionSaveAppRequest("쿠키", "OUT")));
+                List.of(
+                        new MemberActionSaveAppRequest("쿠키", "OUT"),
+                        new MemberActionSaveAppRequest("쿠키", "OUT")
+                ));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(memberAction), startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 
@@ -207,11 +223,14 @@ class MemberActionFactoryTest {
         memberActionRepository.save(memberAction);
 
         MemberActionsSaveAppRequest request = new MemberActionsSaveAppRequest(
-                List.of(new MemberActionSaveAppRequest("쿠키", "IN"),
-                        new MemberActionSaveAppRequest("쿠키", "OUT")));
+                List.of(
+                        new MemberActionSaveAppRequest("쿠키", "IN"),
+                        new MemberActionSaveAppRequest("쿠키", "OUT")
+                ));
         Action startAction = new Action(event, 2L);
+        CurrentMembers currentMembers = CurrentMembers.of(List.of(memberAction));
 
-        assertThatCode(() -> memberActionFactory.createMemberActions(request, List.of(memberAction), startAction))
+        assertThatCode(() -> memberActionFactory.createMemberActions(request, currentMembers, startAction))
                 .isInstanceOf(HaengdongException.class);
     }
 }

--- a/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/CurrentMembersTest.java
@@ -1,6 +1,7 @@
 package server.haengdong.domain.action;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static server.haengdong.domain.action.MemberActionStatus.IN;
 import static server.haengdong.domain.action.MemberActionStatus.OUT;
 
@@ -8,7 +9,10 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import server.haengdong.application.request.MemberActionSaveAppRequest;
+import server.haengdong.application.request.MemberActionsSaveAppRequest;
 import server.haengdong.domain.event.Event;
+import server.haengdong.exception.HaengdongException;
 
 class CurrentMembersTest {
 
@@ -54,5 +58,41 @@ class CurrentMembersTest {
         CurrentMembers addedCurrentMembers = currentMembers.addMemberAction(memberAction2);
 
         assertThat(addedCurrentMembers.getMembers()).hasSize(0);
+    }
+
+    @DisplayName("현재 참여중인 인원은 나갈 수 있다.")
+    @Test
+    void validate1() {
+        CurrentMembers currentMembers = new CurrentMembers(Set.of("토다리"));
+
+        assertThatCode(() -> currentMembers.validate("토다리", OUT))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("현재 참여중이지 않은 인원은 들어올 수 있다.")
+    @Test
+    void validate2() {
+        CurrentMembers currentMembers = new CurrentMembers(Set.of("쿠키"));
+
+        assertThatCode(() -> currentMembers.validate("토다리", IN))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("현재 참여중인 인원은 들어올 수 없다.")
+    @Test
+    void validate3() {
+        CurrentMembers currentMembers = new CurrentMembers(Set.of("토다리"));
+
+        assertThatCode(() -> currentMembers.validate("토다리", IN))
+                .isInstanceOf(HaengdongException.class);
+    }
+
+    @DisplayName("현재 참여중이지 않은 인원은 나갈 수 없다.")
+    @Test
+    void validate4() {
+        CurrentMembers currentMembers = new CurrentMembers(Set.of("쿠키"));
+
+        assertThatCode(() -> currentMembers.validate("토다리", OUT))
+                .isInstanceOf(HaengdongException.class);
     }
 }


### PR DESCRIPTION
## issue
- close #118 

## 구현 사항
예외 메시지를 구체화했습니다.
<img width="865" alt="image" src="https://github.com/user-attachments/assets/7ccc1e86-ed53-4009-a1be-d009530ec3dd">

예외 상황에 따라 code 필드를 추가로 전달해 주도록 변경했습니다.
도메인에서 발생한 예외는 좀 더 구체적인 message를 전달합니다.
ex)`MA_002` : message가 `"%s은 이미 참여하고 있습니다."`와 `%s은 현재 참여하고 있지 않습니다."`로 구분되어 전달합니다.