### PR TITLE
[BE] API 엔드포인트 수정

### DIFF
--- a/server/src/main/java/server/haengdong/presentation/BillActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillActionController.java
@@ -19,7 +19,7 @@ public class BillActionController {
 
     private final BillActionService billActionService;
 
-    @PostMapping("/api/events/{eventId}/actions/bills")
+    @PostMapping("/api/events/{eventId}/bill-actions")
     public ResponseEntity<Void> saveAllBillAction(
             @PathVariable("eventId") String token,
             @RequestBody @Valid BillActionsSaveRequest request
@@ -30,7 +30,7 @@ public class BillActionController {
                 .build();
     }
 
-    @PutMapping("/api/events/{eventId}/actions/bills/{actionId}")
+    @PutMapping("/api/events/{eventId}/bill-actions/{actionId}")
     public ResponseEntity<Void> updateBillAction(
             @PathVariable("eventId") String token,
             @PathVariable("actionId") Long actionId,
@@ -42,7 +42,7 @@ public class BillActionController {
                 .build();
     }
 
-    @DeleteMapping("/api/events/{eventId}/actions/{actionId}/bills")
+    @DeleteMapping("/api/events/{eventId}/bill-actions/{actionId}")
     public ResponseEntity<Void> deleteBillAction(
             @PathVariable("eventId") String token,
             @PathVariable("actionId") Long actionId

--- a/server/src/main/java/server/haengdong/presentation/MemberActionController.java
+++ b/server/src/main/java/server/haengdong/presentation/MemberActionController.java
@@ -20,7 +20,7 @@ public class MemberActionController {
 
     private final MemberActionService memberActionService;
 
-    @PostMapping("/api/events/{eventId}/actions/members")
+    @PostMapping("/api/events/{eventId}/member-actions")
     public ResponseEntity<Void> saveMemberAction(
             @PathVariable("eventId") String token,
             @RequestBody MemberActionsSaveRequest request
@@ -48,7 +48,7 @@ public class MemberActionController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/api/events/{eventId}/actions/{actionId}/members")
+    @DeleteMapping("/api/events/{eventId}/member-actions/{actionId}")
     public ResponseEntity<Void> deleteMemberAction(
             @PathVariable("eventId") String token,
             @PathVariable("actionId") Long actionId

--- a/server/src/test/java/server/haengdong/presentation/BillActionControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionControllerTest.java
@@ -48,7 +48,7 @@ class BillActionControllerTest {
         String requestBody = objectMapper.writeValueAsString(request);
         String token = "TOKEN";
 
-        mockMvc.perform(post("/api/events/{token}/actions/bills", token)
+        mockMvc.perform(post("/api/events/{token}/bill-actions", token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andDo(print())
@@ -67,7 +67,7 @@ class BillActionControllerTest {
         String requestBody = objectMapper.writeValueAsString(request);
         String token = "TOKEN";
 
-        mockMvc.perform(post("/api/events/{token}/actions/bills", token)
+        mockMvc.perform(post("/api/events/{token}/bill-actions", token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andDo(print())
@@ -82,7 +82,7 @@ class BillActionControllerTest {
         String requestBody = objectMapper.writeValueAsString(request);
         String token = "TOKEN";
 
-        mockMvc.perform(put("/api/events/{token}/actions/bills/{actionId}", token, 1L)
+        mockMvc.perform(put("/api/events/{token}/bill-actions/{actionId}", token, 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andDo(print())
@@ -94,7 +94,7 @@ class BillActionControllerTest {
     void deleteBillAction() throws Exception {
         String token = "토다리토큰";
 
-        mockMvc.perform(delete("/api/events/{token}/actions/{actionId}/bills", token, 1))
+        mockMvc.perform(delete("/api/events/{token}/bill-actions/{actionId}", token, 1))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -106,7 +106,7 @@ class BillActionControllerTest {
         doThrow(new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT))
                 .when(billActionService).deleteBillAction(any(String.class), any(Long.class));
 
-        mockMvc.perform(delete("/api/events/{token}/actions/{actionId}/bills", token, 1))
+        mockMvc.perform(delete("/api/events/{token}/bill-actions/{actionId}", token, 1))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/server/src/test/java/server/haengdong/presentation/MemberActionControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/MemberActionControllerTest.java
@@ -43,7 +43,7 @@ class MemberActionControllerTest {
 
         String requestBody = objectMapper.writeValueAsString(memberActionsSaveRequest);
 
-        mockMvc.perform(post("/api/events/TOKEN/actions/members")
+        mockMvc.perform(post("/api/events/TOKEN/member-actions")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andDo(print())
@@ -72,7 +72,7 @@ class MemberActionControllerTest {
         String token = "TOKEN";
         Long actionId = 2L;
 
-        mockMvc.perform(delete("/api/events/{token}/actions/{actionId}/members", token, actionId))
+        mockMvc.perform(delete("/api/events/{token}/member-actions/{actionId}", token, actionId))
                 .andDo(print())
                 .andExpect(status().isOk());
     }


### PR DESCRIPTION
## issue
- close #189

## 구현 사항
멤버 액션, 지출 액션 관련 API 엔드포인트를 수정합니다.

### 변경된 API
#### MemberActionCotroller
- 멤버 액션 추가 (POST)
  - Before: `/api/events/{eventId}/actions/members` 
  - After:  `/api/events/{eventId}/member-actions`
- 멤버 액션 삭제 (DELETE)
  - Before: `/api/events/{eventId}/actions/{actionId}/members` 
  - After:  `/api/events/{eventId}/member-actions/{actionId}`
  
#### BillActionController
- 지출 액션 추가 (POST)
  - Before: `/api/events/{eventId}/actions/bills` 
  - After:  `/api/events/{eventId}/bill-actions`
- 지출 액션 삭제 (DELETE)
  - Before: `/api/events/{eventId}/actions/{actionId}/bills` 
  - After:  `/api/events/{eventId}/bill-actions/{actionId}`
- 지출 액션 수정 (PUT)
  - Before: `/api/events/{eventId}/actions/bills/{actionId}` 
  - After:  `/api/events/{eventId}/bill-actions/{actionId}`


## 중점적으로 리뷰받고 싶은 부분(선택)
노션 보면서 여러 번 확인하긴 했는데, 혹시 모르니까 API 잘 수정했는지 크로스 체크 해주세요!