### PR TITLE
[FE] 디자인시스템 Text 컴포넌트 color prop 받도록 변경

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.60",
+  "version": "0.1.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.60",
+      "version": "0.1.62",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.60",
+  "version": "0.1.62",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/DragHandleItem/DragHandleItem.style.ts
+++ b/HDesign/src/components/DragHandleItem/DragHandleItem.style.ts
@@ -18,8 +18,3 @@ export const dragHandlerStyle = css({
   gap: '0.25rem',
   width: '100%',
 });
-
-export const textStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.black,
-  });

--- a/HDesign/src/components/DragHandleItem/DragHandleItem.tsx
+++ b/HDesign/src/components/DragHandleItem/DragHandleItem.tsx
@@ -9,7 +9,7 @@ import {useTheme} from '@theme/HDesignProvider';
 
 import IconButton from '../IconButton/IconButton';
 
-import {dragHandleItemStyle, dragHandlerStyle, textStyle} from './DragHandleItem.style';
+import {dragHandleItemStyle, dragHandlerStyle} from './DragHandleItem.style';
 import {DragHandleItemProps} from './DragHandleItem.type';
 
 export const DragHandleItem = ({
@@ -31,10 +31,10 @@ export const DragHandleItem = ({
           </IconButton>
         )}
         <Flex justifyContent="spaceBetween" width="100%">
-          <Text css={textStyle(theme)} size="bodyBold">
+          <Text color="black" size="bodyBold">
             {prefix}
           </Text>
-          <Text css={textStyle(theme)} size="body">
+          <Text color="black" size="body">
             {suffix}
           </Text>
         </Flex>

--- a/HDesign/src/components/DragHandleItem/DragHandleItem.tsx
+++ b/HDesign/src/components/DragHandleItem/DragHandleItem.tsx
@@ -31,12 +31,8 @@ export const DragHandleItem = ({
           </IconButton>
         )}
         <Flex justifyContent="spaceBetween" width="100%">
-          <Text color="black" size="bodyBold">
-            {prefix}
-          </Text>
-          <Text color="black" size="body">
-            {suffix}
-          </Text>
+          <Text size="bodyBold">{prefix}</Text>
+          <Text>{suffix}</Text>
         </Flex>
       </div>
     </div>

--- a/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.style.ts
+++ b/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.style.ts
@@ -13,25 +13,3 @@ export const containerStyle = (theme: Theme, backgroundColor: ColorKeys) =>
     borderRadius: '0.75rem',
     backgroundColor: theme.colors[backgroundColor],
   });
-
-export const topLeftStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-  });
-
-//TODO: (@todari) : 추후 클릭 기능을 넣었을 때 underline
-export const topRightStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-    // textDecoration: 'underline',
-  });
-
-export const bottomLeftTextStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-  });
-
-export const bottomRightTextStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-  });

--- a/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.tsx
+++ b/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.tsx
@@ -4,13 +4,7 @@ import {useTheme} from '@theme/HDesignProvider';
 import Text from '../Text/Text';
 import Flex from '../Flex/Flex';
 
-import {
-  bottomLeftTextStyle,
-  bottomRightTextStyle,
-  containerStyle,
-  topLeftStyle,
-  topRightStyle,
-} from './DragHandleItemContainer.style';
+import {containerStyle} from './DragHandleItemContainer.style';
 import {DragHandleItemContainerProps} from './DragHandleItemContainer.type';
 
 export const DragHandleItemContainer: React.FC<DragHandleItemContainerProps> = ({
@@ -27,19 +21,19 @@ export const DragHandleItemContainer: React.FC<DragHandleItemContainerProps> = (
   return (
     <div css={containerStyle(theme, backgroundColor)} {...htmlProps}>
       <Flex justifyContent="spaceBetween" paddingInline="0.5rem">
-        <Text css={topLeftStyle(theme)} size="captionBold">
+        <Text color="gray" size="captionBold">
           {topLeftText}
         </Text>
-        <Text css={topRightStyle(theme)} size="caption">
+        <Text color="gray" size="caption">
           {topRightText}
         </Text>
       </Flex>
       {children}
       <Flex justifyContent="spaceBetween" paddingInline="0.5rem">
-        <Text css={bottomLeftTextStyle(theme)} size="captionBold">
+        <Text color="gray" size="captionBold">
           {bottomLeftText}
         </Text>
-        <Text css={bottomRightTextStyle(theme)} size="caption">
+        <Text color="gray" size="caption">
           {bottomRightText}
         </Text>
       </Flex>

--- a/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.tsx
+++ b/HDesign/src/components/DragHandleItemContainer/DragHandleItemContainer.tsx
@@ -21,19 +21,19 @@ export const DragHandleItemContainer: React.FC<DragHandleItemContainerProps> = (
   return (
     <div css={containerStyle(theme, backgroundColor)} {...htmlProps}>
       <Flex justifyContent="spaceBetween" paddingInline="0.5rem">
-        <Text color="gray" size="captionBold">
+        <Text textColor="gray" size="captionBold">
           {topLeftText}
         </Text>
-        <Text color="gray" size="caption">
+        <Text textColor="gray" size="caption">
           {topRightText}
         </Text>
       </Flex>
       {children}
       <Flex justifyContent="spaceBetween" paddingInline="0.5rem">
-        <Text color="gray" size="captionBold">
+        <Text textColor="gray" size="captionBold">
           {bottomLeftText}
         </Text>
-        <Text color="gray" size="caption">
+        <Text textColor="gray" size="caption">
           {bottomRightText}
         </Text>
       </Flex>

--- a/HDesign/src/components/ExpenseList/ExpenseList.style.ts
+++ b/HDesign/src/components/ExpenseList/ExpenseList.style.ts
@@ -19,11 +19,6 @@ export const expenseItemLeftStyle = () =>
     gap: '1rem',
   });
 
-export const TextStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.onTertiary,
-  });
-
 export const expenseListStyle = (theme: Theme) =>
   css({
     width: '100%',

--- a/HDesign/src/components/ExpenseList/ExpenseList.tsx
+++ b/HDesign/src/components/ExpenseList/ExpenseList.tsx
@@ -14,11 +14,9 @@ function ExpenseItem({name, price, ...buttonProps}: ExpenseItemProps) {
   const {theme} = useTheme();
   return (
     <button css={expenseItemStyle} {...buttonProps}>
-      <Text size="bodyBold" color="black">
-        {name}
-      </Text>
+      <Text size="bodyBold">{name}</Text>
       <div css={expenseItemLeftStyle}>
-        <Text color="black">{price.toLocaleString('ko-kr')}원</Text>
+        <Text>{price.toLocaleString('ko-kr')}원</Text>
         <Icon iconType="rightChevron" />
       </div>
     </button>

--- a/HDesign/src/components/ExpenseList/ExpenseList.tsx
+++ b/HDesign/src/components/ExpenseList/ExpenseList.tsx
@@ -6,7 +6,7 @@ import Icon from '@components/Icon/Icon';
 import {useTheme} from '@theme/HDesignProvider';
 
 import {ExpenseItemProps, ExpenseListProps} from './ExpenseList.type';
-import {expenseItemStyle, expenseListStyle, expenseItemLeftStyle, TextStyle} from './ExpenseList.style';
+import {expenseItemStyle, expenseListStyle, expenseItemLeftStyle} from './ExpenseList.style';
 
 // TODO: (@soha) 따로 파일 분리할까 고민중.. 여기서만 사용할 것 같긴 한데.. 흠
 // TODO: (@todari) : 추후 클릭 시 상호작용이 생기면 iconButton으로 변경할 수 있음
@@ -14,11 +14,11 @@ function ExpenseItem({name, price, ...buttonProps}: ExpenseItemProps) {
   const {theme} = useTheme();
   return (
     <button css={expenseItemStyle} {...buttonProps}>
-      <Text size="bodyBold" css={TextStyle(theme)}>
+      <Text size="bodyBold" color="black">
         {name}
       </Text>
       <div css={expenseItemLeftStyle}>
-        <Text css={TextStyle(theme)}>{price.toLocaleString('ko-kr')}원</Text>
+        <Text color="black">{price.toLocaleString('ko-kr')}원</Text>
         <Icon iconType="rightChevron" />
       </div>
     </button>

--- a/HDesign/src/components/ListButton/ListButton.style.ts
+++ b/HDesign/src/components/ListButton/ListButton.style.ts
@@ -14,8 +14,3 @@ export const listButtonStyle = (theme: Theme) =>
 
     boxShadow: `0 1px 0 0 ${theme.colors.grayContainer} inset `,
   });
-
-export const textStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-  });

--- a/HDesign/src/components/ListButton/ListButton.tsx
+++ b/HDesign/src/components/ListButton/ListButton.tsx
@@ -18,11 +18,11 @@ export const ListButton: React.FC<ListButtonProps> = forwardRef<HTMLButtonElemen
   const {theme} = useTheme();
   return (
     <button css={listButtonStyle(theme)} ref={ref} {...htmlProps}>
-      <Text size="caption" color="gray">
+      <Text size="caption" textColor="gray">
         {prefix}
       </Text>
       <Flex gap="0.5rem" alignItems="center">
-        <Text size="caption" color="gray">
+        <Text size="caption" textColor="gray">
           {suffix}
         </Text>
         <IconButton variants="none">

--- a/HDesign/src/components/ListButton/ListButton.tsx
+++ b/HDesign/src/components/ListButton/ListButton.tsx
@@ -9,7 +9,7 @@ import Icon from '@components/Icon/Icon';
 import {useTheme} from '@theme/HDesignProvider';
 
 import {ListButtonProps} from './ListButton.type';
-import {listButtonStyle, textStyle} from './ListButton.style';
+import {listButtonStyle} from './ListButton.style';
 
 export const ListButton: React.FC<ListButtonProps> = forwardRef<HTMLButtonElement, ListButtonProps>(function Button(
   {prefix, suffix, ...htmlProps}: ListButtonProps,
@@ -18,11 +18,11 @@ export const ListButton: React.FC<ListButtonProps> = forwardRef<HTMLButtonElemen
   const {theme} = useTheme();
   return (
     <button css={listButtonStyle(theme)} ref={ref} {...htmlProps}>
-      <Text size="caption" css={textStyle(theme)}>
+      <Text size="caption" color="gray">
         {prefix}
       </Text>
       <Flex gap="0.5rem" alignItems="center">
-        <Text size="caption" css={textStyle(theme)}>
+        <Text size="caption" color="gray">
           {suffix}
         </Text>
         <IconButton variants="none">

--- a/HDesign/src/components/Text/Text.style.ts
+++ b/HDesign/src/components/Text/Text.style.ts
@@ -1,11 +1,11 @@
-import type {TextProps} from './Text.type';
+import type {TextStylePropsWithTheme} from './Text.type';
 
 import {css} from '@emotion/react';
 
 // TODO: (@todari) themeProvider 이용하도록 변경
 import TYPOGRAPHY from '@token/typography';
 
-export const getSizeStyling = (size: Required<TextProps>['size']) => {
+export const getSizeStyling = ({size, color, theme}: Required<TextStylePropsWithTheme>) => {
   const style = {
     head: css(TYPOGRAPHY.head),
     title: css(TYPOGRAPHY.title),
@@ -19,5 +19,7 @@ export const getSizeStyling = (size: Required<TextProps>['size']) => {
     tiny: css(TYPOGRAPHY.tiny),
   };
 
-  return style[size];
+  const colorStyle = css({color: theme.colors[color]});
+
+  return [style[size], colorStyle];
 };

--- a/HDesign/src/components/Text/Text.style.ts
+++ b/HDesign/src/components/Text/Text.style.ts
@@ -5,7 +5,7 @@ import {css} from '@emotion/react';
 // TODO: (@todari) themeProvider 이용하도록 변경
 import TYPOGRAPHY from '@token/typography';
 
-export const getSizeStyling = ({size, color, theme}: Required<TextStylePropsWithTheme>) => {
+export const getSizeStyling = ({size, textColor, theme}: Required<TextStylePropsWithTheme>) => {
   const style = {
     head: css(TYPOGRAPHY.head),
     title: css(TYPOGRAPHY.title),
@@ -19,7 +19,7 @@ export const getSizeStyling = ({size, color, theme}: Required<TextStylePropsWith
     tiny: css(TYPOGRAPHY.tiny),
   };
 
-  const colorStyle = css({color: theme.colors[color]});
+  const colorStyle = css({color: theme.colors[textColor]});
 
   return [style[size], colorStyle];
 };

--- a/HDesign/src/components/Text/Text.tsx
+++ b/HDesign/src/components/Text/Text.tsx
@@ -6,10 +6,10 @@ import React from 'react';
 import {getSizeStyling} from './Text.style';
 import {useTheme} from '@theme/HDesignProvider';
 
-const Text: React.FC<TextProps> = ({size = 'body', color = 'black', children, ...attributes}: TextProps) => {
+const Text: React.FC<TextProps> = ({size = 'body', textColor = 'black', children, ...attributes}: TextProps) => {
   const {theme} = useTheme();
   return (
-    <p css={getSizeStyling({size, color, theme})} {...attributes}>
+    <p css={getSizeStyling({size, textColor, theme})} {...attributes}>
       {children}
     </p>
   );

--- a/HDesign/src/components/Text/Text.tsx
+++ b/HDesign/src/components/Text/Text.tsx
@@ -4,10 +4,12 @@ import type {TextProps} from '@components/Text/Text.type';
 import React from 'react';
 
 import {getSizeStyling} from './Text.style';
+import {useTheme} from '@theme/HDesignProvider';
 
-const Text: React.FC<TextProps> = ({size = 'body', children, ...attributes}: TextProps) => {
+const Text: React.FC<TextProps> = ({size = 'body', color = 'black', children, ...attributes}: TextProps) => {
+  const {theme} = useTheme();
   return (
-    <p css={getSizeStyling(size)} {...attributes}>
+    <p css={getSizeStyling({size, color, theme})} {...attributes}>
       {children}
     </p>
   );

--- a/HDesign/src/components/Text/Text.tsx
+++ b/HDesign/src/components/Text/Text.tsx
@@ -3,8 +3,9 @@ import type {TextProps} from '@components/Text/Text.type';
 
 import React from 'react';
 
-import {getSizeStyling} from './Text.style';
 import {useTheme} from '@theme/HDesignProvider';
+
+import {getSizeStyling} from './Text.style';
 
 const Text: React.FC<TextProps> = ({size = 'body', textColor = 'black', children, ...attributes}: TextProps) => {
   const {theme} = useTheme();

--- a/HDesign/src/components/Text/Text.type.ts
+++ b/HDesign/src/components/Text/Text.type.ts
@@ -1,3 +1,6 @@
+import {Theme} from '@theme/theme.type';
+import {ColorKeys} from '@token/colors';
+
 export type TextSize =
   | 'head'
   | 'title'
@@ -12,6 +15,11 @@ export type TextSize =
 
 export interface TextStyleProps {
   size?: TextSize;
+  color?: ColorKeys;
+}
+
+export interface TextStylePropsWithTheme extends TextStyleProps {
+  theme: Theme;
 }
 
 export interface TextCustomProps {}

--- a/HDesign/src/components/Text/Text.type.ts
+++ b/HDesign/src/components/Text/Text.type.ts
@@ -1,4 +1,5 @@
 import {Theme} from '@theme/theme.type';
+
 import {ColorKeys} from '@token/colors';
 
 export type TextSize =

--- a/HDesign/src/components/Text/Text.type.ts
+++ b/HDesign/src/components/Text/Text.type.ts
@@ -15,7 +15,7 @@ export type TextSize =
 
 export interface TextStyleProps {
   size?: TextSize;
-  color?: ColorKeys;
+  textColor?: ColorKeys;
 }
 
 export interface TextStylePropsWithTheme extends TextStyleProps {

--- a/HDesign/src/components/TextButton/TextButton.style.ts
+++ b/HDesign/src/components/TextButton/TextButton.style.ts
@@ -2,14 +2,9 @@ import {css} from '@emotion/react';
 
 import {Theme} from '@theme/theme.type';
 
-import {TextColor} from './TextButton.type';
+import {ColorKeys} from '@token/colors';
 
 interface TextButtonStyleProps {
-  textColor: TextColor;
+  textColor: ColorKeys;
   theme: Theme;
 }
-
-export const textButtonStyle = ({textColor, theme}: TextButtonStyleProps) =>
-  css({
-    color: theme.colors[textColor],
-  });

--- a/HDesign/src/components/TextButton/TextButton.tsx
+++ b/HDesign/src/components/TextButton/TextButton.tsx
@@ -6,7 +6,6 @@ import {useTheme} from '@theme/HDesignProvider';
 import Text from '../Text/Text';
 
 import {TextButtonProps} from './TextButton.type';
-import {textButtonStyle} from './TextButton.style';
 
 export const TextButton: React.FC<TextButtonProps> = forwardRef<HTMLButtonElement, TextButtonProps>(function Button(
   {textColor, textSize, children, ...htmlProps}: TextButtonProps,
@@ -16,7 +15,7 @@ export const TextButton: React.FC<TextButtonProps> = forwardRef<HTMLButtonElemen
 
   return (
     <button ref={ref} {...htmlProps}>
-      <Text size={textSize} css={textButtonStyle({textColor, theme})}>
+      <Text size={textSize} color={textColor}>
         {children}
       </Text>
     </button>

--- a/HDesign/src/components/TextButton/TextButton.tsx
+++ b/HDesign/src/components/TextButton/TextButton.tsx
@@ -15,7 +15,7 @@ export const TextButton: React.FC<TextButtonProps> = forwardRef<HTMLButtonElemen
 
   return (
     <button ref={ref} {...htmlProps}>
-      <Text size={textSize} color={textColor}>
+      <Text size={textSize} textColor={textColor}>
         {children}
       </Text>
     </button>

--- a/HDesign/src/components/Title/Title.style.ts
+++ b/HDesign/src/components/Title/Title.style.ts
@@ -12,28 +12,8 @@ export const titleContainerStyle = (theme: Theme) =>
     padding: '1rem',
   });
 
-export const titleStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.black,
-  });
-
-export const descriptionStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.darkGray,
-  });
-
 export const priceContainerStyle = css({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'end',
 });
-
-export const priceTitleStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.gray,
-  });
-
-export const priceStyle = (theme: Theme) =>
-  css({
-    color: theme.colors.black,
-  });

--- a/HDesign/src/components/Title/Title.tsx
+++ b/HDesign/src/components/Title/Title.tsx
@@ -1,13 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import Text from '@components/Text/Text';
-import {
-  descriptionStyle,
-  priceContainerStyle,
-  priceStyle,
-  priceTitleStyle,
-  titleContainerStyle,
-  titleStyle,
-} from '@components/Title/Title.style';
+import {priceContainerStyle, titleContainerStyle} from '@components/Title/Title.style';
 import {TitleProps} from '@components/Title/Title.type';
 
 import {useTheme} from '@theme/HDesignProvider';
@@ -16,20 +9,20 @@ export const Title: React.FC<TitleProps> = ({title, description, price}: TitlePr
   const {theme} = useTheme();
   return (
     <div css={titleContainerStyle(theme)}>
-      <Text css={titleStyle(theme)} size="subTitle">
+      <Text color="black" size="subTitle">
         {title}
       </Text>
       {description && (
-        <Text css={descriptionStyle(theme)} size="caption">
+        <Text color="darkGray" size="caption">
           {description}
         </Text>
       )}
       {price !== undefined && (
         <div css={priceContainerStyle}>
-          <Text css={priceTitleStyle(theme)} size="caption">
+          <Text color="gray" size="caption">
             전체 지출 금액
           </Text>
-          <Text css={priceStyle(theme)}>{price.toLocaleString('ko-kr')}원</Text>
+          <Text color="black">{price.toLocaleString('ko-kr')}원</Text>
         </div>
       )}
     </div>

--- a/HDesign/src/components/Title/Title.tsx
+++ b/HDesign/src/components/Title/Title.tsx
@@ -9,20 +9,18 @@ export const Title: React.FC<TitleProps> = ({title, description, price}: TitlePr
   const {theme} = useTheme();
   return (
     <div css={titleContainerStyle(theme)}>
-      <Text color="black" size="subTitle">
-        {title}
-      </Text>
+      <Text size="subTitle">{title}</Text>
       {description && (
-        <Text color="darkGray" size="caption">
+        <Text textColor="darkGray" size="caption">
           {description}
         </Text>
       )}
       {price !== undefined && (
         <div css={priceContainerStyle}>
-          <Text color="gray" size="caption">
+          <Text textColor="gray" size="caption">
             전체 지출 금액
           </Text>
-          <Text color="black">{price.toLocaleString('ko-kr')}원</Text>
+          <Text>{price.toLocaleString('ko-kr')}원</Text>
         </div>
       )}
     </div>


### PR DESCRIPTION
## issue
- close #254 

## 구현 목적
현재 Text color를 설정해 주는 굉장히 많은 부분에서 보일러플레이트 코드가 발생하고 있습니다.

```tsx
// DragHandleItem.tsx
  // ~
          <Text css={textStyle(theme)} size="bodyBold">
            {prefix}
          </Text>
  // ~

// DragHandleItem.style.ts
  // ~
export const textStyle = (theme: Theme) =>
  css({
    color: theme.colors.black,
  });
```
심지어 사용처에서는 color를 별도로 지정해 줄 수 있는 방법이 없었습니다.

이에 따라 color를 prop으로 받아 사용할 수 있도록 변경합니다.

## 고려 사항
```tsx
export interface TextStyleProps {
  size?: TextSize;
  color?: ColorKeys;
}
```
ColorKeys type을 받아서, semantic token 값을 prop 으로 받을 수 있도록 변경합니다.

## TroubleShooting
color prop을 만들었지만, 사용처에서 color prop이 적용되지 않는 문제가 발생했습니다.
사용처에서 color의 타입을 확인해 본 결과, 
`React.HTMLAttributes<HTMLParagraphElement>.color` 로 들어가는 것을 확인할 수 있었습니다.
![image](https://github.com/user-attachments/assets/d878462d-44e4-4ff1-a13c-6cb74757f468)


아마 기존의 paragraph prop들도 함께 받는 과정에서, color prop이 덫씌워진 것 같았습니다.

```tsx
export type TextSize =
  | 'head'
  | 'title'
  | 'subTitle'
  | 'body'
  | 'smallBody'
  | 'caption'
  | 'tiny'
  | 'bodyBold'
  | 'smallBodyBold'
  | 'captionBold';

export interface TextStyleProps {
  size?: TextSize;
  color?: ColorKeys;
}

export interface TextStylePropsWithTheme extends TextStyleProps {
  theme: Theme;
}

export interface TextCustomProps {}

export type TextOptionProps = TextStyleProps & TextCustomProps;

// 이곳에서 paragraph attribute를 병합함
export type TextProps = React.ComponentProps<'p'> & TextOptionProps;
```

따라서 Text component의 `color` prop을 `textColor`로 변경하였습니다.

## 구현 사항
#### 기존 코드
```tsx
const Text: React.FC<TextProps> = ({size = 'body', children, ...attributes}: TextProps) => {
  return (
    <p css={getSizeStyling(size)} {...attributes}>
      {children}
    </p>
  );
};

export default Text;
```

#### 변경된 코드
```tsx
const Text: React.FC<TextProps> = ({size = 'body', textColor = 'black', children, ...attributes}: TextProps) => {
  const {theme} = useTheme();
  return (
    <p css={getSizeStyling({size, textColor, theme})} {...attributes}>
      {children}
    </p>
  );
};

export default Text;
```
기존에는 size만 받고 style에 theme을 넘겨주어 불필요한 코드가 많이 발생했지만,
color를 받고, style에 별도의 css를 만들지 않아도 되도록 변경했습니다.

![image](https://github.com/user-attachments/assets/6aaf3a02-ca77-46d9-b5f5-c78e8b470a94)

실제로 많은 코드가 줄어든 것을 확인할 수 있습니다.


## 사용 예시 코드
```tsx
<Text size="body" textColor="gray">
  아래 버튼을 클릭한 뒤 붙여넣어 행사 링크를 보관해 주세요
</Text>
```
