### PR TITLE
[FE] Button컴포넌트에서 disabled일 때 커서 포인터가 보임

### DIFF
--- a/HDesign/src/theme/GlobalStyle.ts
+++ b/HDesign/src/theme/GlobalStyle.ts
@@ -27,6 +27,10 @@ export const GlobalStyle = css`
     line-height: 0;
   }
 
+  button:disabled {
+    cursor: default;
+  }
+
   /* Remove list styles (bullets/numbers) */
   ol,
   ul,


### PR DESCRIPTION
## issue
- close #170

## 구현 사항
GlobalStyle.tsx에 button:disabled를 수정했습니다.
