### PR TITLE
[FE] 사용성 개선 - Title component 변경 및 UX writing 수정

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.69",
+  "version": "0.1.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.69",
+      "version": "0.1.72",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.69",
+  "version": "0.1.72",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/Text/Text.style.ts
+++ b/HDesign/src/components/Text/Text.style.ts
@@ -21,5 +21,9 @@ export const getSizeStyling = ({size, textColor, theme}: Required<TextStyleProps
 
   const colorStyle = css({color: theme.colors[textColor]});
 
-  return [style[size], colorStyle];
+  const baseStyle = css({
+    whiteSpace: 'pre-line',
+  });
+
+  return [style[size], colorStyle, baseStyle];
 };

--- a/HDesign/src/components/Title/Title.stories.tsx
+++ b/HDesign/src/components/Title/Title.stories.tsx
@@ -25,7 +25,8 @@ const meta = {
   },
   args: {
     title: '페이지 제목이에요',
-    description: '이곳에는 페이지 설명이 들어가요. 페이지에 대한 설명을 자세하게 적어주면 좋아요 :)',
+    description: `이곳에는 페이지 설명이 들어가요.
+    페이지에 대한 설명을 자세하게 적어주면 좋아요 :)`,
     price: 100000,
   },
 } satisfies Meta<typeof Title>;

--- a/HDesign/src/components/Title/Title.tsx
+++ b/HDesign/src/components/Title/Title.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import Flex from '@components/Flex/Flex';
 import Text from '@components/Text/Text';
 import {priceContainerStyle, titleContainerStyle} from '@components/Title/Title.style';
 import {TitleProps} from '@components/Title/Title.type';
@@ -11,7 +12,7 @@ export const Title: React.FC<TitleProps> = ({title, description, price}: TitlePr
     <div css={titleContainerStyle(theme)}>
       <Text size="subTitle">{title}</Text>
       {description && (
-        <Text textColor="darkGray" size="caption">
+        <Text textColor="darkGray" size="body">
           {description}
         </Text>
       )}
@@ -20,7 +21,10 @@ export const Title: React.FC<TitleProps> = ({title, description, price}: TitlePr
           <Text textColor="gray" size="caption">
             전체 지출 금액
           </Text>
-          <Text>{price.toLocaleString('ko-kr')}원</Text>
+          <Flex alignItems="center" gap="0.25rem">
+            <Text>{price.toLocaleString('ko-kr')}</Text>
+            <Text size="caption">원</Text>
+          </Flex>
         </div>
       )}
     </div>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@sentry/react": "^8.25.0",
-        "haengdong-design": "^0.1.69",
+        "haengdong-design": "^0.1.72",
         "react": "^18.3.1",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
@@ -8123,9 +8123,9 @@
       }
     },
     "node_modules/haengdong-design": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.69.tgz",
-      "integrity": "sha512-XlZ7hnKn51aQOOz/x+hNM6tLjJDvvTOqLiVfOSjEvRpkMKquNWFoijclXHLNhK7tqrb6m+hDREf12mIXwSN/Ew==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.72.tgz",
+      "integrity": "sha512-7Qtk/HygT5IhLzUTQzcx7FbgZo/ZrqVZhKA08zJaf1wcOlc3CkXO3Ljl1wQloHGejg71K1N1BO3L208tppxycQ==",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@sentry/react": "^8.25.0",
-    "haengdong-design": "^0.1.69",
+    "haengdong-design": "^0.1.72",
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",

--- a/client/src/components/Modal/SetInitialMemberListModal/SetInitialMemberListModal.tsx
+++ b/client/src/components/Modal/SetInitialMemberListModal/SetInitialMemberListModal.tsx
@@ -37,7 +37,7 @@ const SetInitialMemberListModal = ({isOpenBottomSheet, setIsOpenBottomSheet}: Se
   return (
     <BottomSheet isOpened={isOpenBottomSheet} onClose={() => setIsOpenBottomSheet(false)}>
       <div css={setInitialMemberListModalStyle}>
-        <Text size="bodyBold">초기 인원 설정하기</Text>
+        <Text size="bodyBold">시작 인원 추가하기</Text>
         <div css={setInitialMemberListModalInputGroupStyle}>
           <LabelGroupInput labelText="이름" errorText={errorMessage}>
             {inputList.map(({value, index}) => (

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -36,8 +36,9 @@ const AdminPage = () => {
 
   const getTitleDescriptionByInitialMemberSetting = () => {
     return allMemberList.length > 0
-      ? '“행동 추가하기” 버튼을 눌러서 지출 내역 및 인원 변동사항을 추가해 주세요.'
-      : '“초기인원 설정하기” 버튼을 눌러서 행사 초기 인원을 설정해 주세요.';
+      ? `지출 내역 및 인원 변동을 추가해 주세요.
+      인원 변동을 기준으로 몇 차인지 나뉘어져요.`
+      : '“시작 인원 추가” 버튼을 눌러 행사의 시작부터 참여하는 사람들의 이름을 입력해 주세요.';
   };
 
   return (
@@ -55,7 +56,7 @@ const AdminPage = () => {
       <section css={receiptStyle}>
         <StepList />
         <FixedButton
-          children={allMemberList.length === 0 ? '초기인원 설정하기' : '행동 추가하기'}
+          children={allMemberList.length === 0 ? '시작인원 추가하기' : '행동 추가하기'}
           onClick={() => setIsOpenFixedBottomBottomSheet(prev => !prev)}
         />
         {isOpenFixedButtonBottomSheet && (


### PR DESCRIPTION
## issue
- close #348 

## 구현 목적
1. 기존의 Title component의 description 부분이 앱의 전반적인 가이드를 제공해 주고 있지만, 유저들이 읽지 않고 넘어가는 경우가 너무 많음
2. 또한, 이곳에 적힌 UX writing이 직관적이지 못하고 혼동을 일으키는 경우가 많다는 피드백을 받음

## 구현 사항
1. Title component의 description 부분 폰트 사이즈 변경
![image](https://github.com/user-attachments/assets/262a9209-2d8a-4b46-9406-3a76147759c0)

2. 일부 UX writing 유저 친화적으로 변경
![image](https://github.com/user-attachments/assets/8493317e-0fcf-475b-836c-c98aef613aa2)

3. Text component가 줄바꿈 문자를 인식하도록 변경
```tsx
  const baseStyle = css({
    whiteSpace: 'pre-line',
  });
```
whiteSpace : pre-line 속성을 통해서 Text component가 줄바꿈 문자를 인식하도록 변경