### PR TITLE
[BE] CORS, 쿠키 인증오류 수정

### DIFF
--- a/server/src/main/java/server/haengdong/config/AdminInterceptor.java
+++ b/server/src/main/java/server/haengdong/config/AdminInterceptor.java
@@ -3,6 +3,7 @@ package server.haengdong.config;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import server.haengdong.application.AuthService;
 import server.haengdong.exception.AuthenticationException;
@@ -23,8 +24,8 @@ public class AdminInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         log.trace("login request = {}", request.getRequestURI());
 
-        String method = request.getMethod();
-        if (method.equals("GET")) {
+        HttpMethod method = HttpMethod.valueOf(request.getMethod());
+        if (HttpMethod.GET.equals(method) || HttpMethod.OPTIONS.equals(method)) {
             return true;
         }
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ security:
       expire-length: 604800 # 1주일
 
 cookie:
-  http-only: true
+  http-only: false
   secure: false
   path: /
   max-age: 7D


### PR DESCRIPTION
## issue
- close #233 

## 구현 사항

CORS는 HttpMethod Options로 Preflight 요청을 보냅니다.
백엔드 서버에서 쿠키가 없는 상태에서는 Get만 가능하게 막아두어 CORS 인증에 실패하는 버그가 있었습니다.
