### PR TITLE
[FE] 이벤트 페이지 새로고침 시 이벤트 이름이 삭제됐다가 추가되는 버그

### DIFF
--- a/client/src/hooks/loader/getEventId.ts
+++ b/client/src/hooks/loader/getEventId.ts
@@ -1,0 +1,13 @@
+const extractIdFromUrl = (url: string) => {
+  const regex = /\/event\/([a-zA-Z0-9-]+)\//;
+  const match = url.match(regex);
+  return match ? match[1] : null;
+};
+
+const getEventId = () => {
+  const eventId = extractIdFromUrl(window.location.pathname) ?? '';
+
+  return eventId;
+};
+
+export default getEventId;

--- a/client/src/hooks/loader/getEventIdAndName.ts
+++ b/client/src/hooks/loader/getEventIdAndName.ts
@@ -1,0 +1,13 @@
+import type {EventIdAndName} from 'types/serviceType';
+
+import getEventId from './getEventId';
+import getEventName from './getEventName';
+
+const getEventIdAndName = async (): Promise<EventIdAndName> => {
+  const eventId = getEventId();
+  const eventName = await getEventName(eventId);
+
+  return {eventId, eventName};
+};
+
+export default getEventIdAndName;

--- a/client/src/hooks/loader/getEventName.ts
+++ b/client/src/hooks/loader/getEventName.ts
@@ -1,0 +1,9 @@
+import {requestGetEventName} from '@apis/request/event';
+
+const getEventName = async (eventId: string) => {
+  const {eventName} = await requestGetEventName({eventId});
+
+  return eventName;
+};
+
+export default getEventName;

--- a/client/src/hooks/loader/index.ts
+++ b/client/src/hooks/loader/index.ts
@@ -1,0 +1,1 @@
+export {default as getEventIdAndName} from './getEventIdAndName';

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -1,13 +1,14 @@
+import type {EventIdAndName} from 'types/serviceType';
+
 import {useEffect, useState} from 'react';
 import {Title, FixedButton, ListButton} from 'haengdong-design';
-import {useNavigate} from 'react-router-dom';
+import {useLoaderData, useNavigate} from 'react-router-dom';
 
 import StepList from '@components/StepList/StepList';
 import {requestGetEventName} from '@apis/request/event';
 import {ModalBasedOnMemberCount} from '@components/Modal/index';
 
 import {useStepList} from '@hooks/useStepList';
-import useEventId from '@hooks/useEventId';
 import useAuth from '@hooks/useAuth';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
@@ -18,17 +19,14 @@ const AdminPage = () => {
   const [isOpenFixedButtonBottomSheet, setIsOpenFixedBottomBottomSheet] = useState(false);
   const [isOpenAllMemberListButton, setIsOpenAllMemberListButton] = useState(false);
 
-  // TODO: (@weadie) eventName이 새로고침시 공간이 없다가 생겨나 레이아웃이 움직이는 문제
-  const [eventName, setEventName] = useState(' ');
+  const {eventId, eventName} = useLoaderData() as EventIdAndName;
+
   const {getTotalPrice, allMemberList} = useStepList();
-  const {eventId} = useEventId();
   const {postAuthentication} = useAuth();
   const navigate = useNavigate();
 
   // TODO: (@weadie) 아래 로직을 훅으로 분리합니다.
   useEffect(() => {
-    if (eventId === '') return;
-
     const postAuth = async () => {
       try {
         await postAuthentication({eventId: eventId});
@@ -38,14 +36,7 @@ const AdminPage = () => {
       }
     };
 
-    const getEventName = async () => {
-      const {eventName} = await requestGetEventName({eventId: eventId});
-
-      setEventName(eventName);
-    };
-
     postAuth();
-    getEventName();
   }, [eventId]);
 
   const handleOpenAllMemberListButton = () => {

--- a/client/src/pages/EventPage/HomePage/HomePage.tsx
+++ b/client/src/pages/EventPage/HomePage/HomePage.tsx
@@ -1,31 +1,17 @@
+import type {EventIdAndName} from 'types/serviceType';
+
 import {Tab, Tabs, Title} from 'haengdong-design';
-import {useEffect, useState} from 'react';
+import {useLoaderData} from 'react-router-dom';
 
 import MemberReportList from '@components/MemberReportList/MemberReportList';
 import StepList from '@components/StepList/StepList';
-import {requestGetEventName} from '@apis/request/event';
 
 import {useStepList} from '@hooks/useStepList';
-import useEventId from '@hooks/useEventId';
 
 const HomePage = () => {
   const {getTotalPrice} = useStepList();
-  const {eventId} = useEventId();
 
-  // TODO: (@soha) 행사 이름 나중에 따로 분리해야 함
-  const [eventName, setEventName] = useState(' ');
-
-  useEffect(() => {
-    if (eventId === '') return;
-
-    const getEventName = async () => {
-      const {eventName} = await requestGetEventName({eventId: eventId ?? ''});
-
-      setEventName(eventName);
-    };
-
-    getEventName();
-  }, [eventId]);
+  const {eventName} = useLoaderData() as EventIdAndName;
 
   return (
     <div>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -6,6 +6,8 @@ import ErrorPage from '@pages/ErrorPage/ErrorPage';
 import SetEventPasswordPage from '@pages/CreateEventPage/SetEventPasswordPage';
 import EventLoginPage from '@pages/EventPage/AdminPage/EventLoginPage';
 
+import {getEventIdAndName} from '@hooks/loader';
+
 import {CompleteCreateEventPage, SetEventNamePage} from '@pages/CreateEventPage';
 import {MainPage} from '@pages/MainPage';
 import {EventPage} from '@pages/EventPage';
@@ -43,9 +45,14 @@ const router = createBrowserRouter([
       {
         path: ROUTER_URLS.event,
         element: <EventPage />,
+
         children: [
-          {path: ROUTER_URLS.eventManage, element: <AdminPage />},
-          {path: ROUTER_URLS.home, element: <HomePage />},
+          {path: ROUTER_URLS.eventManage, element: <AdminPage />, loader: getEventIdAndName},
+          {
+            path: ROUTER_URLS.home,
+            element: <HomePage />,
+            loader: getEventIdAndName,
+          },
         ],
       },
       {

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -2,6 +2,11 @@ export type MemberType = 'IN' | 'OUT';
 
 export type InOutType = '늦참' | '탈주';
 
+export type EventIdAndName = {
+  eventName: string;
+  eventId: string;
+};
+
 export type MemberReport = {
   name: string;
   price: number;


### PR DESCRIPTION
## issue
- close #325 

## 구현 사항
이벤트 페이지 새로고침 시 이벤트 이름이 삭제됐다가 추가되는 버그를 잡았습니다.

https://github.com/user-attachments/assets/eaf61dc0-e035-4c0e-8685-5f82e80dc17d

지금 구현은 AdminPage, HomePage가 마운트 된 후 useEventId에서 eventId를 받아온 후 useEffect에서 name을 받아옵니다. 그래서 eventId와 name이 없을 때까지 빈 공간으로 보여서 이슈 동영상과 같은 버그가 발생합니다.

그래서 제 구현방식은 AdminPage, HomePage가 마운트 되기 전 id와 name을 불러와서 컴포넌트에 값을 넣어주는 방식입니다. 

이를 구현하기 위해 react-router-dom v6의 loader를 사용했습니다.
loader 기능을 사용하게 되면 router에 맞는 컴포넌트가 마운트 되기 전에 미리 데이터를 받아와서 마운트 될 때 불러온 값을 넣어줄 수 있습니다. 그래서 컴포넌트가 마운트 될 때 항상 데이터가 있기 때문에, 데이터가 없어서 빈 공간으로 보이는 버그를 해결할 수 있습니다.

[react-router-dom v6 loader reference](https://velog.io/@sanghyeon/React-Router-loader-%EC%9D%B4%EC%9A%A9%ED%95%98%EA%B8%B0)

router.tsx
```ts
{
    path: ROUTER_URLS.home,
    element: <HomePage />,
    loader: getEventIdAndName,
},
```

하지만 이벤트 아이디가 잘못된 경우 에러가 발생할 때 이 때 errorElement를 따로 넣어주어야 합니다. loader는 훅이 아니라 일반 함수이기 때문에 useToast 방식으로는 보여줄 수 없습니다.
이에 대한 대책은 추후에 필요합니다.

## 논의하고 싶은 부분(선택)
useLoaderData()의 타입 단언을 해야 typescript에서 사용할 수 있더라구요
이 문제를 해결하려면 [react-router-typesafe](https://github.com/fredericoo/react-router-typesafe) 을 설치해서 해결할 수 있다고 해요.
[reference](https://velog.io/@bangdori/Mere-%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-%EB%A7%88%EC%9D%B4%EA%B7%B8%EB%A0%88%EC%9D%B4%EC%85%98-%EB%8F%84%EC%A4%91-%EB%B0%9C%EC%83%9D%ED%95%9C-useLoaderData-%ED%83%80%EC%9E%85-%EC%A7%80%EC%A0%95%ED%95%98%EA%B8%B0)

아직 설치해서 테스트는 안 해봤습니다..

## 🫡 참고사항
