### PR TITLE
[FE] 지출 액션 수정, 삭제 기능 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",
-        "haengdong-design": "^0.1.58",
+        "haengdong-design": "^0.1.60",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.1"
@@ -6448,9 +6448,9 @@
       "dev": true
     },
     "node_modules/haengdong-design": {
-      "version": "0.1.58",
-      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.58.tgz",
-      "integrity": "sha512-eXpjBpFJKwrVjEN6m7GMAQ0qzbc/mgN6/A76Y/Q1oKRMuS48m/EjIqp886AgdoqEz7CwDUtJcDEcf239KYk5JA==",
+      "version": "0.1.60",
+      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.60.tgz",
+      "integrity": "sha512-XZ8Dtsg9s3WAiQ3XCGNbSjMUOkH0yw1HYvjkmp/BgwErMhwVOH5QlpM9O7jsiSf9p08foS+K2w9Xqtg2pMWZFg==",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",

--- a/client/package.json
+++ b/client/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
-    "haengdong-design": "^0.1.58",
+    "haengdong-design": "^0.1.60",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1"

--- a/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.style.ts
+++ b/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.style.ts
@@ -6,7 +6,7 @@ export const bottomSheetStyle = css({
   gap: '1.5rem',
   width: '100%',
   height: '100%',
-  padding: '0 1.5rem',
+  padding: '0 1rem',
 });
 
 export const bottomSheetHeaderStyle = css({
@@ -15,6 +15,7 @@ export const bottomSheetHeaderStyle = css({
   alignContent: 'center',
 
   width: '100%',
+  padding: '0 0.5rem',
 });
 
 export const inputGroupStyle = css({

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -36,7 +36,7 @@ const PutAndDeleteBillActionModal = ({
           <LabelGroupInput labelText="지출내역 / 금액" errorText={errorMessage}>
             <LabelGroupInput.Element
               aria-label="지출 내역"
-              elementKey={'0'}
+              elementKey={'title'}
               type="text"
               value={inputPair.title}
               onChange={event => handleInputChange('title', event)}
@@ -46,7 +46,7 @@ const PutAndDeleteBillActionModal = ({
             />
             <LabelGroupInput.Element
               aria-label="금액"
-              elementKey={'0'}
+              elementKey={'price'}
               type="number"
               value={inputPair.price}
               onChange={event => handleInputChange('price', event)}

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -20,8 +20,10 @@ const PutAndDeleteBillActionModal = ({
   setIsBottomSheetOpened,
 }: PutAndDeleteBillActionModalProps) => {
   const {inputPair, handleInputChange, handleOnBlur, errorMessage, errorInfo, canSubmit, onSubmit, onDelete} =
-    usePutAndDeleteBillAction({title: billAction.name, price: billAction.price + '', index: 0}, validatePurchase, () =>
-      setIsBottomSheetOpened(false),
+    usePutAndDeleteBillAction(
+      {title: billAction.name, price: String(billAction.price), index: 0},
+      validatePurchase,
+      () => setIsBottomSheetOpened(false),
     );
 
   return (

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -2,8 +2,9 @@ import type {BillAction} from 'types/serviceType';
 
 import {BottomSheet, FixedButton, LabelGroupInput, Text} from 'haengdong-design';
 
-import usePutBillAction from '@hooks/usePutBillAction/usePutBillAction';
 import validatePurchase from '@utils/validate/validatePurchase';
+
+import {usePutAndDeleteBillAction} from '@hooks/usePutAndDeleteBillAction';
 
 import {bottomSheetHeaderStyle, bottomSheetStyle, inputContainerStyle} from './PutAndDeltetBillActionModal.style';
 
@@ -18,11 +19,10 @@ const PutAndDeleteBillActionModal = ({
   isBottomSheetOpened,
   setIsBottomSheetOpened,
 }: PutAndDeleteBillActionModalProps) => {
-  const {inputPair, handleInputChange, handleOnBlur, errorMessage, errorInfo, canSubmit, onSubmit} = usePutBillAction(
-    {title: billAction.name, price: billAction.price + '', index: 0},
-    validatePurchase,
-    () => setIsBottomSheetOpened(false),
-  );
+  const {inputPair, handleInputChange, handleOnBlur, errorMessage, errorInfo, canSubmit, onSubmit, onDelete} =
+    usePutAndDeleteBillAction({title: billAction.name, price: billAction.price + '', index: 0}, validatePurchase, () =>
+      setIsBottomSheetOpened(false),
+    );
 
   return (
     <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
@@ -54,7 +54,12 @@ const PutAndDeleteBillActionModal = ({
             />
           </LabelGroupInput>
         </fieldset>
-        <FixedButton variants="primary" disabled={!canSubmit}>
+        <FixedButton
+          type="submit"
+          variants="primary"
+          disabled={!canSubmit}
+          onDeleteClick={() => onDelete(billAction.actionId)}
+        >
           수정 완료
         </FixedButton>
       </form>

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -1,0 +1,65 @@
+import type {BillAction} from 'types/serviceType';
+
+import {BottomSheet, FixedButton, LabelGroupInput, Text} from 'haengdong-design';
+
+import usePutBillAction from '@hooks/usePutBillAction/usePutBillAction';
+import validatePurchase from '@utils/validate/validatePurchase';
+
+import {bottomSheetHeaderStyle, bottomSheetStyle, inputContainerStyle} from './PutAndDeltetBillActionModal.style';
+
+type PutAndDeleteBillActionModalProps = {
+  billAction: BillAction;
+  isBottomSheetOpened: boolean;
+  setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const PutAndDeleteBillActionModal = ({
+  billAction,
+  isBottomSheetOpened,
+  setIsBottomSheetOpened,
+}: PutAndDeleteBillActionModalProps) => {
+  const {inputPair, handleInputChange, handleOnBlur, errorMessage, errorInfo, canSubmit, onSubmit} = usePutBillAction(
+    {title: billAction.name, price: billAction.price + '', index: 0},
+    validatePurchase,
+    () => setIsBottomSheetOpened(false),
+  );
+
+  return (
+    <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
+      <form css={bottomSheetStyle} onSubmit={event => onSubmit(event, inputPair, billAction.actionId)}>
+        <header css={bottomSheetHeaderStyle}>
+          <Text size="bodyBold">지출 내역 수정하기</Text>
+        </header>
+        <fieldset css={inputContainerStyle}>
+          <LabelGroupInput labelText="지출내역 / 금액" errorText={errorMessage}>
+            <LabelGroupInput.Element
+              aria-label="지출 내역"
+              elementKey={'0'}
+              type="text"
+              value={inputPair.title}
+              onChange={event => handleInputChange('title', event)}
+              onBlur={handleOnBlur}
+              isError={errorInfo.title}
+              placeholder="지출 내역"
+            />
+            <LabelGroupInput.Element
+              aria-label="금액"
+              elementKey={'0'}
+              type="number"
+              value={inputPair.price}
+              onChange={event => handleInputChange('price', event)}
+              onBlur={handleOnBlur}
+              isError={errorInfo.price}
+              placeholder="금액"
+            />
+          </LabelGroupInput>
+        </fieldset>
+        <FixedButton variants="primary" disabled={!canSubmit}>
+          수정 완료
+        </FixedButton>
+      </form>
+    </BottomSheet>
+  );
+};
+
+export default PutAndDeleteBillActionModal;

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -29,9 +29,9 @@ const PutAndDeleteBillActionModal = ({
   return (
     <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
       <form css={bottomSheetStyle} onSubmit={event => onSubmit(event, inputPair, billAction.actionId)}>
-        <header css={bottomSheetHeaderStyle}>
+        <h2 css={bottomSheetHeaderStyle}>
           <Text size="bodyBold">지출 내역 수정하기</Text>
-        </header>
+        </h2>
         <fieldset css={inputContainerStyle}>
           <LabelGroupInput labelText="지출내역 / 금액" errorText={errorMessage}>
             <LabelGroupInput.Element

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeltetBillActionModal.style.ts
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeltetBillActionModal.style.ts
@@ -6,7 +6,7 @@ export const bottomSheetStyle = css({
   gap: '1.5rem',
   width: '100%',
   height: '100%',
-  padding: '0 1.5rem',
+  padding: '0 1rem',
 });
 
 export const bottomSheetHeaderStyle = css({
@@ -15,6 +15,7 @@ export const bottomSheetHeaderStyle = css({
   alignContent: 'center',
 
   width: '100%',
+  padding: '0 0.5rem',
 });
 
 export const inputContainerStyle = css({

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeltetBillActionModal.style.ts
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeltetBillActionModal.style.ts
@@ -1,0 +1,27 @@
+import {css} from '@emotion/react';
+
+export const bottomSheetStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  width: '100%',
+  height: '100%',
+  padding: '0 1.5rem',
+});
+
+export const bottomSheetHeaderStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignContent: 'center',
+
+  width: '100%',
+});
+
+export const inputContainerStyle = css({
+  display: 'flex',
+  height: '100%',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  overflow: 'auto',
+  paddingBottom: '14rem',
+});

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/index.ts
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/index.ts
@@ -1,0 +1,1 @@
+export {default as PutAndDeleteBillActionModal} from './PutAndDeleteBillActionModal';

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -1,6 +1,9 @@
 import type {BillStep} from 'types/serviceType';
 
 import {DragHandleItem, DragHandleItemContainer} from 'haengdong-design';
+import {Fragment, useState} from 'react';
+
+import {PutAndDeleteBillActionModal} from '@components/Modal/SetActionModal/PutAndDeleteBillActionModal';
 
 interface BillStepItemProps {
   step: BillStep;
@@ -9,7 +12,13 @@ interface BillStepItemProps {
 }
 
 const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, setOpenBottomSheet}) => {
+  const [clickedIndex, setClickedIndex] = useState(-1);
   const totalPrice = step.actions.reduce((acc, cur) => acc + cur.price, 0);
+
+  const handleDragHandleItemClick = (index: number) => {
+    setClickedIndex(index);
+    setOpenBottomSheet(true);
+  };
 
   return (
     <DragHandleItemContainer
@@ -19,13 +28,23 @@ const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, set
       bottomRightText={`${totalPrice.toLocaleString('ko-kr')} 원`}
       backgroundColor="white"
     >
-      {step.actions.map(action => (
-        <DragHandleItem
-          hasDragHandler={true}
-          prefix={action.name}
-          suffix={`${action.price.toLocaleString('ko-kr')} 원`}
-          backgroundColor="lightGrayContainer"
-        />
+      {step.actions.map((action, index) => (
+        <Fragment key={action.actionId}>
+          <DragHandleItem
+            hasDragHandler={true}
+            prefix={action.name}
+            suffix={`${action.price.toLocaleString('ko-kr')} 원`}
+            backgroundColor="lightGrayContainer"
+            onClick={() => handleDragHandleItemClick(index)}
+          />
+          {isOpenBottomSheet && clickedIndex === index && (
+            <PutAndDeleteBillActionModal
+              billAction={action}
+              isBottomSheetOpened={isOpenBottomSheet}
+              setIsBottomSheetOpened={setOpenBottomSheet}
+            />
+          )}
+        </Fragment>
       ))}
     </DragHandleItemContainer>
   );

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -3,6 +3,7 @@ const ERROR_MESSAGE = {
   memberName: '참여자 이름은 8자 이하의 한글, 영어만 가능해요',
   purchasePrice: '10,000,000원 이하의 숫자만 입력이 가능해요',
   purchaseTitle: '지출 이름은 30자 이하의 한글, 영어, 숫자만 가능해요',
+  preventEmpty: '값은 비어있을 수 없어요',
 };
 
 export default ERROR_MESSAGE;

--- a/client/src/hooks/useDynamicBillActionInput.tsx
+++ b/client/src/hooks/useDynamicBillActionInput.tsx
@@ -3,12 +3,12 @@ import {useEffect, useRef, useState} from 'react';
 import {ValidateResult} from '@utils/validate/type';
 import {Bill} from 'types/serviceType';
 
-type InputPair = Omit<Bill, 'price'> & {
+export type InputPair = Omit<Bill, 'price'> & {
   price: string;
   index: number;
 };
 
-type BillInputType = 'title' | 'price';
+export type BillInputType = 'title' | 'price';
 
 // TODO: (@weadie) 지나치게 도메인에 묶여있는 인풋. 절대 다른 페어인풋으로 재사용할 수 없다.
 const useDynamicBillActionInput = (validateFunc: (inputPair: Bill) => ValidateResult) => {
@@ -32,8 +32,6 @@ const useDynamicBillActionInput = (validateFunc: (inputPair: Bill) => ValidateRe
       price: 0, // price가 input에서 0을 초기값으로 갖지않도록 타입을 수정했기 때문에 0을 명시적으로 넘겨줍니다.
       [field]: value,
     });
-
-    const {title, price} = targetInputPair;
 
     // TODO: (@weadie) 가독성이 안좋다는 리뷰. 함수로 분리
     if (isLastInputPairFilled({index, field, value})) {

--- a/client/src/hooks/usePutAndDeleteBillAction/index.ts
+++ b/client/src/hooks/usePutAndDeleteBillAction/index.ts
@@ -1,0 +1,1 @@
+export {default as usePutAndDeleteBillAction} from './usePutAndDeleteBillAction';

--- a/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
+++ b/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
@@ -9,6 +9,8 @@ import {useStepList} from '@hooks/useStepList/useStepList';
 
 import {BillInputType, InputPair} from '@hooks/useDynamicBillActionInput';
 
+import ERROR_MESSAGE from '@constants/errorMessage';
+
 const usePutAndDeleteBillAction = (
   initialValue: InputPair,
   validateFunc: (inputPair: Bill) => ValidateResult,
@@ -66,7 +68,7 @@ const usePutAndDeleteBillAction = (
 
     // blur시 값이 비었을 때 error state 반영
     if (inputPair.price.length === 0 || inputPair.title.length === 0) {
-      setErrorMessage('값은 비어있을 수 없어요');
+      setErrorMessage(ERROR_MESSAGE.preventEmpty);
       setErrorInfo({title: inputPair.title.length === 0, price: inputPair.price.length === 0});
       setCanSubmit(false);
       return;

--- a/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
+++ b/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
@@ -3,13 +3,13 @@ import type {Bill} from 'types/serviceType';
 import {useState} from 'react';
 
 import {ValidateResult} from '@utils/validate/type';
-import {requestPutBillAction} from '@apis/request/bill';
+import {requestDeleteBillAction, requestPutBillAction} from '@apis/request/bill';
 import useEventId from '@hooks/useEventId/useEventId';
 import {useStepList} from '@hooks/useStepList/useStepList';
 
 import {BillInputType, InputPair} from '@hooks/useDynamicBillActionInput';
 
-const usePutBillAction = (
+const usePutAndDeleteBillAction = (
   initialValue: InputPair,
   validateFunc: (inputPair: Bill) => ValidateResult,
   onClose: () => void,
@@ -87,15 +87,21 @@ const usePutBillAction = (
     onClose();
   };
 
+  const onDelete = async (actionId: number) => {
+    await requestDeleteBillAction({eventId, actionId});
+    refreshStepList();
+  };
+
   return {
     inputPair,
     handleInputChange,
     handleOnBlur,
     onSubmit,
+    onDelete,
     canSubmit,
     errorMessage,
     errorInfo,
   };
 };
 
-export default usePutBillAction;
+export default usePutAndDeleteBillAction;

--- a/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
+++ b/client/src/hooks/usePutAndDeleteBillAction/usePutAndDeleteBillAction.ts
@@ -90,6 +90,7 @@ const usePutAndDeleteBillAction = (
   const onDelete = async (actionId: number) => {
     await requestDeleteBillAction({eventId, actionId});
     refreshStepList();
+    onClose();
   };
 
   return {

--- a/client/src/hooks/usePutBillAction/usePutBillAction.ts
+++ b/client/src/hooks/usePutBillAction/usePutBillAction.ts
@@ -1,0 +1,101 @@
+import type {Bill} from 'types/serviceType';
+
+import {useState} from 'react';
+
+import {ValidateResult} from '@utils/validate/type';
+import {requestPutBillAction} from '@apis/request/bill';
+import useEventId from '@hooks/useEventId/useEventId';
+import {useStepList} from '@hooks/useStepList/useStepList';
+
+import {BillInputType, InputPair} from '@hooks/useDynamicBillActionInput';
+
+const usePutBillAction = (
+  initialValue: InputPair,
+  validateFunc: (inputPair: Bill) => ValidateResult,
+  onClose: () => void,
+) => {
+  const {eventId} = useEventId();
+  const {refreshStepList} = useStepList();
+
+  const [inputPair, setInputPair] = useState<InputPair>(initialValue);
+  const [canSubmit, setCanSubmit] = useState(false);
+  const [errorInfo, setErrorInfo] = useState<Record<string, boolean>>({title: false, price: false});
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const handleInputChange = (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target;
+
+    // 현재 타겟의 event.target.value를 넣어주기 위해서
+    const getFieldValue = (): Bill => {
+      if (field === 'title') {
+        return {title: value, price: Number(inputPair.price)};
+      } else {
+        return {title: inputPair.title, price: Number(value)};
+      }
+    };
+
+    const {isValid, errorMessage, errorInfo} = validateFunc(getFieldValue());
+
+    if (isValid) {
+      // valid일 경우 에러메시지 nope, setValue, submit은 value가 비지 않았을 때 true를 설정
+      setErrorMessage(undefined);
+      setInputPair(prevInputPair => {
+        return {
+          ...prevInputPair,
+          [field]: value,
+        };
+      });
+      setCanSubmit(value.length !== 0);
+    } else {
+      // valid하지 않으면 event.target.value 덮어쓰기
+      event.target.value = inputPair[field];
+      setErrorMessage(errorMessage);
+      setCanSubmit(false);
+    }
+
+    if (field === 'title') {
+      // 현재 field가 title일 때는 title의 errorInfo만 반영해줌 (blur에서도 errorInfo를 조작하기 때문)
+      setErrorInfo(prev => ({title: errorInfo?.title ?? false, price: prev.price}));
+    } else {
+      setErrorInfo(prev => ({title: prev.title, price: errorInfo?.price ?? false}));
+    }
+  };
+
+  const handleOnBlur = () => {
+    const {isValid, errorMessage, errorInfo} = validateFunc({title: inputPair.title, price: Number(inputPair.price)});
+
+    // blur시 값이 비었을 때 error state 반영
+    if (inputPair.price.length === 0 || inputPair.title.length === 0) {
+      setErrorMessage('값은 비어있을 수 없어요');
+      setErrorInfo({title: inputPair.title.length === 0, price: inputPair.price.length === 0});
+      setCanSubmit(false);
+      return;
+    }
+
+    // 이외 blur시에 추가로 검증함
+    setErrorMessage(errorMessage);
+    setCanSubmit(isValid);
+    setErrorInfo(errorInfo ?? {title: false, price: false});
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>, inputPair: InputPair, actionId: number) => {
+    event.preventDefault();
+
+    const {title, price} = inputPair;
+    await requestPutBillAction({eventId, actionId, title, price: Number(price)});
+    refreshStepList();
+    onClose();
+  };
+
+  return {
+    inputPair,
+    handleInputChange,
+    handleOnBlur,
+    onSubmit,
+    canSubmit,
+    errorMessage,
+    errorInfo,
+  };
+};
+
+export default usePutBillAction;

--- a/client/src/utils/validate/type.ts
+++ b/client/src/utils/validate/type.ts
@@ -1,4 +1,5 @@
 export interface ValidateResult {
   isValid: boolean;
   errorMessage?: string;
+  errorInfo?: Record<string, boolean>;
 }

--- a/client/src/utils/validate/validatePurchase.ts
+++ b/client/src/utils/validate/validatePurchase.ts
@@ -10,27 +10,38 @@ const validatePurchase = (inputPair: Bill): ValidateResult => {
   const {title, price} = inputPair;
   let errorMessage;
 
+  const errorInfo = {
+    price: false,
+    title: false,
+  };
+
   const validatePrice = () => {
     if (price > RULE.maxPrice) {
       errorMessage = ERROR_MESSAGE.purchasePrice;
+      errorInfo.price = true;
       return false;
     }
+
+    errorInfo.price = false;
     return true;
   };
 
   const validateTitle = () => {
-    if (REGEXP.purchaseTitle.test(title)) {
+    if (!REGEXP.purchaseTitle.test(title)) {
       errorMessage = ERROR_MESSAGE.purchaseTitle;
+      errorInfo.title = true;
       return false;
     }
+
+    errorInfo.title = false;
     return true;
   };
 
   if (validatePrice() && validateTitle()) {
-    return {isValid: true};
+    return {isValid: true, errorMessage: ''};
   }
 
-  return {isValid: true, errorMessage: ''};
+  return {isValid: false, errorMessage, errorInfo};
 };
 
 export default validatePurchase;


### PR DESCRIPTION
## issue
- close #175 

## 구현 사항
- 지출 액션 수정과 삭제를 구현했습니다.

### 지출 액션 수정
지출 수정을 위해 액션을 클릭 시에 바텀 시트가 올라오면서 들어옵니다.
이 때 수정을 하지 않았으면 바텀 시트의 버튼은 비활성화로 유지됩니다.
![image](https://github.com/user-attachments/assets/68a005f4-03b5-4d8a-983a-3011a8f4d632)

검증 조건에 맞지 않는 경우 아래 사진과 같이 에러 메시지와 input 테두리에 에러 표시를 보여줍니다.
![image](https://github.com/user-attachments/assets/47fc82cb-46ef-48d9-878b-f04e5e4f2096)

100,000,000을 적을 경우 10,000,000 이하로 입력하세요라는 에러가 나온다. 하지만 에러일 때는 값을 덮어쓰므로 값은 10,000,000이 되고 여기서 10,000,000은 정상적인 입력이기 때문에 에러가 아니라고 표시를 해주어야 하기 때문에 blur시에 다시 검증을 합니다.

![image](https://github.com/user-attachments/assets/d80725e8-88ce-47ab-9473-9fe30cd5c1b2)

값이 비워질 경우 에러이기 때문에 비워지는 순간 submit 버튼을 비활성화합니다
![image](https://github.com/user-attachments/assets/245e7afd-a701-4cdb-8165-33022ee340b2)

그리고 blur시에 에러를 활성화시키며 값은 비어있을 수 없다는 에러를 보여줍니다.
![image](https://github.com/user-attachments/assets/53950d5d-ba45-4bbb-8481-964679dad029)

수정완료를 누르면 수정 api가 호출됩니다. 하지만 dev서버가 지금 말썽이라 테스트는 할 수 없는 상황..;; 뭐 되겠지?

삭제도 마찬가지 삭제도 누르면 삭제 api가 호출되지만 뭐 되겠지?



## 🫡 참고사항
validateResult에 errorInfo를 추가해줬습니다. 각 인풋 창에 아래 사진과 같이 에러 상태를 보여주어야 하기 때문입니다.
![image](https://github.com/user-attachments/assets/838cac7b-fe46-4b3c-bff4-82fe61c82d05)
```ts
export interface ValidateResult {
  isValid: boolean;
  errorMessage?: string;
  errorInfo?: Record<string, boolean>;
}

const errorInfo = {
    price: false,
    title: false,
  };
```