### PR TITLE
[BE] actuator health 엔드포인트 설정 변경

### DIFF
--- a/server/src/main/java/server/haengdong/HaengdongApplication.java
+++ b/server/src/main/java/server/haengdong/HaengdongApplication.java
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class HaengdongApplication {
 
     public static void main(String[] args) {
-        log.error("################### 안녕하세요. CI/CD 테스트입니다. ###################");
         SpringApplication.run(HaengdongApplication.class, args);
     }
 

--- a/server/src/main/java/server/haengdong/config/AdminInterceptor.java
+++ b/server/src/main/java/server/haengdong/config/AdminInterceptor.java
@@ -23,7 +23,7 @@ public class AdminInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        log.trace("login request = {}", request.getRequestURI());
+        log.debug("login request = {}", request.getRequestURI());
 
         String requestURI = request.getRequestURI();
 

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -17,25 +17,35 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ErrorResponse> authenticationException(AuthenticationException e) {
+        log.warn(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ErrorResponse.of(e.getErrorCode()));
     }
 
-    @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class})
-    public ResponseEntity<ErrorResponse> noResourceException() {
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> noResourceException(HttpRequestMethodNotSupportedException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(HaengdongErrorCode.REQUEST_METHOD_NOT_SUPPORTED));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> noResourceException(NoResourceFoundException e) {
+        log.warn(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(HaengdongErrorCode.NO_RESOURCE_REQUEST));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> httpMessageNotReadableException() {
+    public ResponseEntity<ErrorResponse> httpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(HaengdongErrorCode.MESSAGE_NOT_READABLE));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.info(e.getMessage(), e);
+        log.warn(e.getMessage(), e);
         String errorMessage = e.getFieldErrors().stream()
                 .map(error -> error.getField() + " " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
@@ -46,7 +56,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HaengdongException.class)
     public ResponseEntity<ErrorResponse> haengdongException(HaengdongException e) {
-        log.info(e.getMessage(), e);
+        log.warn(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(e.getErrorCode()));
     }

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -53,6 +53,7 @@ public enum HaengdongErrorCode {
     /* System */,
 
     MESSAGE_NOT_READABLE("읽을 수 없는 요청입니다."),
+    REQUEST_METHOD_NOT_SUPPORTED("지원하지 않는 요청 메서드입니다."),
     NO_RESOURCE_REQUEST("존재하지 않는 자원입니다."),
     INTERNAL_SERVER_ERROR("서버 내부에서 에러가 발생했습니다.");
 

--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -36,8 +36,6 @@ public class EventController {
 
     @PostMapping("/api/events")
     public ResponseEntity<EventResponse> saveEvent(@Valid @RequestBody EventSaveRequest request) {
-        log.error("################### 안녕하세요. CI/CD 테스트입니다. ###################");
-
         EventResponse eventResponse = EventResponse.of(eventService.saveEvent(request.toAppRequest()));
 
         String jwtToken = authService.createToken(eventResponse.eventId());

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,7 +39,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: logfile, metrics
+        include: health, metrics, logfile
 
 logging:
   level:

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -6,7 +6,8 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} - %msg%n</pattern>
+            <!-- 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식 -->
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## issue
- close #297 

## 구현 사항
- application.yml 설정에 actuator health 엔드포인트를 열어서 개발, 운영 서버가 정상 작동중인지 확인할 수 있도록 했습니다.
- 기존 logback-spring.xml 에 작성되어있던 로그 메세지 패턴을 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식을 볼 수 있도록 변경했습니다. 
- EventController, HaengdongAppliction 클래스에 작성한 테스트용 로그 메세지를 삭제했습니다.
- HaengdongErrorCode에 새로운 에러코드 `REQUEST_METHOD_NOT_SUPPORTED("지원하지 않는 요청 메서드입니다.")`를 추가했습니다. 아래와 같이 노션 API 문서에 반영하였습니다.
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/24aef845-a0ee-438c-b488-90b70c3530b7">

- GlobalExceptionHandler에서 관리하는 핸들러 중 Exception을 제외한 나머지 핸들러의 로깅 레벨을 warn으로 변경했습니다.
- AdminInterceptor prehandle 메서드에 있던 로그 레벨을 trace에서 debug로 변경했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
