### PR TITLE
[FE] webpack.dev.mjs에 sentryWebpackPlugin가 import되어있지 않음 

### DIFF
--- a/client/webpack.dev.mjs
+++ b/client/webpack.dev.mjs
@@ -3,6 +3,7 @@ import {merge} from 'webpack-merge';
 import Dotenv from 'dotenv-webpack';
 import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
+import {sentryWebpackPlugin} from '@sentry/webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## issue
- close #292

## 구현 사항
webpack.dev.mjs에 sentryWebpackPlugin를 import합니다.

