### PR TITLE
[BE] 에러 코드 재정의

### DIFF
--- a/server/src/main/java/server/haengdong/application/ActionService.java
+++ b/server/src/main/java/server/haengdong/application/ActionService.java
@@ -24,7 +24,7 @@ public class ActionService {
 
     public List<MemberBillReportAppResponse> getMemberBillReports(String token) {
         Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
         List<BillAction> billActions = billActionRepository.findByAction_Event(event);
         List<MemberAction> memberActions = memberActionRepository.findAllByEvent(event);
 

--- a/server/src/main/java/server/haengdong/application/AuthService.java
+++ b/server/src/main/java/server/haengdong/application/AuthService.java
@@ -4,6 +4,7 @@ package server.haengdong.application;
 import java.util.Map;
 import server.haengdong.domain.TokenProvider;
 import server.haengdong.exception.AuthenticationException;
+import server.haengdong.exception.HaengdongErrorCode;
 
 public class AuthService {
 
@@ -30,7 +31,7 @@ public class AuthService {
 
     private void validateToken(String token) {
         if (!tokenProvider.validateToken(token)) {
-            throw new AuthenticationException();
+            throw new AuthenticationException(HaengdongErrorCode.TOKEN_INVALID);
         }
     }
 

--- a/server/src/main/java/server/haengdong/application/BillActionService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionService.java
@@ -45,7 +45,7 @@ public class BillActionService {
     @Transactional
     public void updateBillAction(String token, Long actionId, BillActionUpdateAppRequest request) {
         BillAction billAction = billActionRepository.findByAction_Id(actionId)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_BILL_ACTION));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND));
 
         validateToken(token, billAction);
 
@@ -56,19 +56,19 @@ public class BillActionService {
     private void validateToken(String token, BillAction billAction) {
         Event event = billAction.getEvent();
         if (event.isTokenMismatch(token)) {
-            throw new HaengdongException(HaengdongErrorCode.NOT_FOUND_BILL_ACTION);
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND);
         }
     }
 
     private Event getEvent(String eventToken) {
         return eventRepository.findByToken(eventToken)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
     }
 
     @Transactional
     public void deleteBillAction(String token, Long actionId) {
         Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
 
         billActionRepository.deleteByAction_EventAndActionId(event, actionId);
     }

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -112,19 +112,19 @@ public class EventService {
     private void validateMemberNameUnique(Event event, String updatedMemberName) {
         boolean isMemberNameExist = memberActionRepository.existsByAction_EventAndMemberName(event, updatedMemberName);
         if (isMemberNameExist) {
-            throw new HaengdongException(HaengdongErrorCode.DUPLICATED_MEMBER_NAME);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE);
         }
     }
 
     public void validatePassword(EventLoginAppRequest request) throws HaengdongException {
         Event event = getEvent(request.token());
         if (event.isSamePassword(request.password())) {
-            throw new AuthenticationException();
+            throw new AuthenticationException(HaengdongErrorCode.PASSWORD_INVALID);
         }
     }
 
     private Event getEvent(String token) {
         return eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
     }
 }

--- a/server/src/main/java/server/haengdong/application/MemberActionFactory.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionFactory.java
@@ -1,7 +1,6 @@
 package server.haengdong.application;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -48,7 +47,7 @@ public class MemberActionFactory {
 
         long uniqueCount = memberNames.stream().distinct().count();
         if (uniqueCount != memberNames.size()) {
-            throw new HaengdongException(HaengdongErrorCode.DUPLICATED_MEMBER_ACTION);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE);
         }
     }
 

--- a/server/src/main/java/server/haengdong/application/MemberActionService.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionService.java
@@ -56,12 +56,12 @@ public class MemberActionService {
 
     private Event findEvent(String token) {
         return eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
     }
 
     public void deleteMember(String token, String memberName) {
         Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
 
         memberActionRepository.deleteAllByEventAndMemberName(event, memberName);
     }
@@ -69,11 +69,11 @@ public class MemberActionService {
     @Transactional
     public void deleteMemberAction(String token, Long actionId) {
         Event event = eventRepository.findByToken(token)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
         Action action = actionRepository.findByIdAndEvent(actionId, event)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_ACTION));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.ACTION_NOT_FOUND));
         MemberAction memberAction = memberActionRepository.findByAction(action)
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.NOT_FOUND_MEMBER_ACTION));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.MEMBER_ACTION_NOT_FOUND));
 
         memberActionRepository.deleteAllByMemberNameAndMinSequence(memberAction.getMemberName(),
                 memberAction.getSequence());

--- a/server/src/main/java/server/haengdong/config/AdminInterceptor.java
+++ b/server/src/main/java/server/haengdong/config/AdminInterceptor.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.HandlerInterceptor;
 import server.haengdong.application.AuthService;
 import server.haengdong.exception.AuthenticationException;
+import server.haengdong.exception.HaengdongErrorCode;
 import server.haengdong.infrastructure.auth.AuthenticationExtractor;
 
 @Slf4j
@@ -38,7 +39,7 @@ public class AdminInterceptor implements HandlerInterceptor {
         String tokenEventId = authService.findEventIdByToken(token);
         String eventId = request.getRequestURI().split("/")[3];
         if (!tokenEventId.equals(eventId)) {
-            throw new AuthenticationException();
+            throw new AuthenticationException(HaengdongErrorCode.FORBIDDEN);
         }
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -20,10 +20,10 @@ import server.haengdong.exception.HaengdongException;
 @Entity
 public class BillAction implements Comparable<BillAction> {
 
-    private static final int MIN_TITLE_LENGTH = 2;
-    private static final int MAX_TITLE_LENGTH = 30;
-    private static final long MIN_PRICE = 1L;
-    private static final long MAX_PRICE = 10_000_000L;
+    public static final int MIN_TITLE_LENGTH = 1;
+    public static final int MAX_TITLE_LENGTH = 30;
+    public static final long MIN_PRICE = 1L;
+    public static final long MAX_PRICE = 10_000_000L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,15 +53,17 @@ public class BillAction implements Comparable<BillAction> {
     private void validateTitle(String title) {
         int titleLength = title.trim().length();
         if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
-                    String.format("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다.", MIN_TITLE_LENGTH, MAX_TITLE_LENGTH));
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID,
+                    String.format(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID.getMessage(),
+                            MIN_TITLE_LENGTH,
+                            MAX_TITLE_LENGTH));
         }
     }
 
     private void validatePrice(Long price) {
         if (price < MIN_PRICE || price > MAX_PRICE) {
-            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
-                    String.format("지출 금액은 %,d 이하의 자연수여야 합니다.", MAX_PRICE));
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_PRICE_INVALID,
+                    String.format(HaengdongErrorCode.BILL_ACTION_PRICE_INVALID.getMessage(), MAX_PRICE));
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -53,17 +53,13 @@ public class BillAction implements Comparable<BillAction> {
     private void validateTitle(String title) {
         int titleLength = title.trim().length();
         if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID,
-                    String.format(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID.getMessage(),
-                            MIN_TITLE_LENGTH,
-                            MAX_TITLE_LENGTH));
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID);
         }
     }
 
     private void validatePrice(Long price) {
         if (price < MIN_PRICE || price > MAX_PRICE) {
-            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_PRICE_INVALID,
-                    String.format(HaengdongErrorCode.BILL_ACTION_PRICE_INVALID.getMessage(), MAX_PRICE));
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_PRICE_INVALID);
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
+++ b/server/src/main/java/server/haengdong/domain/action/CurrentMembers.java
@@ -56,10 +56,10 @@ public class CurrentMembers {
 
     public void validate(String memberName, MemberActionStatus memberActionStatus) {
         if (memberActionStatus == MemberActionStatus.IN && members.contains(memberName)) {
-            throw new HaengdongException(HaengdongErrorCode.INVALID_MEMBER_IN_ACTION);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_ALREADY_EXIST);
         }
         if (memberActionStatus == MemberActionStatus.OUT && !members.contains(memberName)) {
-            throw new HaengdongException(HaengdongErrorCode.INVALID_MEMBER_OUT_ACTION);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NOT_EXIST);
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/MemberAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberAction.java
@@ -48,10 +48,7 @@ public class MemberAction implements Comparable<MemberAction> {
     private void validateMemberName(String memberName) {
         int memberLength = memberName.length();
         if (memberLength < MIN_NAME_LENGTH || memberLength > MAX_NAME_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID,
-                    String.format(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID.getMessage(),
-                            MIN_NAME_LENGTH,
-                            MAX_NAME_LENGTH));
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID);
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/MemberAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberAction.java
@@ -12,11 +12,16 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class MemberAction implements Comparable<MemberAction> {
+
+    public static final int MIN_NAME_LENGTH = 1;
+    public static final int MAX_NAME_LENGTH = 4;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,13 +38,25 @@ public class MemberAction implements Comparable<MemberAction> {
     private Long memberGroupId;
 
     public MemberAction(Action action, String memberName, MemberActionStatus status, Long memberGroupId) {
+        validateMemberName(memberName);
         this.action = action;
         this.memberName = memberName;
         this.status = status;
         this.memberGroupId = memberGroupId;
     }
 
+    private void validateMemberName(String memberName) {
+        int memberLength = memberName.length();
+        if (memberLength < MIN_NAME_LENGTH || memberLength > MAX_NAME_LENGTH) {
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID,
+                    String.format(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID.getMessage(),
+                            MIN_NAME_LENGTH,
+                            MAX_NAME_LENGTH));
+        }
+    }
+
     public void updateMemberName(String memberName) {
+        validateMemberName(memberName);
         this.memberName = memberName;
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/MemberActionStatus.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberActionStatus.java
@@ -13,7 +13,7 @@ public enum MemberActionStatus {
         return Arrays.stream(MemberActionStatus.values())
                 .filter(s -> s.name().equals(status))
                 .findFirst()
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
-                        "존재하지 않는 인원 변동 액션입니다."));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.MEMBER_ACTION_STATUS_INVALID,
+                        String.format(HaengdongErrorCode.MEMBER_ACTION_STATUS_INVALID.getMessage(), status)));
     }
 }

--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -17,10 +17,11 @@ import server.haengdong.exception.HaengdongException;
 @Entity
 public class Event {
 
-    private static final int MIN_NAME_LENGTH = 2;
-    private static final int MAX_NAME_LENGTH = 20;
+    public static final int MIN_NAME_LENGTH = 1;
+    public static final int MAX_NAME_LENGTH = 20;
+    public static final int PASSWORD_LENGTH = 4;
     private static final String SPACES = "  ";
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^\\d{4}$");
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(String.format("^\\d{%d}$", PASSWORD_LENGTH));
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,16 +42,16 @@ public class Event {
     }
 
     private void validateName(String name) {
-        int nameLength = name.length();
+        int nameLength = name.trim().length();
         if (nameLength < MIN_NAME_LENGTH || MAX_NAME_LENGTH < nameLength) {
-            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+            throw new HaengdongException(HaengdongErrorCode.EVENT_NAME_LENGTH_INVALID,
                     String.format("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다. 입력한 이름 길이 : %d",
                             MIN_NAME_LENGTH,
                             MAX_NAME_LENGTH,
                             name.length()));
         }
         if (isBlankContinuous(name)) {
-            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST,
+            throw new HaengdongException(HaengdongErrorCode.EVENT_NAME_CONSECUTIVE_SPACES,
                     String.format("행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : %s", name));
         }
     }
@@ -58,7 +59,7 @@ public class Event {
     private void validatePassword(String password) {
         Matcher matcher = PASSWORD_PATTERN.matcher(password);
         if (!matcher.matches()) {
-            throw new HaengdongException(HaengdongErrorCode.BAD_REQUEST, "비밀번호는 4자리 숫자만 가능합니다.");
+            throw new HaengdongException(HaengdongErrorCode.EVENT_PASSWORD_FORMAT_INVALID, "비밀번호는 4자리 숫자만 가능합니다.");
         }
     }
 

--- a/server/src/main/java/server/haengdong/exception/AuthenticationException.java
+++ b/server/src/main/java/server/haengdong/exception/AuthenticationException.java
@@ -1,4 +1,19 @@
 package server.haengdong.exception;
 
+import lombok.Getter;
+
+@Getter
 public class AuthenticationException extends RuntimeException {
+
+    private final HaengdongErrorCode errorCode;
+    private final String message;
+
+    public AuthenticationException(HaengdongErrorCode errorCode) {
+        this(errorCode, errorCode.getMessage());
+    }
+
+    public AuthenticationException(HaengdongErrorCode errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
 }

--- a/server/src/main/java/server/haengdong/exception/ErrorResponse.java
+++ b/server/src/main/java/server/haengdong/exception/ErrorResponse.java
@@ -1,15 +1,15 @@
 package server.haengdong.exception;
 
 public record ErrorResponse(
-        String code,
+        HaengdongErrorCode errorCode,
         String message
 ) {
 
     public static ErrorResponse of(HaengdongErrorCode errorCode) {
-        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+        return new ErrorResponse(errorCode, errorCode.getMessage());
     }
 
-    public static ErrorResponse of(HaengdongErrorCode errorCode, String message){
-        return new ErrorResponse(errorCode.getCode(), message);
+    public static ErrorResponse of(HaengdongErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode, message);
     }
 }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -16,9 +16,9 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ErrorResponse> authenticationException() {
+    public ResponseEntity<ErrorResponse> authenticationException(AuthenticationException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(HaengdongErrorCode.UNAUTHORIZED));
+                .body(ErrorResponse.of(e.getErrorCode()));
     }
 
     @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class})
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HaengdongErrorCode.BAD_REQUEST, errorMessage));
+                .body(ErrorResponse.of(HaengdongErrorCode.REQUEST_EMPTY, errorMessage));
     }
 
     @ExceptionHandler(HaengdongException.class)

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -1,29 +1,63 @@
 package server.haengdong.exception;
 
 import lombok.Getter;
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.MemberAction;
+import server.haengdong.domain.event.Event;
 
 @Getter
 public enum HaengdongErrorCode {
-    BAD_REQUEST("R_001", "잘못된 요청입니다."),
-    NO_RESOURCE_REQUEST("R_002", "잘못된 엔드포인트입니다."),
-    MESSAGE_NOT_READABLE("R_003", "읽을 수 없는 요청 형식입니다."),
-    UNAUTHORIZED("A_001", "인증에 실패했습니다."),
-    INTERNAL_SERVER_ERROR("S_001", "서버 내부에서 에러가 발생했습니다."),
-    DUPLICATED_MEMBER_NAME("EV_001", "중복된 행사 참여 인원 이름이 존재합니다."),
-    NOT_FOUND_EVENT("EV_400", "존재하지 않는 행사입니다."),
-    DUPLICATED_MEMBER_ACTION("MA_001", "중복된 인원이 존재합니다."),
-    INVALID_MEMBER_IN_ACTION("MA_002", "현재 참여하고 있는 인원이 존재합니다."),
-    INVALID_MEMBER_OUT_ACTION("MA_003", "현재 참여하고 있지 않는 인원이 존재합니다."),
-    NOT_FOUND_MEMBER_ACTION("MA_400", "존재하지 않는 멤버 액션입니다."),
-    NOT_FOUND_BILL_ACTION("BA_400", "존재하지 않는 지출 액션입니다."),
-    NOT_FOUND_ACTION("AC_400", "존재하지 않는 액션입니다."),
-    ;
 
-    private final String code;
+    /* Domain */
+
+    EVENT_NOT_FOUND("존재하지 않는 행사입니다."),
+    EVENT_NAME_LENGTH_INVALID(String.format("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다.",
+            Event.MIN_NAME_LENGTH,
+            Event.MAX_NAME_LENGTH)),
+    EVENT_NAME_CONSECUTIVE_SPACES("행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : %s"),
+    EVENT_PASSWORD_FORMAT_INVALID(String.format("비밀번호는 %d자리 숫자만 가능합니다.", Event.PASSWORD_LENGTH)),
+
+    ACTION_NOT_FOUND("존재하지 않는 액션입니다."),
+
+    MEMBER_NAME_LENGTH_INVALID(String.format("멤버 이름은 %d자 이상 %d자 이하만 입력 가능합니다.",
+            MemberAction.MIN_NAME_LENGTH,
+            MemberAction.MAX_NAME_LENGTH)),
+    MEMBER_NAME_DUPLICATE("중복된 행사 참여 인원 이름이 존재합니다."),
+    MEMBER_NOT_EXIST("현재 참여하고 있지 않는 인원이 존재합니다."),
+    MEMBER_ALREADY_EXIST("현재 참여하고 있는 인원이 존재합니다."),
+
+    MEMBER_ACTION_NOT_FOUND("존재하지 않는 멤버 액션입니다."),
+    MEMBER_ACTION_STATUS_INVALID("멤버 액션은 IN, OUT만 가능합니다. 입력한 멤버 액션: %s"),
+
+    BILL_ACTION_NOT_FOUND("존재하지 않는 지출 액션입니다."),
+    BILL_ACTION_TITLE_INVALID(String.format("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다.",
+            BillAction.MIN_TITLE_LENGTH,
+            BillAction.MAX_TITLE_LENGTH)),
+    BILL_ACTION_PRICE_INVALID(String.format("지출 금액은 %,d 이하의 자연수여야 합니다.", BillAction.MAX_PRICE)),
+
+    /* Authentication */
+
+    PASSWORD_INVALID("비밀번호가 일치하지 않습니다."),
+
+    TOKEN_NOT_FOUND("토큰이 존재하지 않습니다."),
+    TOKEN_EXPIRED("만료된 토큰입니다."),
+    TOKEN_INVALID("유효하지 않은 토큰입니다."),
+
+    FORBIDDEN("접근할 수 없는 행사입니다."),
+
+    /* Request Validation */
+
+    REQUEST_EMPTY("입력 값은 공백일 수 없습니다.")
+
+    /* System */,
+
+    MESSAGE_NOT_READABLE("읽을 수 없는 요청입니다."),
+    NO_RESOURCE_REQUEST("존재하지 않는 자원입니다."),
+    INTERNAL_SERVER_ERROR("서버 내부에서 에러가 발생했습니다.");
+
     private final String message;
 
-    HaengdongErrorCode(String code, String message) {
-        this.code = code;
+    HaengdongErrorCode(String message) {
         this.message = message;
     }
 }

--- a/server/src/main/java/server/haengdong/exception/HaengdongException.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongException.java
@@ -9,19 +9,11 @@ public class HaengdongException extends RuntimeException {
     private final String message;
 
     public HaengdongException(HaengdongErrorCode errorCode) {
-        this(errorCode, null);
+        this(errorCode, errorCode.getMessage());
     }
 
     public HaengdongException(HaengdongErrorCode errorCode, String message) {
         this.errorCode = errorCode;
         this.message = message;
-    }
-
-    @Override
-    public String getMessage() {
-        if (message == null) {
-            return errorCode.getMessage();
-        }
-        return message;
     }
 }

--- a/server/src/main/java/server/haengdong/infrastructure/auth/AuthenticationExtractor.java
+++ b/server/src/main/java/server/haengdong/infrastructure/auth/AuthenticationExtractor.java
@@ -4,19 +4,20 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import server.haengdong.exception.AuthenticationException;
+import server.haengdong.exception.HaengdongErrorCode;
 
 public class AuthenticationExtractor {
 
     public String extract(HttpServletRequest request, String cookieName) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
-            throw new AuthenticationException();
+            throw new AuthenticationException(HaengdongErrorCode.TOKEN_NOT_FOUND);
         }
 
         return Arrays.stream(cookies)
                 .filter(cookie -> cookieName.equals(cookie.getName()))
                 .findFirst()
-                .orElseThrow(AuthenticationException::new)
+                .orElseThrow(() -> new AuthenticationException(HaengdongErrorCode.TOKEN_NOT_FOUND))
                 .getValue();
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionSaveRequest.java
@@ -6,10 +6,10 @@ import server.haengdong.application.request.BillActionAppRequest;
 
 public record BillActionSaveRequest(
 
-        @NotBlank
+        @NotBlank(message = "지출 내역 제목은 공백일 수 없습니다.")
         String title,
 
-        @NotNull
+        @NotNull(message = "지출 금액은 공백일 수 없습니다.")
         Long price
 ) {
 

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionUpdateRequest.java
@@ -6,13 +6,13 @@ import server.haengdong.application.request.BillActionUpdateAppRequest;
 
 public record BillActionUpdateRequest(
 
-        @NotBlank
+        @NotBlank(message = "지출 내역 제목은 공백일 수 없습니다.")
         String title,
 
-        @NotNull
+        @NotNull(message = "지출 금액은 공백일 수 없습니다.")
         Long price
 ) {
-        public BillActionUpdateAppRequest toAppResponse() {
-                return new BillActionUpdateAppRequest(title, price);
-        }
+    public BillActionUpdateAppRequest toAppResponse() {
+        return new BillActionUpdateAppRequest(title, price);
+    }
 }

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionsSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionsSaveRequest.java
@@ -4,7 +4,10 @@ import jakarta.validation.Valid;
 import java.util.List;
 import server.haengdong.application.request.BillActionAppRequest;
 
-public record BillActionsSaveRequest(@Valid List<BillActionSaveRequest> actions) {
+public record BillActionsSaveRequest(
+
+        @Valid List<BillActionSaveRequest> actions
+) {
 
     public List<BillActionAppRequest> toAppRequests() {
         return actions.stream()

--- a/server/src/main/java/server/haengdong/presentation/request/EventLoginRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventLoginRequest.java
@@ -5,10 +5,10 @@ import server.haengdong.application.request.EventLoginAppRequest;
 
 public record EventLoginRequest(
 
-        @NotBlank
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
         String password
 ) {
-        public EventLoginAppRequest toAppRequest(String token) {
-                return new EventLoginAppRequest(token, password);
-        }
+    public EventLoginAppRequest toAppRequest(String token) {
+        return new EventLoginAppRequest(token, password);
+    }
 }

--- a/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/EventSaveRequest.java
@@ -5,10 +5,10 @@ import server.haengdong.application.request.EventAppRequest;
 
 public record EventSaveRequest(
 
-        @NotBlank
+        @NotBlank(message = "행사 이름은 공백일 수 없습니다.")
         String eventName,
 
-        @NotBlank
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
         String password
 ) {
 

--- a/server/src/main/java/server/haengdong/presentation/request/MemberActionsSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/MemberActionsSaveRequest.java
@@ -8,7 +8,7 @@ import server.haengdong.application.request.MemberActionsSaveAppRequest;
 public record MemberActionsSaveRequest(
         List<String> members,
 
-        @NotBlank
+        @NotBlank(message = "멤버 액션은 공백일 수 없습니다.")
         String status
 ) {
 

--- a/server/src/main/java/server/haengdong/presentation/request/MemberUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/MemberUpdateRequest.java
@@ -4,7 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import server.haengdong.application.request.MemberUpdateAppRequest;
 
 public record MemberUpdateRequest(
-        @NotBlank String name
+
+        @NotBlank(message = "멤버 이름은 공백일 수 없습니다.")
+        String name
 ) {
 
     public MemberUpdateAppRequest toAppRequest() {

--- a/server/src/test/java/server/haengdong/application/ActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/ActionServiceTest.java
@@ -72,6 +72,6 @@ class ActionServiceTest extends ServiceTestSupport {
     void getMemberBillReports1() {
         assertThatThrownBy(() -> actionService.getMemberBillReports("invalid token"))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage(HaengdongErrorCode.NOT_FOUND_EVENT.getMessage());
+                .hasMessage(HaengdongErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 }

--- a/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
@@ -14,9 +14,9 @@ import server.haengdong.support.fixture.Fixture;
 
 class BillActionTest {
 
-    @DisplayName("지출 내역 제목의 앞뒤 공백을 제거한 길이가 2 ~ 30자가 아니면 지출을 생성할 수 없다.")
+    @DisplayName("지출 내역 제목의 앞뒤 공백을 제거한 길이가 1 ~ 30자가 아니면 지출을 생성할 수 없다.")
     @ParameterizedTest
-    @ValueSource(strings = {" 감 ", "", " ", "1234567890123456789012345678901"})
+    @ValueSource(strings = {"", " ", "1234567890123456789012345678901"})
     void validateTitle(String title) {
         Event event = Fixture.EVENT1;
         Action action = new Action(event, 1L);
@@ -24,7 +24,7 @@ class BillActionTest {
 
         assertThatThrownBy(() -> new BillAction(action, title, price))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("앞뒤 공백을 제거한 지출 내역 제목은 2 ~ 30자여야 합니다.");
+                .hasMessage("앞뒤 공백을 제거한 지출 내역 제목은 1 ~ 30자여야 합니다.");
     }
 
     @DisplayName("금액이 10,000,000 이하의 자연수가 아니면 지출을 생성할 수 없다.")

--- a/server/src/test/java/server/haengdong/domain/event/EventTest.java
+++ b/server/src/test/java/server/haengdong/domain/event/EventTest.java
@@ -26,13 +26,13 @@ class EventTest {
                 .hasMessage(String.format("행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : %s", eventName));
     }
 
-    @DisplayName("이름이 2자 미만이거나 20자 초과인 경우 예외가 발생한다.")
+    @DisplayName("이름이 1자 미만이거나 20자 초과인 경우 예외가 발생한다.")
     @ParameterizedTest
     @ValueSource(strings = {"", " ", "123456789012345678901"})
     void createFilTest2(String eventName) {
         assertThatCode(() -> new Event(eventName, "1234", "TEST_TOKEN"))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage(String.format("행사 이름은 2자 이상 20자 이하만 입력 가능합니다. 입력한 이름 길이 : %d", eventName.length()));
+                .hasMessage(String.format("행사 이름은 1자 이상 20자 이하만 입력 가능합니다. 입력한 이름 길이 : %d", eventName.length()));
     }
 
     @DisplayName("비밀번호는 4자리 숫자 입니다.")

--- a/server/src/test/java/server/haengdong/presentation/BillActionControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionControllerTest.java
@@ -87,7 +87,7 @@ class BillActionControllerTest extends ControllerTestSupport {
     @Test
     void deleteBillAction1() throws Exception {
         String eventId = "이상해토큰";
-        doThrow(new HaengdongException(HaengdongErrorCode.NOT_FOUND_EVENT))
+        doThrow(new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND))
                 .when(billActionService).deleteBillAction(any(String.class), any(Long.class));
 
         mockMvc.perform(delete("/api/events/{eventId}/bill-actions/{actionId}", eventId, 1))


### PR DESCRIPTION
## issue
- close #223 

## 응답 객체 변경

### 문제1: 에러 코드 불명확

프론트 크루 `웨디`의 요청에 따라 기존의 에러 코드를 보다 명확하고 직관적으로 표현하는 방식으로 수정하였습니다. 기존 도메인명 앞글자를 따서 만든 에러 코드에서, 에러 상황을 코드에 의미를 명확하게 담도록 변경하였습니다.

**기존 에러 응답 예시**

```json
{
	"code": "MA_002",
	"message": "현재 참여하고 있는 인원이 존재합니다."
}
```

**변경된 에러 응답**

```json
{
	"code": "MEMBER_ALREADY_EXIST",
	"message": "현재 참여하고 있는 인원이 존재합니다."
}
```

### 구현 방식

기존에 사용하던 ErrorCode를 ErrorResponse 필드에 넣는 방식을 변경하여, 보다 명확한 에러 코드를 제공하도록 구현하였습니다.

```java
public record ErrorResponse(
        // 이전 코드
        // String code,

        // 변경된 코드
        HaengdongErrorCode errorCode,

        String message
) {}
```

## 문제2: 에러 코드 세분화되어 있지 않음

프론트 크루 `웨디`의 요청에 따라, 기존의 에러 코드 체계를 보다 세분화하여 각 API에서 발생하는 예외 상황을 명확하게 표현하도록 수정하였습니다. 기존에는 전역적으로 8개의 에러 코드만 정의되어 있었으나, 이를 각 API별로 세분화된 에러 코드 체계로 개선하였습니다.

**기존 에러 코드 체계 문제점**

- 에러 코드가 전역적으로 8개만 정의되어 있어, 구체적인 에러 원인을 파악하기 어려웠습니다.
- 각 API에서 발생하는 예외가 5~10가지인데, 이를 명확하게 구분하지 못했습니다.

**이전 에러 코드**

<img width="765" alt="스크린샷 2024-08-07 16 03 16" src="https://github.com/user-attachments/assets/527b9525-0f4a-4942-967b-d7989c236e50">

**변경된 API 문서 예시: 지출 내역 추가 API** 

<img width="748" alt="스크린샷 2024-08-07 16 22 02" src="https://github.com/user-attachments/assets/002cb87f-915b-43fa-82af-1b0c78285d75">

**수정한 에러 코드**

추가로 발생할 수 있는 모든 에러 코드를 노션 데이터베이스에 저장했습니다. 이제 `웨디`는 에러 코드와 메시지를 한 곳에서 볼 수 있습니다. 

<img width="1103" alt="스크린샷 2024-08-07 15 59 43" src="https://github.com/user-attachments/assets/d08d4f0a-248b-4678-bad4-10c80afe87f7">

### 고민한 내용

**변경사항 요약**

이번 PR에서는 DTO와 도메인에서 발생하는 예외 상황을 보다 구체적으로 전달하기 위해 에러 코드 체계를 개선하였습니다. 이를 통해 프론트 크루 웨디가 예외 상황을 더 명확하게 이해할 수 있도록 하였습니다.

**기존 코드 문제점**

- DTO와 도메인 두 곳에서 검증을 수행하고 있습니다.
  - DTO에서는 @NotBlank를 사용하여 공백과 널 검증을 수행합니다.
  - 도메인에서는 정책 관련 검증을 수행합니다.
- 도메인에서 발생한 예외는 에러 코드와 메시지를 자유롭게 수정할 수 있지만, DTO에서 발생하는 예외는 에러 코드를 전달하기 어렵습니다.
- DTO의 널과 공백 검증을 위해 커스텀 Validator를 만들 수 있지만, 이를 구현하는 데 많은 공수가 듭니다.


```java

// BillAction.java
private void validateTitle(String title) {
    int titleLength = title.trim().length();
    if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
        throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_TITLE_INVALID);
    }
}

// HaengdongErrorCode.java

... 

BILL_ACTION_TITLE_INVALID(String.format("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다.",
        BillAction.MIN_TITLE_LENGTH,
        BillAction.MAX_TITLE_LENGTH
```

**변경사항 요약**

이번 PR에서는 DTO 검증에서 발생하는 예외를 효율적으로 처리하기 위해 에러 코드 체계를 개선하였습니다. 기존의 어노테이션 기반 검증에서 발생하는 한계를 고려하여, 널과 공백 검증을 일관되게 처리하는 방식을 도입하였습니다.

**기존 문제점**

- DTO에서 발생하는 예외는 에러 코드를 전달하기 어렵습니다.
- 어노테이션 내에 메시지 설정은 가능하지만, Validation이 발생하는 에러까지 조작하기 위해 커스텀 Validator를 만드는 것은 공수가 많이 듭니다.

**결정사항**

- DTO에서 수행하는 널과 공백 검증은 REQUEST_EMPTY 에러 코드로 일괄 처리하기로 하였습니다.
