### PR TITLE
[FE] useDeleteMemberAction 토스트 함수 결합도 제거

### DIFF
--- a/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
@@ -23,16 +23,7 @@ const DeleteMemberActionModal = ({
 }: DeleteMemberActionModalProps) => {
   const {showToast} = useToast();
 
-  const {aliveActionList, deleteMemberActionList, addDeleteMemberAction, isExistSameMemberFromAfterStep} =
-    useDeleteMemberAction(memberActionList, setIsBottomSheetOpened);
-
-  const onDeleteIconClick = (member: MemberAction) => {
-    alertSpecificCaseFromAddDeleteMember(member);
-    addDeleteMemberAction(member);
-  };
-
-  // 삭제버튼 누를 때 특수한 케이스이면 토스트를 띄우는 기능
-  const alertSpecificCaseFromAddDeleteMember = (memberAction: MemberAction) => {
+  const checkAlreadyExistMemberAction = (memberAction: MemberAction) => {
     if (!memberActionList.includes(memberAction)) {
       showToast({
         isClickToClose: true,
@@ -43,7 +34,12 @@ const DeleteMemberActionModal = ({
       });
       return;
     }
+  };
 
+  const checkExistSameMemberFromAfterStep = (
+    memberAction: MemberAction,
+    isExistSameMemberFromAfterStep: (memberAction: MemberAction) => boolean,
+  ) => {
     if (isExistSameMemberFromAfterStep(memberAction)) {
       showToast({
         isClickToClose: true,
@@ -59,6 +55,13 @@ const DeleteMemberActionModal = ({
     }
   };
 
+  const {aliveActionList, deleteMemberActionList, addDeleteMemberAction} = useDeleteMemberAction({
+    memberActionList,
+    setIsBottomSheetOpened,
+    checkAlreadyExistMemberAction,
+    checkExistSameMemberFromAfterStep,
+  });
+
   return (
     <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
       <div css={bottomSheetStyle}>
@@ -73,7 +76,7 @@ const DeleteMemberActionModal = ({
                 <div style={{flexGrow: 1}}>
                   <Input disabled key={`${member.actionId}`} type="text" style={{flexGrow: 1}} value={member.name} />
                 </div>
-                <IconButton size="medium" variants="tertiary" onClick={() => onDeleteIconClick(member)}>
+                <IconButton size="medium" variants="tertiary" onClick={() => addDeleteMemberAction(member)}>
                   <Icon iconType="trash" iconColor="onTertiary" />
                 </IconButton>
               </Flex>

--- a/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
@@ -23,43 +23,35 @@ const DeleteMemberActionModal = ({
 }: DeleteMemberActionModalProps) => {
   const {showToast} = useToast();
 
-  const checkAlreadyExistMemberAction = (memberAction: MemberAction) => {
-    if (!memberActionList.includes(memberAction)) {
-      showToast({
-        isClickToClose: true,
-        showingTime: 3000,
-        message: '이미 삭제된 인원입니다.',
-        type: 'error',
-        bottom: '160px',
-      });
-      return;
-    }
+  const showToastAlreadyExistMemberAction = () => {
+    showToast({
+      isClickToClose: true,
+      showingTime: 3000,
+      message: '이미 삭제된 인원입니다.',
+      type: 'error',
+      bottom: '160px',
+    });
   };
 
-  const checkExistSameMemberFromAfterStep = (
-    memberAction: MemberAction,
-    isExistSameMemberFromAfterStep: (memberAction: MemberAction) => boolean,
-  ) => {
-    if (isExistSameMemberFromAfterStep(memberAction)) {
-      showToast({
-        isClickToClose: true,
-        showingTime: 3000,
-        message: `이후의 ${memberAction.name}가 사라져요`,
-        type: 'error',
-        position: 'top',
-        top: '30px',
-        style: {
-          zIndex: 9000,
-        },
-      });
-    }
+  const showToastExistSameMemberFromAfterStep = (name: string) => {
+    showToast({
+      isClickToClose: true,
+      showingTime: 3000,
+      message: `이후의 ${name}가 사라져요`,
+      type: 'error',
+      position: 'top',
+      top: '30px',
+      style: {
+        zIndex: 9000,
+      },
+    });
   };
 
   const {aliveActionList, deleteMemberActionList, addDeleteMemberAction} = useDeleteMemberAction({
     memberActionList,
     setIsBottomSheetOpened,
-    checkAlreadyExistMemberAction,
-    checkExistSameMemberFromAfterStep,
+    showToastAlreadyExistMemberAction,
+    showToastExistSameMemberFromAfterStep,
   });
 
   return (

--- a/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/DeleteMemberActionModal/DeleteMemberActionModal.tsx
@@ -2,6 +2,8 @@ import type {MemberAction, MemberType} from 'types/serviceType';
 
 import {BottomSheet, Flex, Input, Text, IconButton, FixedButton, Icon} from 'haengdong-design';
 
+import {useToast} from '@components/Toast/ToastProvider';
+
 import useDeleteMemberAction from '@hooks/useDeleteMemberAction';
 
 import {bottomSheetHeaderStyle, bottomSheetStyle, inputGroupStyle} from './DeleteMemberActionModal.style';
@@ -19,10 +21,43 @@ const DeleteMemberActionModal = ({
   isBottomSheetOpened,
   setIsBottomSheetOpened,
 }: DeleteMemberActionModalProps) => {
-  const {aliveActionList, deleteMemberActionList, addDeleteMemberAction} = useDeleteMemberAction(
-    memberActionList,
-    setIsBottomSheetOpened,
-  );
+  const {showToast} = useToast();
+
+  const {aliveActionList, deleteMemberActionList, addDeleteMemberAction, isExistSameMemberFromAfterStep} =
+    useDeleteMemberAction(memberActionList, setIsBottomSheetOpened);
+
+  const onDeleteIconClick = (member: MemberAction) => {
+    alertSpecificCaseFromAddDeleteMember(member);
+    addDeleteMemberAction(member);
+  };
+
+  // 삭제버튼 누를 때 특수한 케이스이면 토스트를 띄우는 기능
+  const alertSpecificCaseFromAddDeleteMember = (memberAction: MemberAction) => {
+    if (!memberActionList.includes(memberAction)) {
+      showToast({
+        isClickToClose: true,
+        showingTime: 3000,
+        message: '이미 삭제된 인원입니다.',
+        type: 'error',
+        bottom: '160px',
+      });
+      return;
+    }
+
+    if (isExistSameMemberFromAfterStep(memberAction)) {
+      showToast({
+        isClickToClose: true,
+        showingTime: 3000,
+        message: `이후의 ${memberAction.name}가 사라져요`,
+        type: 'error',
+        position: 'top',
+        top: '30px',
+        style: {
+          zIndex: 9000,
+        },
+      });
+    }
+  };
 
   return (
     <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
@@ -38,7 +73,7 @@ const DeleteMemberActionModal = ({
                 <div style={{flexGrow: 1}}>
                   <Input disabled key={`${member.actionId}`} type="text" style={{flexGrow: 1}} value={member.name} />
                 </div>
-                <IconButton size="medium" variants="tertiary" onClick={() => addDeleteMemberAction(member)}>
+                <IconButton size="medium" variants="tertiary" onClick={() => onDeleteIconClick(member)}>
                   <Icon iconType="trash" iconColor="onTertiary" />
                 </IconButton>
               </Flex>

--- a/client/src/hooks/useDeleteMemberAction.tsx
+++ b/client/src/hooks/useDeleteMemberAction.tsx
@@ -2,7 +2,6 @@ import type {MemberAction} from 'types/serviceType';
 
 import {useState} from 'react';
 
-import {useToast} from '@components/Toast/ToastProvider';
 import {requestDeleteMemberAction} from '@apis/request/member';
 
 import {useStepList} from '@hooks/useStepList';
@@ -18,7 +17,6 @@ const useDeleteMemberAction = (
   const {stepList, refreshStepList} = useStepList();
   const [aliveActionList, setAliveActionList] = useState<MemberAction[]>(memberActionList);
   const eventId = getEventIdByUrl();
-  const {showToast} = useToast();
   const {fetch} = useFetch();
 
   const deleteMemberAction = async (actionId: number) => {
@@ -47,35 +45,11 @@ const useDeleteMemberAction = (
   };
 
   const addDeleteMemberAction = (memberAction: MemberAction) => {
-    if (!memberActionList.includes(memberAction)) {
-      showToast({
-        isClickToClose: true,
-        showingTime: 3000,
-        message: '이미 삭제된 인원입니다.',
-        type: 'error',
-        bottom: '160px',
-      });
-      return;
-    }
-
-    if (isExistSameMemberFromAfterStep(memberAction)) {
-      showToast({
-        isClickToClose: true,
-        showingTime: 3000,
-        message: `이후의 ${memberAction.name}가 사라져요`,
-        type: 'error',
-        position: 'top',
-        top: '30px',
-        style: {
-          zIndex: 9000,
-        },
-      });
-    }
-
     setAliveActionList(prev => prev.filter(aliveMember => aliveMember.actionId !== memberAction.actionId));
   };
 
   // 현재 선택된 액션의 인덱스를 구해서 뒤의 동일인물의 액션이 있는지를 파악하는 기능
+  // 논의 후 제거 여부 결정
   const isExistSameMemberFromAfterStep = (memberAction: MemberAction) => {
     const memberActionList = stepList
       .filter(step => step.type !== 'BILL')
@@ -88,7 +62,7 @@ const useDeleteMemberAction = (
     return memberNameList.filter(member => member === memberAction.name).length >= 2;
   };
 
-  return {aliveActionList, deleteMemberActionList, addDeleteMemberAction};
+  return {aliveActionList, deleteMemberActionList, addDeleteMemberAction, isExistSameMemberFromAfterStep};
 };
 
 export default useDeleteMemberAction;

--- a/client/src/hooks/useDeleteMemberAction.tsx
+++ b/client/src/hooks/useDeleteMemberAction.tsx
@@ -13,18 +13,15 @@ import getEventIdByUrl from '@utils/getEventIdByUrl';
 type UseDeleteMemberActionProps = {
   memberActionList: MemberAction[];
   setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>;
-  checkAlreadyExistMemberAction: (memberAction: MemberAction) => void;
-  checkExistSameMemberFromAfterStep: (
-    memberAction: MemberAction,
-    isExistSameMemberFromAfterStep: (memberAction: MemberAction) => boolean,
-  ) => void;
+  showToastAlreadyExistMemberAction: () => void;
+  showToastExistSameMemberFromAfterStep: (name: string) => void;
 };
 
 const useDeleteMemberAction = ({
   memberActionList,
   setIsBottomSheetOpened,
-  checkAlreadyExistMemberAction,
-  checkExistSameMemberFromAfterStep,
+  showToastAlreadyExistMemberAction,
+  showToastExistSameMemberFromAfterStep,
 }: UseDeleteMemberActionProps) => {
   const {stepList, refreshStepList} = useStepList();
   const [aliveActionList, setAliveActionList] = useState<MemberAction[]>(memberActionList);
@@ -56,9 +53,21 @@ const useDeleteMemberAction = ({
     }
   };
 
+  const checkAlreadyExistMemberAction = (memberAction: MemberAction, showToast: () => void) => {
+    if (!memberActionList.includes(memberAction)) {
+      showToast();
+    }
+  };
+
+  const checkExistSameMemberFromAfterStep = (memberAction: MemberAction, showToast: () => void) => {
+    if (isExistSameMemberFromAfterStep(memberAction)) {
+      showToast();
+    }
+  };
+
   const addDeleteMemberAction = (memberAction: MemberAction) => {
-    checkAlreadyExistMemberAction(memberAction);
-    checkExistSameMemberFromAfterStep(memberAction, isExistSameMemberFromAfterStep);
+    checkAlreadyExistMemberAction(memberAction, showToastAlreadyExistMemberAction);
+    checkExistSameMemberFromAfterStep(memberAction, () => showToastExistSameMemberFromAfterStep(memberAction.name));
     setAliveActionList(prev => prev.filter(aliveMember => aliveMember.actionId !== memberAction.actionId));
   };
 

--- a/client/src/hooks/useDeleteMemberAction.tsx
+++ b/client/src/hooks/useDeleteMemberAction.tsx
@@ -71,8 +71,6 @@ const useDeleteMemberAction = ({
     setAliveActionList(prev => prev.filter(aliveMember => aliveMember.actionId !== memberAction.actionId));
   };
 
-  // 현재 선택된 액션의 인덱스를 구해서 뒤의 동일인물의 액션이 있는지를 파악하는 기능
-  // 논의 후 제거 여부 결정
   const isExistSameMemberFromAfterStep = (memberAction: MemberAction) => {
     const memberActionList = stepList
       .filter(step => step.type !== 'BILL')

--- a/client/src/hooks/useDeleteMemberAction.tsx
+++ b/client/src/hooks/useDeleteMemberAction.tsx
@@ -10,10 +10,22 @@ import {useFetch} from '@apis/useFetch';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
-const useDeleteMemberAction = (
-  memberActionList: MemberAction[],
-  setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>,
-) => {
+type UseDeleteMemberActionProps = {
+  memberActionList: MemberAction[];
+  setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>;
+  checkAlreadyExistMemberAction: (memberAction: MemberAction) => void;
+  checkExistSameMemberFromAfterStep: (
+    memberAction: MemberAction,
+    isExistSameMemberFromAfterStep: (memberAction: MemberAction) => boolean,
+  ) => void;
+};
+
+const useDeleteMemberAction = ({
+  memberActionList,
+  setIsBottomSheetOpened,
+  checkAlreadyExistMemberAction,
+  checkExistSameMemberFromAfterStep,
+}: UseDeleteMemberActionProps) => {
   const {stepList, refreshStepList} = useStepList();
   const [aliveActionList, setAliveActionList] = useState<MemberAction[]>(memberActionList);
   const eventId = getEventIdByUrl();
@@ -45,6 +57,8 @@ const useDeleteMemberAction = (
   };
 
   const addDeleteMemberAction = (memberAction: MemberAction) => {
+    checkAlreadyExistMemberAction(memberAction);
+    checkExistSameMemberFromAfterStep(memberAction, isExistSameMemberFromAfterStep);
     setAliveActionList(prev => prev.filter(aliveMember => aliveMember.actionId !== memberAction.actionId));
   };
 
@@ -62,7 +76,7 @@ const useDeleteMemberAction = (
     return memberNameList.filter(member => member === memberAction.name).length >= 2;
   };
 
-  return {aliveActionList, deleteMemberActionList, addDeleteMemberAction, isExistSameMemberFromAfterStep};
+  return {aliveActionList, deleteMemberActionList, addDeleteMemberAction};
 };
 
 export default useDeleteMemberAction;


### PR DESCRIPTION
## issue
- close #346 

## 구현 사항
useDeleteMemberAction 토스트 함수 결합도 제거를 해서 UI 컴포넌트에 위임했습니다.
삭제 멤버로 추가할 때 특수한 케이스에 대해 경고를 해주는 기능이라는 함수로 분리하여, 이미 지워진 멤버이거나 이전에 액션이 있는 멤버일 때 경고를 합니다.

```ts
 const alertSpecificCaseFromAddDeleteMember = (memberAction: MemberAction) => {
    if (!memberActionList.includes(memberAction)) {
      showToast({
        isClickToClose: true,
        showingTime: 3000,
        message: '이미 삭제된 인원입니다.',
        type: 'error',
        bottom: '160px',
      });
      return;
    }

    if (isExistSameMemberFromAfterStep(memberAction)) {
      showToast({
        isClickToClose: true,
        showingTime: 3000,
        message: `이후의 ${memberAction.name}가 사라져요`,
        type: 'error',
        position: 'top',
        top: '30px',
        style: {
          zIndex: 9000,
        },
      });
    }
  };
```

## 🫡 참고사항
