### PR TITLE
[FE] FixedButton의 delete button type "button"으로 변경

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.58",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.58",
+      "version": "0.1.60",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.58",
+  "version": "0.1.60",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/FixedButton/FixedButton.tsx
+++ b/HDesign/src/components/FixedButton/FixedButton.tsx
@@ -4,12 +4,11 @@ import {forwardRef} from 'react';
 import {
   fixedButtonContainerStyle,
   fixedButtonStyle,
-  deleteButtonStyle,
   buttonContainerStyle,
 } from '@components/FixedButton/FixedButton.style';
 import {FixedButtonProps} from '@components/FixedButton/FixedButton.type';
-
-import Trash from '@assets/trash.svg';
+import IconButton from '@components/IconButton/IconButton';
+import Icon from '@components/Icon/Icon';
 
 import {useTheme} from '@theme/HDesignProvider';
 
@@ -22,9 +21,9 @@ export const FixedButton: React.FC<FixedButtonProps> = forwardRef<HTMLButtonElem
     <div css={fixedButtonContainerStyle(theme)}>
       <div css={buttonContainerStyle}>
         {onDeleteClick && (
-          <button type="button" css={deleteButtonStyle(theme)} onClick={onDeleteClick}>
-            <Trash />
-          </button>
+          <IconButton type="button" size="large" variants="destructive" onClick={onDeleteClick}>
+            <Icon iconType="trash" />
+          </IconButton>
         )}
         <button css={fixedButtonStyle({variants, theme})} ref={ref} {...htmlProps} />
       </div>

--- a/HDesign/src/components/FixedButton/FixedButton.tsx
+++ b/HDesign/src/components/FixedButton/FixedButton.tsx
@@ -8,8 +8,6 @@ import {
   buttonContainerStyle,
 } from '@components/FixedButton/FixedButton.style';
 import {FixedButtonProps} from '@components/FixedButton/FixedButton.type';
-import IconButton from '@components/IconButton/IconButton';
-import Icon from '@components/Icon/Icon';
 
 import Trash from '@assets/trash.svg';
 
@@ -24,9 +22,9 @@ export const FixedButton: React.FC<FixedButtonProps> = forwardRef<HTMLButtonElem
     <div css={fixedButtonContainerStyle(theme)}>
       <div css={buttonContainerStyle}>
         {onDeleteClick && (
-          <IconButton size="large" variants="destructive" onClick={onDeleteClick}>
-            <Icon iconType="trash" />
-          </IconButton>
+          <button type="button" css={deleteButtonStyle(theme)} onClick={onDeleteClick}>
+            <Trash />
+          </button>
         )}
         <button css={fixedButtonStyle({variants, theme})} ref={ref} {...htmlProps} />
       </div>

--- a/HDesign/src/components/IconButton/IconButton.style.ts
+++ b/HDesign/src/components/IconButton/IconButton.style.ts
@@ -57,8 +57,8 @@ const getIconButtonSize = (size: IconButtonSize) => {
       borderRadius: '1rem',
     }),
     large: css({
-      padding: '1rem',
-      borderRadius: '1.25rem',
+      padding: '0.875rem',
+      borderRadius: '1.125rem',
     }),
   };
 


### PR DESCRIPTION
## issue
- close #229 

## 구현 사항
### 구현 목적
```tsx
      <form css={bottomSheetStyle} onSubmit={event => onSubmit(event, inputPair, billAction.actionId)}>
        <header css={bottomSheetHeaderStyle}>
          <Text size="bodyBold">지출 내역 수정하기</Text>
        </header>
        <fieldset css={inputContainerStyle}>
          <LabelGroupInput labelText="지출내역 / 금액" errorText={errorMessage}>
            <LabelGroupInput.Element
              aria-label="지출 내역"
              elementKey={'0'}
              type="text"
              value={inputPair.title}
              onChange={event => handleInputChange('title', event)}
              onBlur={handleOnBlur}
              isError={errorInfo.title}
              placeholder="지출 내역"
            />
            <LabelGroupInput.Element
              aria-label="금액"
              elementKey={'0'}
              type="number"
              value={inputPair.price}
              onChange={event => handleInputChange('price', event)}
              onBlur={handleOnBlur}
              isError={errorInfo.price}
              placeholder="금액"
            />
          </LabelGroupInput>
        </fieldset>
        <FixedButton
          type="submit"
          variants="primary"
          disabled={!canSubmit}
          onDeleteClick={() => onDelete(billAction.actionId)}
        >
          수정 완료
        </FixedButton>
      </form>
```
기존 코드의 다양한 부분에서 value를 `form`을 통해서 넘겨주고 있음
하지만, FixedButton 내부에 2개의 버튼이 있는데, 두 버튼 모두 `submit` type의 버튼이기 때문에, 둘 다 form을 submit 시킴

### 구현 내용
```tsx
export const FixedButton: React.FC<FixedButtonProps> = forwardRef<HTMLButtonElement, FixedButtonProps>(function Button(
  {variants = 'primary', onDeleteClick, ...htmlProps}: FixedButtonProps,
  ref,
) {
  const {theme} = useTheme();
  return (
    <div css={fixedButtonContainerStyle(theme)}>
      <div css={buttonContainerStyle}>
        {onDeleteClick && (
          <button type="button" css={deleteButtonStyle(theme)} onClick={onDeleteClick}>
            <Trash />
          </button>
        )}
        <button css={fixedButtonStyle({variants, theme})} ref={ref} {...htmlProps} />
      </div>
    </div>
  );
});
```
delete Button에 type="button"을 추가하여, submit으로 사용할 수 없도록 변경하였습니다.

## 참고사항

 @jinhokim98  v0.1.60 npm publish 완료했습니다 