### PR TITLE
[FE] 홈에서 액션 수정 삭제 바텀시트 활성화 버그

### DIFF
--- a/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
+++ b/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
@@ -27,12 +27,12 @@ const OutMember = ({dynamicProps}: OutMemberProps) => {
 
   return inputList.map(({value, index}) => (
     <Search
+      key={`${value}-${index}`}
       isShowTargetInput={currentInputIndex === index}
       matchItems={filteredInMemberList}
       onMatchItemClick={(term: string) => chooseMember(currentInputIndex, term)}
     >
       <LabelGroupInput.Element
-        key={index}
         elementKey={`${index}`}
         type="text"
         value={value}

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -2,6 +2,7 @@ import type {BillStep} from 'types/serviceType';
 
 import {DragHandleItem, DragHandleItemContainer} from 'haengdong-design';
 import {Fragment, useState} from 'react';
+import {useOutletContext} from 'react-router-dom';
 
 import {PutAndDeleteBillActionModal} from '@components/Modal/SetActionModal/PutAndDeleteBillActionModal';
 
@@ -12,6 +13,7 @@ interface BillStepItemProps {
 }
 
 const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, setIsOpenBottomSheet}) => {
+  const isAdmin = useOutletContext<boolean>();
   const [clickedIndex, setClickedIndex] = useState(-1);
 
   const totalPrice = step.actions.reduce((acc, cur) => acc + cur.price, 0);
@@ -32,13 +34,13 @@ const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, set
       {step.actions.map((action, index) => (
         <Fragment key={action.actionId}>
           <DragHandleItem
-            hasDragHandler={true}
+            hasDragHandler={isAdmin}
             prefix={action.name}
             suffix={`${action.price.toLocaleString('ko-kr')} 원`}
             backgroundColor="lightGrayContainer"
             onClick={() => handleDragHandleItemClick(index)}
           />
-          {isOpenBottomSheet && clickedIndex === index && (
+          {isOpenBottomSheet && clickedIndex === index && isAdmin && (
             <PutAndDeleteBillActionModal
               billAction={action}
               isBottomSheetOpened={isOpenBottomSheet}

--- a/client/src/components/StepList/MemberStepItem.tsx
+++ b/client/src/components/StepList/MemberStepItem.tsx
@@ -1,6 +1,7 @@
 import type {MemberStep} from 'types/serviceType';
 
 import {DragHandleItem} from 'haengdong-design';
+import {useOutletContext} from 'react-router-dom';
 
 import {DeleteMemberActionModal} from '@components/Modal/SetActionModal/DeleteMemberActionModal';
 
@@ -11,14 +12,17 @@ interface MemberStepItemProps {
 }
 
 const MemberStepItem: React.FC<MemberStepItemProps> = ({step, isOpenBottomSheet, setIsOpenBottomSheet}) => {
+  const isAdmin = useOutletContext<boolean>();
+
   return (
     <>
       <DragHandleItem
+        hasDragHandler={isAdmin}
         backgroundColor="white"
         prefix={`${step.actions.map(({name}) => name).join(', ')} ${step.type === 'IN' ? '들어옴' : '나감'}`}
         onClick={() => setIsOpenBottomSheet(prev => !prev)}
       />
-      {isOpenBottomSheet && (
+      {isOpenBottomSheet && isAdmin && (
         <DeleteMemberActionModal
           memberActionType={step.type}
           memberActionList={step.actions}

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -11,7 +11,7 @@ const StepList = () => {
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
       {stepList.map((step, index) => (
-        <Step step={step} key={`${step.stepName}${index}`}></Step>
+        <Step step={step} key={`${step.stepName}${index}`} />
       ))}
     </Flex>
   );

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -1,12 +1,15 @@
 import {MainLayout, TopNav, Switch} from 'haengdong-design';
-import {Outlet} from 'react-router-dom';
+import {Outlet, useMatch} from 'react-router-dom';
 
 import StepListProvider from '@hooks/useStepList/useStepList';
 
 import useNavSwitch from '@hooks/useNavSwitch';
 
+import {ROUTER_URLS} from '@constants/routerUrls';
+
 const EventPageLayout = () => {
   const {nav, paths, onChange} = useNavSwitch();
+  const isAdmin = useMatch(ROUTER_URLS.eventManage) !== null;
 
   return (
     <StepListProvider>
@@ -14,7 +17,7 @@ const EventPageLayout = () => {
         <TopNav>
           <Switch value={nav} values={paths} onChange={onChange} />
         </TopNav>
-        <Outlet />
+        <Outlet context={isAdmin} />
       </MainLayout>
     </StepListProvider>
   );


### PR DESCRIPTION
## issue
- close #284 

## 구현 사항
홈에서 액션 수정 삭제 바텀시트 활성화가 되는 버그를 해결했어요
추가로 불주사도 홈과 관리에 따라서 활성화 변하도록 설정했어요

react-router-dom의 useMatch를 활용해서 isAdmin을 url에 따라서 구분할 수 있도록 설정했어요
EventLayout에서 isAdmin을 구한뒤 outletContext를 통해서 내부 컴포넌트로 값을 전달해줍니다.
내부에서 useOutletContext를 받아서 isAdmin을 사용합니다.


## 🫡 참고사항
지금은 outlet에 isAdmin boolean 값밖에 없지만 추가될 때는 context type을 추가해야합니다.