### PR TITLE
[BE] 행사에 참여한 전체 인원 조회 기능 구현

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, backend-dev ]
 
     defaults:
       run:

--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/backend-pull-request.yml
+++ b/.github/workflows/backend-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, backend-dev ]
 
     defaults:
       run:

--- a/.github/workflows/backend-pull-request.yml
+++ b/.github/workflows/backend-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -10,6 +10,7 @@ import server.haengdong.application.request.EventAppRequest;
 import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.application.response.MembersAppResponse;
 import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionRepository;
 import server.haengdong.domain.action.MemberAction;
@@ -87,5 +88,14 @@ public class EventService {
         }
 
         return actionAppResponses;
+    }
+
+    public MembersAppResponse findAllMembers(String token) {
+        Event event = eventRepository.findByToken(token)
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+
+        List<String> memberNames = memberActionRepository.findAllUniqueMemberByEvent(event);
+
+        return new MembersAppResponse(memberNames);
     }
 }

--- a/server/src/main/java/server/haengdong/application/response/MembersAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/MembersAppResponse.java
@@ -1,0 +1,8 @@
+package server.haengdong.application.response;
+
+import java.util.List;
+
+public record MembersAppResponse(
+        List<String> memberNames
+) {
+}

--- a/server/src/main/java/server/haengdong/domain/action/MemberActionRepository.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberActionRepository.java
@@ -15,7 +15,11 @@ public interface MemberActionRepository extends JpaRepository<MemberAction, Long
     @Query("select m from MemberAction m join fetch m.action where m.action.event = :event")
     List<MemberAction> findAllByEvent(@Param("event") Event event);
 
-    @Query("select distinct m.memberName from MemberAction m where m.action.event = :event")
+    @Query("""
+            select distinct m.memberName
+            from MemberAction m
+            where m.action.event = :event
+            """)
     List<String> findAllUniqueMemberByEvent(Event event);
 
     @Modifying

--- a/server/src/main/java/server/haengdong/domain/action/MemberActionRepository.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberActionRepository.java
@@ -15,6 +15,9 @@ public interface MemberActionRepository extends JpaRepository<MemberAction, Long
     @Query("select m from MemberAction m join fetch m.action where m.action.event = :event")
     List<MemberAction> findAllByEvent(@Param("event") Event event);
 
+    @Query("select distinct m.memberName from MemberAction m where m.action.event = :event")
+    List<String> findAllUniqueMemberByEvent(Event event);
+
     @Modifying
     @Query("""
             delete

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -12,6 +12,7 @@ import server.haengdong.application.EventService;
 import server.haengdong.presentation.request.EventSaveRequest;
 import server.haengdong.presentation.response.EventDetailResponse;
 import server.haengdong.presentation.response.EventResponse;
+import server.haengdong.presentation.response.MembersResponse;
 import server.haengdong.presentation.response.StepsResponse;
 
 @RequiredArgsConstructor
@@ -39,5 +40,12 @@ public class EventController {
         StepsResponse stepsResponse = StepsResponse.of(eventService.findActions(token));
 
         return ResponseEntity.ok(stepsResponse);
+    }
+
+    @GetMapping("/api/events/{eventId}/members")
+    public ResponseEntity<MembersResponse> findAllMembers(@PathVariable("eventId") String token) {
+        MembersResponse response = MembersResponse.of(eventService.findAllMembers(token));
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/MembersResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/MembersResponse.java
@@ -1,0 +1,13 @@
+package server.haengdong.presentation.response;
+
+import java.util.List;
+import server.haengdong.application.response.MembersAppResponse;
+
+public record MembersResponse(
+        List<String> memberNames
+) {
+
+    public static MembersResponse of(MembersAppResponse response) {
+        return new MembersResponse(response.memberNames());
+    }
+}

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -116,16 +116,16 @@ class EventServiceTest {
         String token = "웨디_토큰";
         Event event = new Event("행동대장 회식", token);
         Action action1 = new Action(event, 1L);
-        MemberAction memberAction1 = new MemberAction(action1, "토다리", IN, 1L);
         Action action2 = new Action(event, 2L);
-        MemberAction memberAction2 = new MemberAction(action2, "쿠키", IN, 1L);
         Action action3 = new Action(event, 3L);
+        Action action4 = new Action(event, 4L);
         BillAction billAction = new BillAction(action3, "뽕나무쟁이족발", 30000L);
-        Action action4 = new Action(event, 3L);
+        MemberAction memberAction1 = new MemberAction(action1, "토다리", IN, 1L);
+        MemberAction memberAction2 = new MemberAction(action2, "쿠키", IN, 1L);
         MemberAction memberAction3 = new MemberAction(action4, "쿠키", OUT, 1L);
         eventRepository.save(event);
-        memberActionRepository.saveAll(List.of(memberAction1, memberAction2, memberAction3));
         billActionRepository.save(billAction);
+        memberActionRepository.saveAll(List.of(memberAction1, memberAction2, memberAction3));
 
         MembersAppResponse membersAppResponse = eventService.findAllMembers(token);
 

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -4,6 +4,8 @@ package server.haengdong.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
+import static server.haengdong.domain.action.MemberActionStatus.IN;
+import static server.haengdong.domain.action.MemberActionStatus.OUT;
 
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -16,13 +18,13 @@ import server.haengdong.application.request.EventAppRequest;
 import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.application.response.MembersAppResponse;
 import server.haengdong.domain.action.Action;
 import server.haengdong.domain.action.ActionRepository;
 import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionRepository;
 import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
-import server.haengdong.domain.action.MemberActionStatus;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.domain.event.EventTokenProvider;
@@ -84,9 +86,9 @@ class EventServiceTest {
     void findActionsTest() {
         Event event = new Event("행동대장 회식", "웨디_토큰");
         Action action = new Action(event, 1L);
-        MemberAction memberAction = new MemberAction(action, "토다리", MemberActionStatus.IN, 1L);
+        MemberAction memberAction = new MemberAction(action, "토다리", IN, 1L);
         Action action1 = new Action(event, 2L);
-        MemberAction memberAction1 = new MemberAction(action1, "쿠키", MemberActionStatus.IN, 1L);
+        MemberAction memberAction1 = new MemberAction(action1, "쿠키", IN, 1L);
         Action action2 = new Action(event, 3L);
         BillAction billAction = new BillAction(action2, "뽕나무쟁이족발", 30000L);
         eventRepository.save(event);
@@ -106,5 +108,27 @@ class EventServiceTest {
                         tuple(2L, "쿠키", null, 2L, "IN"),
                         tuple(3L, "뽕나무쟁이족발", 30000L, 3L, "BILL")
                 );
+    }
+
+    @DisplayName("행사에 참여한 전체 인원을 중복 없이 조회한다.")
+    @Test
+    void findAllMembersTest() {
+        String token = "웨디_토큰";
+        Event event = new Event("행동대장 회식", token);
+        Action action1 = new Action(event, 1L);
+        MemberAction memberAction1 = new MemberAction(action1, "토다리", IN, 1L);
+        Action action2 = new Action(event, 2L);
+        MemberAction memberAction2 = new MemberAction(action2, "쿠키", IN, 1L);
+        Action action3 = new Action(event, 3L);
+        BillAction billAction = new BillAction(action3, "뽕나무쟁이족발", 30000L);
+        Action action4 = new Action(event, 3L);
+        MemberAction memberAction3 = new MemberAction(action4, "쿠키", OUT, 1L);
+        eventRepository.save(event);
+        memberActionRepository.saveAll(List.of(memberAction1, memberAction2, memberAction3));
+        billActionRepository.save(billAction);
+
+        MembersAppResponse membersAppResponse = eventService.findAllMembers(token);
+
+        assertThat(membersAppResponse.memberNames()).containsExactlyInAnyOrder("토다리", "쿠키");
     }
 }

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -1,6 +1,7 @@
 package server.haengdong.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,7 @@ import server.haengdong.application.EventService;
 import server.haengdong.application.request.EventAppRequest;
 import server.haengdong.application.response.EventAppResponse;
 import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.application.response.MembersAppResponse;
 import server.haengdong.presentation.request.EventSaveRequest;
 
 @WebMvcTest(EventController.class)
@@ -62,5 +65,19 @@ class EventControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.eventName").value("행동대장 회식"));
+    }
+
+    @DisplayName("행사에 참여한 전체 인원을 중복 없이 조회한다.")
+    @Test
+    void findAllMembersTest() throws Exception {
+        MembersAppResponse memberAppResponse = new MembersAppResponse(List.of("토다리", "쿠키"));
+        given(eventService.findAllMembers(anyString())).willReturn(memberAppResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/members", "TOKEN"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberNames").isArray())
+                .andExpect(jsonPath("$.memberNames[0]").value("토다리"))
+                .andExpect(jsonPath("$.memberNames[1]").value("쿠키"));
     }
 }


### PR DESCRIPTION
## issue
- close #191 

## 구현 사항

**엔드포인트**

`/api/events/{eventId}/members`

**Path Variable**
- eventId: String

**예외 상황**
- eventId에 해당되는 행사가 없는 경우
  - HttpStatus: 400
  - ErrorCode: EV_400
  - Message: 존재하지 않는 행사입니다.


## 중점적으로 리뷰받고 싶은 부분(선택)
- 간단한 API로 리뷰할 부분이 적을 것 같습니다. 
- 메서드 네이밍과 메서드의 구현 클래스 위치를 확인해 주세요! 
  - ex) eventService 안에 구현했는데 적절한지 


