### PR TITLE
[BE] 참여자 삭제 메서드 @Transactional 추가

### DIFF
--- a/server/src/main/java/server/haengdong/application/MemberActionService.java
+++ b/server/src/main/java/server/haengdong/application/MemberActionService.java
@@ -59,6 +59,7 @@ public class MemberActionService {
                 .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));
     }
 
+    @Transactional
     public void deleteMember(String token, String memberName) {
         Event event = eventRepository.findByToken(token)
                 .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -47,6 +47,13 @@ logging:
     org.springframework.web: debug
     server.haengdong: debug
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
 ---
 
 spring:


### PR DESCRIPTION
## issue

## 구현 사항
```
# application.yml 추가

server:
  servlet:
    encoding:
      charset: UTF-8
      enabled: true
      force: true
```

## 문제: MemberAction을 삭제하는 api가 500 에러 발생

**발생한 로그**

<img width="852" alt="스크린샷 2024-08-08 20 03 00" src="https://github.com/user-attachments/assets/bc26bc5c-aecb-4e0b-ad82-7a7432780359">

**문제가 되었던 부분**

delete 쿼리가 발생했지만 커넥션이 read-only여서 삭제 요청이 처리되지 못했다. 

**해결**

```java
MemberActionService.java

    @Transactional // 추가한 부분
    public void deleteMember(String token, String memberName) {
        Event event = eventRepository.findByToken(token)
                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND));

        memberActionRepository.deleteAllByEventAndMemberName(event, memberName);
    }
```



## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
