### PR TITLE
[FE] 환경 변수 타입 선언

### DIFF
--- a/client/src/apis/baseUrl.ts
+++ b/client/src/apis/baseUrl.ts
@@ -1,3 +1,3 @@
 export const BASE_URL = {
-  HD: process.env.API_BASE_URL ?? '',
+  HD: process.env.API_BASE_URL,
 };

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,1 +1,11 @@
 declare module '*.svg';
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly NODE_ENV: 'development' | 'production' | 'test';
+
+    // env keys
+    readonly API_BASE_URL: string;
+    readonly AMPLITUDE_KEY: string;
+  }
+}

--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -6,6 +6,8 @@ import {css} from '@emotion/react';
 
 import {useToast} from '@components/Toast/ToastProvider';
 
+import getEventPageUrlByEnvironment from '@utils/getEventPageUrlByEnvironment';
+
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 const CompleteCreateEventPage = () => {
@@ -26,8 +28,7 @@ const CompleteCreateEventPage = () => {
 
   const {showToast} = useToast();
 
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  const homeUrlByEnvironment = `https://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${url}/home`;
+  const homePageUrl = getEventPageUrlByEnvironment(url, 'home');
 
   return (
     <MainLayout>
@@ -41,10 +42,10 @@ const CompleteCreateEventPage = () => {
           <Text textColor="gray">링크가 없으면 페이지에 접근할 수 없어요.</Text>
           <Text textColor="primary">관리를 위해서 행사 링크를 복사 후 보관해 주세요.</Text>
         </Flex>
-        <Input value={homeUrlByEnvironment} disabled />
+        <Input value={homePageUrl} disabled />
 
         <CopyToClipboard
-          text={homeUrlByEnvironment}
+          text={homePageUrl}
           onCopy={() =>
             showToast({
               showingTime: 3000,

--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -26,8 +26,8 @@ const CompleteCreateEventPage = () => {
 
   const {showToast} = useToast();
 
-  const env = process.env.NODE_ENV || '';
-  const homeUrlByEnvironment = `https://${env.includes('development') ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${url}/home`;
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const homeUrlByEnvironment = `https://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${url}/home`;
 
   return (
     <MainLayout>

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -45,7 +45,7 @@ const EventPageLayout = () => {
 
   const {showToast} = useToast();
 
-  const env = process.env.NODE_ENV || '';
+  const isDevelopment = process.env.NODE_ENV === 'development';
 
   return (
     <StepListProvider>
@@ -53,7 +53,7 @@ const EventPageLayout = () => {
         <TopNav>
           <Switch value={nav} values={paths} onChange={onChange} />
           <CopyToClipboard
-            text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\nhttps://${env.includes('development') ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/home`}
+            text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\nhttps://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/home`}
             onCopy={() =>
               showToast({
                 showingTime: 3000,

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -10,6 +10,7 @@ import useNavSwitch from '@hooks/useNavSwitch';
 import StepListProvider from '@hooks/useStepList';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
+import getEventPageUrlByEnvironment from '@utils/getEventPageUrlByEnvironment';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
 
@@ -44,8 +45,7 @@ const EventPageLayout = () => {
   };
 
   const {showToast} = useToast();
-
-  const isDevelopment = process.env.NODE_ENV === 'development';
+  const url = getEventPageUrlByEnvironment(eventId, 'home');
 
   return (
     <StepListProvider>
@@ -53,7 +53,7 @@ const EventPageLayout = () => {
         <TopNav>
           <Switch value={nav} values={paths} onChange={onChange} />
           <CopyToClipboard
-            text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\nhttps://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/home`}
+            text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\n${url}`}
             onCopy={() =>
               showToast({
                 showingTime: 3000,

--- a/client/src/utils/getEventPageUrlByEnvironment.ts
+++ b/client/src/utils/getEventPageUrlByEnvironment.ts
@@ -1,0 +1,11 @@
+import {ROUTER_URLS} from '@constants/routerUrls';
+
+type EventPageTab = 'home' | 'admin';
+
+const getEventPageUrlByEnvironment = (eventId: string, tab: EventPageTab) => {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  return `https://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/${tab}`;
+};
+
+export default getEventPageUrlByEnvironment;


### PR DESCRIPTION
## issue
- close #344 

## 구현 사항
env 환경 변수에 대한 타입을 정의해줬습니다.

```ts
declare namespace NodeJS {
  interface ProcessEnv {
    readonly NODE_ENV: 'development' | 'production' | 'test';

    // env keys
    readonly API_BASE_URL: string;
    readonly AMPLITUDE_KEY: string;
  }
}
```

이렇게 적용했을 때 process.env.API_BASE_URL의 타입은 string | undefined가 아닌 string입니다.

## 🫡 참고사항
