### PR TITLE
[BE] actuator metrics 추가하여 모니터링 대상 확장

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,13 +39,18 @@ management:
   endpoints:
     web:
       exposure:
-        include: logfile
+        include: logfile, metrics
 
 logging:
   level:
     root: debug
     org.springframework.web: debug
     server.haengdong: debug
+
+  file:
+    name: logs/spring-boot-application.log
+    path: logs
+  config: classpath:logback-spring.xml
 
 server:
   servlet:


### PR DESCRIPTION
## issue
- close #267 

## 구현 사항


### 반영 전

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2c01bd06-72c0-4e76-b9ba-f72a6944667b">

현재 CloudWatch를 통해 cpu, mem, 네트워크만 한정적으로 모니터링 가능합니다.
이 밖에 appliction, connection-pool, jvm, system 등 모니터링 하는 대상을 확장하기 위해
application.yml에 작성 되어있는 management.endpoints.web.exposure.include 에 metrics를 추가합니다.

### 반영 후
<img width="668" alt="image" src="https://github.com/user-attachments/assets/b51cfee0-0e96-4414-9979-7e420d380d86">

<img width="668" alt="image" src="https://github.com/user-attachments/assets/3d1f4bb5-d4fc-4404-80f2-03b49fab5d39">

<img width="643" alt="image" src="https://github.com/user-attachments/assets/7eed0180-9a39-43f8-a7f6-ede5eb4d03c5">

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
