### PR TITLE
[FE] 인원 탈주 추가 시 disable 버그

### DIFF
--- a/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
+++ b/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
@@ -15,10 +15,10 @@ const OutMember = ({dynamicProps}: OutMemberProps) => {
     deleteEmptyInputElementOnBlur,
     focusNextInputOnEnter,
     handleInputChange,
-    setInputValueTargetIndex,
+    validateAndSetTargetInput,
   } = dynamicProps;
   const {currentInputIndex, filteredInMemberList, handleCurrentInputIndex, searchCurrentInMember, chooseMember} =
-    useSearchInMemberList(setInputValueTargetIndex);
+    useSearchInMemberList(validateAndSetTargetInput);
 
   const validationAndSearchOnChange = (inputIndex: number, event: React.ChangeEvent<HTMLInputElement>) => {
     handleCurrentInputIndex(inputIndex);

--- a/client/src/hooks/useSearchInMemberList.ts
+++ b/client/src/hooks/useSearchInMemberList.ts
@@ -15,7 +15,7 @@ export type ReturnUseSearchInMemberList = {
 };
 
 const useSearchInMemberList = (
-  setInputValueTargetIndex: (index: number, value: string) => void,
+  validateAndSetTargetInput: (index: number, value: string) => void,
 ): ReturnUseSearchInMemberList => {
   const {eventId} = useEventId();
 
@@ -51,7 +51,7 @@ const useSearchInMemberList = (
 
   const chooseMember = (inputIndex: number, name: string) => {
     setFilteredInMemberList([]);
-    setInputValueTargetIndex(inputIndex, name);
+    validateAndSetTargetInput(inputIndex, name);
   };
 
   const searchCurrentInMember = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## issue
- close #337 

## 구현 사항
입력에 따라서 간헐적으로 can submit이 적절하게 반영되지 않았던 현상 해결했어요

https://github.com/user-attachments/assets/b95d65f8-f825-4e4a-958e-fa32a28bae43

버그의 원인은 크게 2가지가 있습니다.

1. 검색어 클릭 시 단순 set만 실행했고 validate 로직이 실행되지 않았습니다. 그래서 validate 로직을 돌아가게 하기 위해 handleInputChange 함수에서 validate 로직을 분리했어요

2. can submit 호출 시점을 변경했습니다. 이전의 can submit 함수는 input이 change되자마자 실행됩니다. 하지만 can submit을 판별하는 로직은 state에 의존합니다. 그래서 아직 setter가 반영이 되기 전에 can submit 함수가 돌아가게 되어 최신 상태의 submit 상태를 판별할 수 없었습니다. 그래서 input state가 반영된 시점에 can submit을 실행할 수 있도록 useEffect를 이용했습니다.

이건 사소한 것이지만 can submit 로직에 errorIndexList가 비어있는지도 체크하게 했습니다. 에러가 없었을 때 submit이 가능해야 한다고 생각해서 추가했어요!

두 가지를 고치고 다른 dynamic input 사용처에 영향을 끼치는지 확인해본 결과 버그는 없었는데 혹시나 문제 생기면 어디서 생겼는지 알려주시면 해결해볼게요..!

## 🫡 참고사항
추가로 첫 번째 입력했을 때 동적으로 칸이 생기는 것은 validate 로직과는 크게 상관이 없어 보입니다. 그래서 별도의 함수로 분리했어요. makeNewInputWhenFirstCharacterInput

그래서 handleInputChange는 이벤트에서 값을 받아서 첫 번째 입력이면 다음 칸을 만들고 validate 후 값을 set하는 함수로 리팩토링을 했습니다. 
