### PR TITLE
[FE] Sentry prod 환경에서만 돌아가도록 fetcher 설정

### DIFF
--- a/client/src/apis/useFetch.ts
+++ b/client/src/apis/useFetch.ts
@@ -45,17 +45,10 @@ export const useFetch = () => {
           onError();
         }
 
-        // prod 환경에서만 Sentry capture 실행
-        if (process.env.NODE_ENV === 'production') {
-          captureError(error, navigate, eventId);
-        }
+        captureError(error, navigate, eventId);
       } else {
         setError({errorCode: UNKNOWN_ERROR, message: JSON.stringify(error)});
-
-        // prod 환경에서만 Sentry capture 실행
-        if (process.env.NODE_ENV === 'production') {
-          captureError(new Error(UNKNOWN_ERROR), navigate, eventId);
-        }
+        captureError(new Error(UNKNOWN_ERROR), navigate, eventId);
 
         // 에러를 throw 해 에러 바운더리로 보냅니다. 따라서 에러 이름은 중요하지 않음
         throw new Error(UNKNOWN_ERROR);
@@ -71,6 +64,9 @@ export const useFetch = () => {
 };
 
 const captureError = async (error: Error, navigate: NavigateFunction, eventId: string) => {
+  // prod 환경에서만 Sentry capture 실행
+  if (process.env.NODE_ENV !== 'production') return;
+
   const errorBody: ServerError =
     error instanceof FetchError ? error.errorBody : {message: error.message, errorCode: error.name};
 

--- a/client/src/apis/useFetch.ts
+++ b/client/src/apis/useFetch.ts
@@ -45,10 +45,17 @@ export const useFetch = () => {
           onError();
         }
 
-        captureError(error, navigate, eventId);
+        // prod 환경에서만 Sentry capture 실행
+        if (process.env.NODE_ENV === 'production') {
+          captureError(error, navigate, eventId);
+        }
       } else {
         setError({errorCode: UNKNOWN_ERROR, message: JSON.stringify(error)});
-        captureError(new Error(UNKNOWN_ERROR), navigate, eventId);
+
+        // prod 환경에서만 Sentry capture 실행
+        if (process.env.NODE_ENV === 'production') {
+          captureError(new Error(UNKNOWN_ERROR), navigate, eventId);
+        }
 
         // 에러를 throw 해 에러 바운더리로 보냅니다. 따라서 에러 이름은 중요하지 않음
         throw new Error(UNKNOWN_ERROR);

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,1 +1,7 @@
 declare module '*.svg';
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly NODE_ENV: 'development' | 'production' | 'test';
+  }
+}


### PR DESCRIPTION
## issue
- close #342 

## 구현 사항
Sentry CaptureError를 배포 환경에서만 실행되도록 설정했습니다.
Sentry는 배포 환경에서 사용자가 우리 프로그램을 이용하면서 발생한 에러를 알려주는 기능이므로 개발환경에서는 필요 없기 때문이에요

그래서 배포 환경과 개발 환경의 구분이 필요했고, global.d.ts에 아래 코드를 추가했습니다

```ts
declare namespace NodeJS {
  interface ProcessEnv {
    readonly NODE_ENV: 'development' | 'production' | 'test';
  }
}
```

process.env.NODE_ENV를 하게 되면 타입 추론이 string | undefined으로 나오게 되는데
위 같이 선언을 해주게 되면 'development' | 'production' | 'test' 세 가지로 타입이 추론됩니다.
그래서 사용 측에서 undefined를 생각해주지 않아도 되기 때문에 위를 추가했어요.

그리고 추가로 env에 있는 key도 위에 추가를 해주면 env의 값이 없을 때 빈 문자열로 만들어서 string으로 타입을 맞춰주는 작업을 하지 않아도 가능해요!

그래서 다음 이슈로 그것을 리팩토링해서 올릴게요

Sentry를 배포 환경에서만 돌리도록 한 코드는 이렇게입니다.

```ts
if (process.env.NODE_ENV === 'production') {
    captureError(error, navigate, eventId);
}
```

## 🫡 참고사항
