### PR TITLE
[BE] REST docs를 통한 문서화

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -47,15 +47,12 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}
-
 ext {
     snippetsDir = file('build/generated-snippets')
 }
 
-test {
+tasks.named('test') {
+    useJUnitPlatform()
     outputs.dir snippetsDir
 }
 
@@ -63,11 +60,22 @@ asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
+    baseDirFollowsSourceFile()
+}
+
+tasks.register('copyApiDocuments', Copy) {
+    doFirst {
+        delete file('src/main/resources/static/docs')
+    }
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
 }
 
 bootJar {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
-        into 'static/docs'
-    }
+    dependsOn copyApiDocuments
+}
+
+build {
+    dependsOn copyApiDocuments
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'server'
@@ -17,6 +18,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -40,8 +42,32 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }

--- a/server/src/docs/asciidoc/billAction.adoc
+++ b/server/src/docs/asciidoc/billAction.adoc
@@ -4,10 +4,118 @@
 
 operation::createBillActions[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"지출 금액은 비어 있으면 안됩니다."
+   },
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"지출 내역은 비어 있으면 안됩니다."
+   },
+   {
+      "code":"BILL_ACTION_TITLE_INVALID",
+      "message":"앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다."
+   },
+   {
+      "code":"BILL_ACTION_PRICE_INVALID",
+      "message":"지출 금액은 10,000,000 이하의 자연수여야 합니다."
+   },
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----
+
 === 지출 액션 수정
 
 operation::updateBillAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"지출 내역 제목은 공백일 수 없습니다."
+   },
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"지출 금액은 공백일 수 없습니다."
+   },
+   {
+      "code":"BILL_ACTION_TITLE_INVALID",
+      "message":"앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다."
+   },
+   {
+      "code":"BILL_ACTION_PRICE_INVALID",
+      "message":"지출 금액은 %,d 이하의 자연수여야 합니다."
+   },
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"BILL_ACTION_NOT_FOUND",
+      "message":"존재하지 않는 지출 액션입니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----
+
 === 지출 액션 삭제
 
 operation::deleteBillAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----

--- a/server/src/docs/asciidoc/billAction.adoc
+++ b/server/src/docs/asciidoc/billAction.adoc
@@ -1,0 +1,13 @@
+== 지출 액션
+
+=== 지출 액션 생성
+
+operation::createBillActions[]
+
+=== 지출 액션 수정
+
+operation::updateBillAction[]
+
+=== 지출 액션 삭제
+
+operation::deleteBillAction[]

--- a/server/src/docs/asciidoc/billAction.adoc
+++ b/server/src/docs/asciidoc/billAction.adoc
@@ -2,7 +2,7 @@
 
 === 지출 액션 생성
 
-operation::createBillActions[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
+operation::createBillActions[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]
 
 ==== [.red]#Exceptions#
 
@@ -46,7 +46,7 @@ operation::createBillActions[snippets="path-parameters,http-request,request-body
 
 === 지출 액션 수정
 
-operation::updateBillAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
+operation::updateBillAction[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]
 
 ==== [.red]#Exceptions#
 
@@ -94,7 +94,7 @@ operation::updateBillAction[snippets="path-parameters,http-request,request-body,
 
 === 지출 액션 삭제
 
-operation::deleteBillAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
+operation::deleteBillAction[snippets="path-parameters,http-request,http-response,request-cookies"]
 
 ==== [.red]#Exceptions#
 

--- a/server/src/docs/asciidoc/billAction.adoc
+++ b/server/src/docs/asciidoc/billAction.adoc
@@ -2,12 +2,12 @@
 
 === 지출 액션 생성
 
-operation::createBillActions[]
+operation::createBillActions[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
 === 지출 액션 수정
 
-operation::updateBillAction[]
+operation::updateBillAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
 === 지출 액션 삭제
 
-operation::deleteBillAction[]
+operation::deleteBillAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]

--- a/server/src/docs/asciidoc/event.adoc
+++ b/server/src/docs/asciidoc/event.adoc
@@ -3,50 +3,146 @@
 === 행사 생성
 
 operation::createEvent[snippets="http-request,request-body,response-body,http-response,request-fields,http-request,response-cookies"]
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"행사 이름은 공백일 수 없습니다."
+   },
+   {
+      "code":"EVENT_NAME_LENGTH_INVALID",
+      "message":"행사 이름은 2자 이상 30자 이하만 입력 가능합니다. 입력한 이름 길이 : 21"
+   },
+   {
+      "code":"EVENT_NAME_MULTIPLE_BLANK",
+      "message":"행사 이름에는 공백 문자가 연속될 수 없습니다. 입력한 이름 : 공백  문자"
+   },
+  {
+      "code":"EVENT_PASSWORD_INVALID",
+      "message":"비밀번호는 4자리 숫자만 가능합니다."
+   }
+]
+----
 
 === 행사 관리자 로그인
 
 operation::eventLogin[snippets="path-parameters,http-request,request-body,http-response,request-fields,http-request,response-cookies"]
+==== [.red]#Exceptions#
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"비밀번호는 공백일 수 없습니다."
+   },
+   {
+      "code":"PASSWORD_INVALID",
+      "message":"비밀번호가 일치하지 않습니다."
+   }
+]
+----
 
 === 행사 정보 조회
 
 operation::getEvent[snippets="path-parameters,http-request,response-body,http-response,http-request"]
 
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   }
+]
+----
+
 === 행사 전체 참여자 목록 조회
 
 operation::findAllEventMember[snippets="path-parameters,http-request,response-body,http-response,http-request"]
 
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   }
+]
+----
+
 === 행사 참여자 이름 변경
 
 operation::updateEventMemberName[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"멤버 이름은 공백일 수 없습니다."
+   },
+   {
+      "code":"MEMBER_NAME_LENGTH_INVALID",
+      "message":"멤버 이름은 1자 이상 4자 이하만 입력 가능합니다."
+   },
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"MEMBER_NAME_DUPLICATE",
+      "message":"중복된 행사 참여 인원 이름이 존재합니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----
 
 === 행사 참여자 삭제 (특정 참여자의 모든 참여자 액션 삭제)
 
 operation::deleteAllMemberActionByName[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
-
 ==== [.red]#Exceptions#
 
-|===
-|Cell in column 1, header row |Cell in column 2, header row
-
-|Cell in column 1, row 2
-|Cell in column 2, row 2
-
-|Cell in column 1, row 3
-|Cell in column 2, row 3
-
-|Cell in column 1, row 4
-|Cell in column 2, row 4
-|===
-
-.+/api/events/{eventId}/bill-actions/{actionId}+
-|===
-|Parameter|Description
-
-|`+eventId+`
-|행사 ID
-
-|`+actionId+`
-|지출 액션 ID
-
-|===
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----

--- a/server/src/docs/asciidoc/event.adoc
+++ b/server/src/docs/asciidoc/event.adoc
@@ -1,0 +1,52 @@
+== 행사
+
+=== 행사 생성
+
+operation::createEvent[]
+
+=== 행사 관리자 로그인
+
+operation::eventLogin[]
+
+=== 행사 정보 조회
+
+operation::getEvent[]
+
+=== 행사 전체 참여자 목록 조회
+
+operation::findAllEventMember[]
+
+=== 행사 참여자 이름 변경
+
+operation::updateEventMemberName[]
+
+=== 행사 참여자 삭제 (특정 참여자의 모든 참여자 액션 삭제)
+
+operation::deleteAllMemberActionByName[]
+
+==== [.red]#Exceptions#
+
+|===
+|Cell in column 1, header row |Cell in column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+
+|Cell in column 1, row 4
+|Cell in column 2, row 4
+|===
+
+.+/api/events/{eventId}/bill-actions/{actionId}+
+|===
+|Parameter|Description
+
+|`+eventId+`
+|행사 ID
+
+|`+actionId+`
+|지출 액션 ID
+
+|===

--- a/server/src/docs/asciidoc/event.adoc
+++ b/server/src/docs/asciidoc/event.adoc
@@ -2,27 +2,27 @@
 
 === 행사 생성
 
-operation::createEvent[]
+operation::createEvent[snippets="http-request,request-body,response-body,http-response,request-fields,http-request,response-cookies"]
 
 === 행사 관리자 로그인
 
-operation::eventLogin[]
+operation::eventLogin[snippets="path-parameters,http-request,request-body,http-response,request-fields,http-request,response-cookies"]
 
 === 행사 정보 조회
 
-operation::getEvent[]
+operation::getEvent[snippets="path-parameters,http-request,response-body,http-response,http-request"]
 
 === 행사 전체 참여자 목록 조회
 
-operation::findAllEventMember[]
+operation::findAllEventMember[snippets="path-parameters,http-request,response-body,http-response,http-request"]
 
 === 행사 참여자 이름 변경
 
-operation::updateEventMemberName[]
+operation::updateEventMemberName[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
 === 행사 참여자 삭제 (특정 참여자의 모든 참여자 액션 삭제)
 
-operation::deleteAllMemberActionByName[]
+operation::deleteAllMemberActionByName[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
 
 ==== [.red]#Exceptions#
 

--- a/server/src/docs/asciidoc/event.adoc
+++ b/server/src/docs/asciidoc/event.adoc
@@ -2,7 +2,7 @@
 
 === 행사 생성
 
-operation::createEvent[snippets="http-request,request-body,response-body,http-response,request-fields,http-request,response-cookies"]
+operation::createEvent[snippets="http-request,request-body,request-fields,response-body,response-fields,http-response,response-cookies"]
 ==== [.red]#Exceptions#
 
 [source,json,options="nowrap"]
@@ -29,8 +29,9 @@ operation::createEvent[snippets="http-request,request-body,response-body,http-re
 
 === 행사 관리자 로그인
 
-operation::eventLogin[snippets="path-parameters,http-request,request-body,http-response,request-fields,http-request,response-cookies"]
+operation::eventLogin[snippets="path-parameters,http-request,request-body,request-fields,http-response,response-cookies"]
 ==== [.red]#Exceptions#
+
 [source,json,options="nowrap"]
 ----
 [
@@ -51,7 +52,7 @@ operation::eventLogin[snippets="path-parameters,http-request,request-body,http-r
 
 === 행사 정보 조회
 
-operation::getEvent[snippets="path-parameters,http-request,response-body,http-response,http-request"]
+operation::getEvent[snippets="path-parameters,http-request,response-body,response-fields,http-response"]
 
 ==== [.red]#Exceptions#
 
@@ -67,7 +68,23 @@ operation::getEvent[snippets="path-parameters,http-request,response-body,http-re
 
 === 행사 전체 참여자 목록 조회
 
-operation::findAllEventMember[snippets="path-parameters,http-request,response-body,http-response,http-request"]
+operation::findAllEventMember[snippets="path-parameters,http-request,response-body,response-fields,http-response,response-fields"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   }
+]
+----
+
+=== 행사 전체 액션 이력 조회
+
+operation::findActions[snippets="path-parameters,http-request,http-response,response-fields"]
 
 ==== [.red]#Exceptions#
 
@@ -83,7 +100,7 @@ operation::findAllEventMember[snippets="path-parameters,http-request,response-bo
 
 === 행사 참여자 이름 변경
 
-operation::updateEventMemberName[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
+operation::updateEventMemberName[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]
 ==== [.red]#Exceptions#
 
 [source,json,options="nowrap"]
@@ -122,7 +139,7 @@ operation::updateEventMemberName[snippets="path-parameters,http-request,request-
 
 === 행사 참여자 삭제 (특정 참여자의 모든 참여자 액션 삭제)
 
-operation::deleteAllMemberActionByName[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
+operation::deleteAllMemberActionByName[snippets="path-parameters,http-request,http-response,request-cookies"]
 ==== [.red]#Exceptions#
 
 [source,json,options="nowrap"]

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -1,0 +1,18 @@
+:source-highlighter: highlightjs
+:hardbreaks:
+:toc: left
+:doctype: book
+:icons: font
+:toc-title: 전체 API 목록
+:toclevels: 2
+:sectlinks:
+:sectnums:
+:sectnumlevels: 2
+
+= 행동대장
+
+include::event.adoc[]
+include::memberBillReport.adoc[]
+include::memberAction.adoc[]
+include::billAction.adoc[]
+

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -11,8 +11,8 @@
 
 = 행동대장
 
-include::event.adoc[]
-include::memberBillReport.adoc[]
-include::memberAction.adoc[]
-include::billAction.adoc[]
+include::{docdir}/event.adoc[]
+include::{docdir}/memberBillReport.adoc[]
+include::{docdir}/memberAction.adoc[]
+include::{docdir}/billAction.adoc[]
 

--- a/server/src/docs/asciidoc/memberAction.adoc
+++ b/server/src/docs/asciidoc/memberAction.adoc
@@ -4,10 +4,96 @@
 
 operation::createMemberAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
-=== 참여자 액션 조회
+==== [.red]#Exceptions#
 
-operation::getMemberAction[snippets="path-parameters,http-request,response-body,http-response,http-request"]
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"REQUEST_EMPTY",
+      "message":"멤버 액션은 공백일 수 없습니다."
+   },
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"MEMBER_ACTION_STATUS_INVALID",
+      "message":"멤버 액션은 IN, OUT만 가능합니다. 입력한 멤버 액션: I_N"
+   },
+   {
+      "code":"MEMBER_ALREADY_EXIST",
+      "message":"현재 참여하고 있는 인원이 존재합니다."
+   },
+   {
+      "code":"MEMBER_NOT_EXIST",
+      "message":"현재 참여하고 있지 않는 인원이 존재합니다."
+   },
+   {
+      "code":"MEMBER_NAME_DUPLICATE",
+      "message":"중복된 이름이 존재합니다. 입력된 이름: 이상, 이상, 감자, 백호"
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----
+
+=== 현재 행사에 참여 중인 (탈주 가능한) 참여자 목록 조회
+
+operation::getCurrentMembers[snippets="path-parameters,http-request,response-body,http-response,http-request"]
+==== [.red]#Exceptions#
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   }
+]
+----
 
 === 참여자 액션 삭제
 
 operation::deleteMemberAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   },
+   {
+      "code":"ACTION_NOT_FOUND",
+      "message":"존재하지 않는 액션입니다."
+   },
+   {
+      "code":"MEMBER_ACTION_NOT_FOUND",
+      "message":"존재하지 않는 멤버 액션입니다."
+   },
+   {
+      "code":"TOKEN_NOT_FOUND",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_EXPIRED",
+      "message":"토큰이 존재하지 않습니다."
+   },
+   {
+      "code":"TOKEN_INVALID",
+      "message":"유효하지 않은 토큰입니다."
+   }
+]
+----

--- a/server/src/docs/asciidoc/memberAction.adoc
+++ b/server/src/docs/asciidoc/memberAction.adoc
@@ -2,7 +2,7 @@
 
 === 참여자 액션 생성
 
-operation::createMemberAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
+operation::createMemberAction[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]
 
 ==== [.red]#Exceptions#
 
@@ -50,8 +50,9 @@ operation::createMemberAction[snippets="path-parameters,http-request,request-bod
 
 === 현재 행사에 참여 중인 (탈주 가능한) 참여자 목록 조회
 
-operation::getCurrentMembers[snippets="path-parameters,http-request,response-body,http-response,http-request"]
+operation::getCurrentMembers[snippets="path-parameters,http-request,http-response,response-fields"]
 ==== [.red]#Exceptions#
+
 [source,json,options="nowrap"]
 ----
 [
@@ -64,7 +65,7 @@ operation::getCurrentMembers[snippets="path-parameters,http-request,response-bod
 
 === 참여자 액션 삭제
 
-operation::deleteMemberAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]
+operation::deleteMemberAction[snippets="path-parameters,http-request,http-response,request-cookies"]
 
 ==== [.red]#Exceptions#
 

--- a/server/src/docs/asciidoc/memberAction.adoc
+++ b/server/src/docs/asciidoc/memberAction.adoc
@@ -2,12 +2,12 @@
 
 === 참여자 액션 생성
 
-operation::createMemberAction[]
+operation::createMemberAction[snippets="path-parameters,http-request,request-body,http-response,request-cookies,request-fields,http-request"]
 
 === 참여자 액션 조회
 
-operation::getMemberAction[]
+operation::getMemberAction[snippets="path-parameters,http-request,response-body,http-response,http-request"]
 
 === 참여자 액션 삭제
 
-operation::deleteMemberAction[]
+operation::deleteMemberAction[snippets="path-parameters,http-request,http-response,request-cookies,http-request"]

--- a/server/src/docs/asciidoc/memberAction.adoc
+++ b/server/src/docs/asciidoc/memberAction.adoc
@@ -1,0 +1,13 @@
+== 참여자 액션
+
+=== 참여자 액션 생성
+
+operation::createMemberAction[]
+
+=== 참여자 액션 조회
+
+operation::getMemberAction[]
+
+=== 참여자 액션 삭제
+
+operation::deleteMemberAction[]

--- a/server/src/docs/asciidoc/memberBillReport.adoc
+++ b/server/src/docs/asciidoc/memberBillReport.adoc
@@ -1,0 +1,17 @@
+== 정산
+
+=== 참여자별 정산 결과 조회
+
+operation::getMemberBillReports[snippets="path-parameters,http-request,response-body,response-fields,http-response,http-request"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+   {
+      "code":"EVENT_NOT_FOUND",
+      "message":"존재하지 않는 행사입니다."
+   }
+]
+----

--- a/server/src/test/java/server/haengdong/docs/ActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/ActionControllerDocsTest.java
@@ -1,0 +1,68 @@
+package server.haengdong.docs;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import server.haengdong.application.ActionService;
+import server.haengdong.application.response.MemberBillReportAppResponse;
+import server.haengdong.presentation.ActionController;
+
+class ActionControllerDocsTest extends RestDocsSupport {
+
+    private final ActionService actionService = mock(ActionService.class);
+
+    @Override
+    protected Object initController() {
+        return new ActionController(actionService);
+    }
+
+    @DisplayName("참여자별 정산 현황을 조회한다.")
+    @Test
+    void getMemberBillReports() throws Exception {
+        List<MemberBillReportAppResponse> memberBillReportAppResponses = List.of(
+                new MemberBillReportAppResponse("소하", 20_000L), new MemberBillReportAppResponse("토다리", 200_000L));
+
+        given(actionService.getMemberBillReports(any())).willReturn(memberBillReportAppResponses);
+
+        mockMvc.perform(get("/api/events/{eventId}/actions/reports", "망쵸토큰")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.reports[0].name").value(equalTo("소하")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.reports[0].price").value(equalTo(20_000)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.reports[1].name").value(equalTo("토다리")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.reports[1].price").value(equalTo(200_000)))
+                .andDo(
+                        document("getMemberBillReports",
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("reports").type(JsonFieldType.ARRAY).description("전체 정산 현황 목록"),
+                                        fieldWithPath("reports[0].name").type(JsonFieldType.STRING)
+                                                .description("참여자 이름"),
+                                        fieldWithPath("reports[0].price").type(JsonFieldType.NUMBER)
+                                                .description("참여자 정산 금액")
+                                ))
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/ActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/ActionControllerDocsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -52,6 +53,7 @@ class ActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.reports[1].price").value(equalTo(200_000)))
                 .andDo(
                         document("getMemberBillReports",
+                                preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")

--- a/server/src/test/java/server/haengdong/docs/BillActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillActionControllerDocsTest.java
@@ -7,6 +7,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -53,6 +56,8 @@ class BillActionControllerDocsTest extends RestDocsSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("createBillActions",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("eventId").description("행사 ID")
                         ),
@@ -82,6 +87,8 @@ class BillActionControllerDocsTest extends RestDocsSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("updateBillAction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("eventId").description("행사 ID"),
                                 parameterWithName("actionId").description("지출 액션 ID")
@@ -107,6 +114,8 @@ class BillActionControllerDocsTest extends RestDocsSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("deleteBillAction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("eventId").description("행사 ID"),
                                 parameterWithName("actionId").description("지출 액션 ID")

--- a/server/src/test/java/server/haengdong/docs/BillActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillActionControllerDocsTest.java
@@ -1,0 +1,119 @@
+package server.haengdong.docs;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import server.haengdong.application.BillActionService;
+import server.haengdong.presentation.BillActionController;
+import server.haengdong.presentation.request.BillActionSaveRequest;
+import server.haengdong.presentation.request.BillActionUpdateRequest;
+import server.haengdong.presentation.request.BillActionsSaveRequest;
+
+class BillActionControllerDocsTest extends RestDocsSupport {
+
+    private final BillActionService billActionService = mock(BillActionService.class);
+
+    @Override
+    protected Object initController() {
+        return new BillActionController(billActionService);
+    }
+
+    @DisplayName("지출 내역을 생성한다.")
+    @Test
+    void saveAllBillAction() throws Exception {
+        BillActionsSaveRequest request = new BillActionsSaveRequest(
+                List.of(
+                        new BillActionSaveRequest("뽕족", 10_000L),
+                        new BillActionSaveRequest("인생맥주", 10_000L)
+                )
+        );
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "쿠키토큰";
+
+        mockMvc.perform(post("/api/events/{eventId}/bill-actions", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(EVENT_COOKIE)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("createBillActions",
+                        pathParameters(
+                                parameterWithName("eventId").description("행사 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName("eventToken").description("행사 관리자 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("actions").description("생성할 지출 액션 목록"),
+                                fieldWithPath("actions[0].title").description("생성할 지출 액션의 제목"),
+                                fieldWithPath("actions[0].price").description("생성할 지출 액션의 금액")
+                        )
+                ));
+    }
+
+    @DisplayName("지출 액션을 수정한다.")
+    @Test
+    void updateBillAction() throws Exception {
+        BillActionUpdateRequest request = new BillActionUpdateRequest("뽕족", 10_000L);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "웨디토큰";
+
+        mockMvc.perform(put("/api/events/{eventId}/bill-actions/{actionId}", eventId, 1L)
+                        .cookie(EVENT_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("updateBillAction",
+                        pathParameters(
+                                parameterWithName("eventId").description("행사 ID"),
+                                parameterWithName("actionId").description("지출 액션 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName("eventToken").description("행사 관리자 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("수정할 지출 액션의 제목"),
+                                fieldWithPath("price").description("수정할 지출 액션의 금액")
+                        )
+                ));
+    }
+
+    @DisplayName("지출 내역을 삭제한다.")
+    @Test
+    void deleteBillAction() throws Exception {
+        String eventId = "토다리토큰";
+
+        mockMvc.perform(delete("/api/events/{eventId}/bill-actions/{actionId}", eventId, 1)
+                        .cookie(EVENT_COOKIE)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("deleteBillAction",
+                        pathParameters(
+                                parameterWithName("eventId").description("행사 ID"),
+                                parameterWithName("actionId").description("지출 액션 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName("eventToken").description("행사 관리자 토큰")
+                        )
+                ));
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -1,0 +1,198 @@
+package server.haengdong.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import server.haengdong.application.AuthService;
+import server.haengdong.application.EventService;
+import server.haengdong.application.request.EventAppRequest;
+import server.haengdong.application.response.EventAppResponse;
+import server.haengdong.application.response.EventDetailAppResponse;
+import server.haengdong.application.response.MembersAppResponse;
+import server.haengdong.infrastructure.auth.CookieProperties;
+import server.haengdong.presentation.EventController;
+import server.haengdong.presentation.request.EventLoginRequest;
+import server.haengdong.presentation.request.EventSaveRequest;
+import server.haengdong.presentation.request.MemberUpdateRequest;
+
+public class EventControllerDocsTest extends RestDocsSupport {
+
+    private final EventService eventService = mock(EventService.class);
+    private final AuthService authService = mock(AuthService.class);
+    private final CookieProperties cookieProperties = new CookieProperties(
+            true, true, "domain", "path", Duration.ofDays(7)
+    );
+
+    @Override
+    protected Object initController() {
+        return new EventController(eventService, authService, cookieProperties);
+    }
+
+    @DisplayName("이벤트를 생성한다.")
+    @Test
+    void saveEvent() throws Exception {
+        EventSaveRequest eventSaveRequest = new EventSaveRequest("토다리", "0987");
+        String requestBody = objectMapper.writeValueAsString(eventSaveRequest);
+        String eventId = "쿠키 토큰";
+        EventAppResponse eventAppResponse = new EventAppResponse(eventId);
+        given(eventService.saveEvent(any(EventAppRequest.class))).willReturn(eventAppResponse);
+        given(authService.createToken(eventId)).willReturn("jwtToken");
+        given(authService.getTokenName()).willReturn("eventToken");
+
+        mockMvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("eventToken", "jwtToken"))
+                .andExpect(jsonPath("$.eventId").value("쿠키 토큰"))
+                .andDo(
+                        document("createEvent",
+                                requestFields(
+                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("행사 비밀 번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("eventId").type(JsonFieldType.STRING)
+                                                .description("행사 ID")
+                                ),
+                                responseCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("토큰으로 행사를 조회한다.")
+    @Test
+    void findEventTest() throws Exception {
+        String eventId = "망쵸토큰";
+        EventDetailAppResponse eventDetailAppResponse = new EventDetailAppResponse("행동대장 회식");
+        given(eventService.findEvent(eventId)).willReturn(eventDetailAppResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}", eventId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventName").value("행동대장 회식"))
+                .andDo(
+                        document("getEvent",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("행사에 참여한 전체 인원을 중복 없이 조회한다.")
+    @Test
+    void findAllMembersTest() throws Exception {
+        MembersAppResponse memberAppResponse = new MembersAppResponse(List.of("토다리", "쿠키"));
+        given(eventService.findAllMembers(anyString())).willReturn(memberAppResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/members", "TOKEN"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberNames").isArray())
+                .andExpect(jsonPath("$.memberNames[0]").value("토다리"))
+                .andExpect(jsonPath("$.memberNames[1]").value("쿠키"))
+                .andDo(
+                        document("findAllEventMember",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("memberNames").type(JsonFieldType.ARRAY)
+                                                .description("행사 참여자 목록")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("행사 참여 인원의 이름을 수정한다.")
+    @Test
+    void updateMember() throws Exception {
+        String token = "TOKEN";
+        MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("변경된 이름");
+        String requestBody = objectMapper.writeValueAsString(memberUpdateRequest);
+
+        mockMvc.perform(put("/api/events/{eventId}/members/{memberName}", token, "변경 전 이름")
+                        .cookie(EVENT_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document("updateEventMemberName",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("memberName").description("참여자 이름")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자 토큰")
+                                ),
+                                requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("수정할 참여자 이름")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("행사 어드민이 로그인한다.")
+    @Test
+    void loginEvent() throws Exception {
+        String token = "TOKEN";
+        EventLoginRequest eventLoginRequest = new EventLoginRequest("1234");
+        String requestBody = objectMapper.writeValueAsString(eventLoginRequest);
+        given(authService.createToken(token)).willReturn("jwtToken");
+        given(authService.getTokenName()).willReturn("eventToken");
+
+        mockMvc.perform(post("/api/events/{eventId}/login", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(cookie().value("eventToken", "jwtToken"))
+                .andExpect(status().isOk())
+                .andDo(
+                        document("eventLogin",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("password").type(JsonFieldType.STRING)
+                                                .description("행사 비밀 번호")
+                                ),
+                                responseCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
+                        )
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -11,6 +11,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -73,6 +76,8 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.eventId").value("쿠키 토큰"))
                 .andDo(
                         document("createEvent",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 requestFields(
                                         fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름"),
                                         fieldWithPath("password").type(JsonFieldType.STRING).description("행사 비밀 번호")
@@ -101,6 +106,8 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.eventName").value("행동대장 회식"))
                 .andDo(
                         document("getEvent",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
                                 ),
@@ -125,6 +132,8 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.memberNames[1]").value("쿠키"))
                 .andDo(
                         document("findAllEventMember",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
                                 ),
@@ -151,6 +160,8 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(
                         document("updateEventMemberName",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID"),
                                         parameterWithName("memberName").description("참여자 이름")
@@ -182,6 +193,8 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(
                         document("eventLogin",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
                                 ),

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -51,7 +51,7 @@ public class EventControllerDocsTest extends RestDocsSupport {
     private final EventService eventService = mock(EventService.class);
     private final AuthService authService = mock(AuthService.class);
     private final CookieProperties cookieProperties = new CookieProperties(
-            true, true, "domain", "path", Duration.ofDays(7)
+            true, true, "domain", "path", "none", Duration.ofDays(7)
     );
 
     @Override

--- a/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
@@ -1,0 +1,148 @@
+package server.haengdong.docs;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import server.haengdong.application.MemberActionService;
+import server.haengdong.application.response.CurrentMemberAppResponse;
+import server.haengdong.presentation.MemberActionController;
+import server.haengdong.presentation.request.MemberActionsSaveRequest;
+
+public class MemberActionControllerDocsTest extends RestDocsSupport {
+
+    private MemberActionService memberActionService = mock(MemberActionService.class);
+
+    @Override
+    protected Object initController() {
+        return new MemberActionController(memberActionService);
+    }
+
+    @DisplayName("참여자 행동을 추가한다.")
+    @Test
+    void saveMemberActionTest() throws Exception {
+        MemberActionsSaveRequest memberActionsSaveRequest = new MemberActionsSaveRequest(
+                List.of("웨디", "소하", "토다리", "쿠키"), "IN");
+
+        String requestBody = objectMapper.writeValueAsString(memberActionsSaveRequest);
+
+        mockMvc.perform(post("/api/events/{eventId}/member-actions", "망쵸토큰")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document("createMemberAction",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("토큰 토큰")
+                                ),
+                                requestFields(
+                                        fieldWithPath("members").type(JsonFieldType.ARRAY)
+                                                .description("액션 대상 참여자 목록"),
+                                        fieldWithPath("status").type(JsonFieldType.STRING)
+                                                .description("참여자 액션 상태 [IN(늦참), OUT(탈주)]")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("현재 참여 인원을 조회합니다.")
+    @Test
+    void getCurrentMembers() throws Exception {
+        List<CurrentMemberAppResponse> currentMemberAppResponses = List.of(
+                new CurrentMemberAppResponse("소하"), new CurrentMemberAppResponse("토다리"));
+
+        given(memberActionService.getCurrentMembers(any())).willReturn(currentMemberAppResponses);
+
+        mockMvc.perform(get("/api/events/{eventId}/members/current", "망쵸토큰")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members[0].name").value(equalTo("소하")))
+                .andExpect(jsonPath("$.members[1].name").value(equalTo("토다리")))
+                .andDo(
+                        document("getMemberAction",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("members").type(JsonFieldType.ARRAY)
+                                                .description("액션 대상 참여자 목록"),
+                                        fieldWithPath("members[0].name").type(JsonFieldType.STRING)
+                                                .description("참여자 이름")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("이벤트에 속한 멤버 액션을 삭제하면 이후에 기록된 해당 참여자의 모든 멤버 액션을 삭제한다.")
+    @Test
+    void deleteMemberAction() throws Exception {
+        String eventId = "망쵸토큰";
+        Long actionId = 2L;
+
+        mockMvc.perform(delete("/api/events/{eventId}/member-actions/{actionId}", eventId, actionId)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document("deleteMemberAction",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("actionId").description("액션 ID")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("행사의 전체 참여자 중에서 특정 참여자의 맴버 액션을 전부 삭제한다.")
+    @Test
+    void deleteMember() throws Exception {
+        String eventId = "망쵸토큰";
+        String memberName = "행동대장";
+
+        mockMvc.perform(delete("/api/events/{eventId}/members/{memberName}", eventId, memberName)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document("deleteAllMemberActionByName",
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("memberName").description("행사 참여자 이름")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
+                        )
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
@@ -10,6 +10,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -55,6 +58,8 @@ public class MemberActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(
                         document("createMemberAction",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
                                 ),
@@ -87,6 +92,8 @@ public class MemberActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.members[1].name").value(equalTo("토다리")))
                 .andDo(
                         document("getMemberAction",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
                                 ),
@@ -112,6 +119,8 @@ public class MemberActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(
                         document("deleteMemberAction",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID"),
                                         parameterWithName("actionId").description("액션 ID")
@@ -135,6 +144,8 @@ public class MemberActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(
                         document("deleteAllMemberActionByName",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID"),
                                         parameterWithName("memberName").description("행사 참여자 이름")

--- a/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/MemberActionControllerDocsTest.java
@@ -35,7 +35,7 @@ import server.haengdong.presentation.request.MemberActionsSaveRequest;
 
 public class MemberActionControllerDocsTest extends RestDocsSupport {
 
-    private MemberActionService memberActionService = mock(MemberActionService.class);
+    private final MemberActionService memberActionService = mock(MemberActionService.class);
 
     @Override
     protected Object initController() {
@@ -91,7 +91,7 @@ public class MemberActionControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.members[0].name").value(equalTo("소하")))
                 .andExpect(jsonPath("$.members[1].name").value(equalTo("토다리")))
                 .andDo(
-                        document("getMemberAction",
+                        document("getCurrentMembers",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(

--- a/server/src/test/java/server/haengdong/docs/RestDocsSupport.java
+++ b/server/src/test/java/server/haengdong/docs/RestDocsSupport.java
@@ -1,0 +1,28 @@
+package server.haengdong.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith({RestDocumentationExtension.class})
+abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    protected abstract Object initController();
+}

--- a/server/src/test/java/server/haengdong/support/fixture/Fixture.java
+++ b/server/src/test/java/server/haengdong/support/fixture/Fixture.java
@@ -1,9 +1,11 @@
 package server.haengdong.support.fixture;
 
+import jakarta.servlet.http.Cookie;
 import server.haengdong.domain.event.Event;
 
 public class Fixture {
 
     public static final Event EVENT1 = new Event("쿠키", "1234", "TOKEN1");
     public static final Event EVENT2 = new Event("웨디", "1234", "TOKEN2");
+    public static final Cookie EVENT_COOKIE = new Cookie("eventToken", "토큰토큰");
 }


### PR DESCRIPTION
## issue
- close #220 

## 구현 사항
Spring REST Docs를 전체 API에 적용했습니다.

### 문서 접속 방법
- 서버 실행 후 `/docs/index.html`로 접속
  <img width="1422" alt="image" src="https://github.com/user-attachments/assets/7e921aca-70fe-4679-8a6b-ab1c29c3720c">

### 문서화된 API 목록
<img width="426" alt="image" src="https://github.com/user-attachments/assets/9c5fab3b-821d-4aa3-b52a-034e7424cc35">

### 각 API의 문서화 항목
- Path parameters: API 엔드포인트와 path 변수에 대한 정보
  <img width="739" alt="image" src="https://github.com/user-attachments/assets/11fb4fee-4247-4ddc-9e82-7df5159cc6c3">

- HTTP request: HTTP Method, Header, Body가 포함된 전체 HTTP 요청 형식
  <img width="743" alt="image" src="https://github.com/user-attachments/assets/fa65076f-fc25-49ce-8cde-9a9340249b03">

- Request body: 요청 본문
  <img width="738" alt="image" src="https://github.com/user-attachments/assets/a3f06905-eae8-4f2e-bcfa-1ab8a159f2a5">

- Request fields: 요청 본문 각 필드에 대한 상세 설명
  <img width="742" alt="image" src="https://github.com/user-attachments/assets/51b0bb89-71ba-4d65-a288-a90bc0886643">

- Response body: 응답 본문
  <img width="740" alt="image" src="https://github.com/user-attachments/assets/5ca8be45-1922-4279-b5f0-2b18191692c4">

- Response fields: 응답 본문 각 필드에 대한 상세 설명
  <img width="741" alt="image" src="https://github.com/user-attachments/assets/affdb130-c788-49a7-917b-10e74d992470">

- HTTP response: HTTP Status, Header, Body가 포함된 전체 HTTP 응답 형식
  <img width="741" alt="image" src="https://github.com/user-attachments/assets/b5ee078b-c3fc-4751-baa7-b99953a77996">

- Request cookies: 요청에 포함되어야 하는 쿠키 목록
  <img width="742" alt="image" src="https://github.com/user-attachments/assets/71791243-0926-4ba7-b154-5440252eb82a">

- Response cookies: API 응답으로 발급되는 쿠키 목록
  <img width="742" alt="image" src="https://github.com/user-attachments/assets/131b7404-9995-4a9b-8297-c61b950251dc">

- Exceptions: 해당 API에서 발생할 수 있는 예외 사항 목록
  <img width="742" alt="image" src="https://github.com/user-attachments/assets/a2c4d2f5-98a2-493d-916b-6a22fa5a2e03">

### 문서 snippet 작성 순서
1. path-parameters
2. http-request
3. request-body
4. request-fields
5. response-body
6. response-fields
7. http-response
8. request-cookies
9. response-cookies
10. exceptions

response-body가 생성되지 않는 경우에는 http-response와 response-fields의 순서를 변경하여 작성합니다.

### build.gradle 작업 설정
- asciidoctor 실행하면 `/build/docs/asciidoc`에 각 adoc에 대응되는 html 파일 생성
  <img width="346" alt="image" src="https://github.com/user-attachments/assets/02969364-4457-4a43-bf9e-a93570cad7f8">
- copyApiDocuments 작업을 등록해 생성된 html 파일들을 `src/main/resources/static/docs` 경로로 복사해 정적 자원으로 제공
  <img width="444" alt="image" src="https://github.com/user-attachments/assets/120e15b9-ebdc-46f3-8b27-b94559f92bdd">
