### PR TITLE
[FE] 행사 생성 완료 페이지에서 불필요한 상태 제거

### DIFF
--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -1,4 +1,3 @@
-import {useEffect, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {Button, FixedButton, Flex, Input, MainLayout, Text, Title, TopNav} from 'haengdong-design';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
@@ -11,23 +10,14 @@ import {ROUTER_URLS} from '@constants/routerUrls';
 const CompleteCreateEventPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [url, setUrl] = useState('');
 
-  useEffect(() => {
-    const getUrl = async () => {
-      // TODO: (@weadie) eventId를 location에서 불러오는 로직 함수로 분리해서 재사용
-      const params = new URLSearchParams(location.search);
-      const eventId = params.get('eventId');
-      // TODO: (@weadie) eventId가 없는 경우에 대한 처리 필요
-      setUrl(eventId ?? '');
-    };
-    getUrl();
-  }, []);
+  const params = new URLSearchParams(location.search);
+  const eventId = params.get('eventId');
 
   const {showToast} = useToast();
 
   const env = process.env.NODE_ENV || '';
-  const homeUrlByEnvironment = `https://${env.includes('development') ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${url}/home`;
+  const homeUrlByEnvironment = `https://${env.includes('development') ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/home`;
 
   return (
     <MainLayout>
@@ -61,7 +51,7 @@ const CompleteCreateEventPage = () => {
         </CopyToClipboard>
       </div>
 
-      <FixedButton onClick={() => navigate(`${ROUTER_URLS.event}/${url}/admin`)}>관리 페이지로 이동</FixedButton>
+      <FixedButton onClick={() => navigate(`${ROUTER_URLS.event}/${eventId}/admin`)}>관리 페이지로 이동</FixedButton>
     </MainLayout>
   );
 };

--- a/client/src/pages/CreateEventPage/SetEventNamePage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventNamePage.tsx
@@ -4,8 +4,6 @@ import {FixedButton, MainLayout, LabelInput, Title, TopNav, Back} from 'haengdon
 
 import validateEventName from '@utils/validate/validateEventName';
 
-import useEvent from '@hooks/useEvent';
-
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 const SetEventNamePage = () => {
@@ -13,7 +11,6 @@ const SetEventNamePage = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const [canSubmit, setCanSubmit] = useState(false);
   const navigate = useNavigate();
-  const {createNewEvent} = useEvent();
 
   const submitEventName = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -3,7 +3,6 @@ import {useLocation, useNavigate} from 'react-router-dom';
 import {FixedButton, MainLayout, LabelInput, Title, TopNav, Back} from 'haengdong-design';
 
 import validateEventPassword from '@utils/validate/validateEventPassword';
-import {requestPostNewEvent} from '@apis/request/event';
 
 import useEvent from '@hooks/useEvent';
 


### PR DESCRIPTION
## issue
- close #349 

## 구현 사항
행사 생성 완료 페이지에서 불필요한 상태를 제거했습니다.
location.search로 충분히 가져올 수 있는 것을 useEffect를 사용해서 setter를 불러서 불필요한 상태를 이용하고 있다고 생각했기 때문입니다.

추가로 사용하지 않는 import 문도 제거했어요!


## 🫡 참고사항
