### PR TITLE
[FE] BottomSheet component width 수정

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.66",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.66",
+      "version": "0.1.68",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.66",
+  "version": "0.1.68",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/BottomSheet/BottomSheet.style.ts
+++ b/HDesign/src/components/BottomSheet/BottomSheet.style.ts
@@ -9,10 +9,12 @@ export const display = (visible: boolean) =>
 
 export const dimmedLayerStyle = (theme: Theme, isOpened: boolean) =>
   css({
-    // TODO: (@todari) zindex foundation
     position: 'fixed',
     zIndex: '30',
-    inset: '0',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    maxWidth: '768px',
     width: '100vw',
     height: '100vh',
     backgroundColor: theme.colors.black,
@@ -30,13 +32,14 @@ export const bottomSheetContainerStyle = (theme: Theme, isOpened: boolean, isDra
     alignItems: 'center',
     gap: '1.5rem',
     zIndex: '50',
-    inset: 'auto 0 0 0',
+    inset: 'auto 0 0 50%',
+    maxWidth: '768px',
     width: '100%',
     height: '80%',
     borderRadius: '1.5rem 1.5rem 0 0',
     backgroundColor: theme.colors.white,
 
-    transform: isOpened ? `translateY(${translateY}px)` : 'translateY(100%)',
+    transform: isOpened ? `translate(-50%, ${translateY}px)` : 'translate(-50%, 100%)',
     transition: isDragging ? 'none' : 'transform 0.2s ease-in-out',
   });
 


### PR DESCRIPTION
## issue
- close #317 

## 기존 구현 사항
![image](https://github.com/user-attachments/assets/48eedc2b-7c41-42f0-a9e4-f8e8a90c5a35)

전체 app의 maxWidth는 768px로 고정되어 있었지만,
bottomSheet가 보일 때, 이를 넘어서 전체 화면의 너비만큼 출력되었음.

## 변경 구현 사항
![image](https://github.com/user-attachments/assets/15b191f3-3e44-4484-bdad-1a0813e58bce)

768px이 넘을 경우, 최대 너비만큼만의 영역이 생기게끔 변경함.

## 논의하고 싶은 부분(선택)
이렇게 만들 경우, 만약 우리 앱의 최대 너비가 768px에서 다른 너비로 변경되어야 할 때,
이 부분을 또 수정해 줘야 할 필요가 있음.
직접 선언해 주는게 아니라, client 단에서 사용하기 쉽게 prop을 받아야 하는것이 맞을까?
그런데, prop을 받는다고 한다면 오히려 사용하는 모든 곳에서 prop 으로 768px을 전달해 줘야 함.

어떤 방법이 좋을지 궁금하네요

## 🫡 참고사항
