### PR TITLE
[BE] yml, Dockerfile TZ Asia/Seoul 적용

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,4 +6,4 @@ COPY /build/libs/*.jar /app/haengdong-0.0.1-SNAPSHOT.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java"]
-CMD ["-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "haengdong-0.0.1-SNAPSHOT.jar"]
+CMD ["-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-Duser.timezone=Asia/Seoul",  "-jar", "haengdong-0.0.1-SNAPSHOT.jar"]

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc.time_zone: Asia/Seoul
     show-sql: true
 
 cors:


### PR DESCRIPTION
## issue
- close #84 

## 구현 사항
- application.yml과 submodule에 들어있는 application-dev.yml, application-prod.yml에`spring.jpa.properties.jdbc.time_zone: Asia/Seoul` 설정을 추가했습니다. 이 설정은 프로퍼티를 추가하여 MySQL 데이터베이스의 Timezone 설정을 변경할 수 있습니다. 특정 database에 의존적이지 않기 때문에 이 방법을 선택했습니다.
- Dockerfile CMD에 java 실행 옵션으로 `-Duser.timezone=Asia/Seoul` 옵션을 추가해서 java 애플리케이션을 kst 시간대로 실행할 수 있도록 수정했습니다.

자바 실행 옵션으로 Asia/Seoul로 실행 했어도, yml에 DB TimeZone이 UTC로 되어있다면, 저장은 UTC 시간대로 저장됩니다.
그렇기 때문에 자바 실행 옵션과 MySQL 데이터베이스 TimeZone 설정을 일치시켜야 시간대 불일치 없이 저장됩니다.

---

> 로그에 시간도 현재 시간으로 잘 찍히는지 궁금합니다.

### java 실행 옵션으로 시간대를 설정

1. UTC 시간대 설정
`java -Duser.timezone=UTC -jar haengdong-0.0.1-SNAPSHOT.jar` 
<img width="603" alt="image" src="https://github.com/user-attachments/assets/dfda0b2e-b6d3-4483-a774-b1b98cc1df5f">

<img width="712" alt="image" src="https://github.com/user-attachments/assets/ca107b6a-7cbd-44a9-bf8d-592641fd889a">

<img width="574" alt="image" src="https://github.com/user-attachments/assets/83392d22-c458-4d4e-9745-b6fd8f7afa93">


---

2. Asia/Seoul 시간대 설정
`java -Duser.timezone=Asia/Seoul -jar haengdong-0.0.1-SNAPSHOT.jar `
<img width="609" alt="image" src="https://github.com/user-attachments/assets/76e08dd2-12af-4293-a2b2-e9fbe9fee50b">

<img width="711" alt="image" src="https://github.com/user-attachments/assets/8087ea9e-9d41-4630-b386-79cce6c97db2">

<img width="572" alt="image" src="https://github.com/user-attachments/assets/7f501740-53fb-4427-85f0-b13fcadf2a7d">



보시는 바와 같이 설정에 따라 시간대가 잘 설정된 것을 볼 수 있습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
