### PR TITLE
[FE] 비밀번호 입력 페이지 커스텀 훅으로 분리

### DIFF
--- a/client/src/hooks/useSetPassword.ts
+++ b/client/src/hooks/useSetPassword.ts
@@ -1,0 +1,57 @@
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import validateEventPassword from '@utils/validate/validateEventPassword';
+
+import {useFetch} from '@apis/useFetch';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
+import RULE from '@constants/rule';
+
+import useEvent from './useEvent';
+
+const useSetPassword = (eventName: string) => {
+  const {fetch} = useFetch();
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [canSubmit, setCanSubmit] = useState(false);
+  const {createNewEvent} = useEvent();
+  const navigate = useNavigate();
+
+  const createEventAndNavigate = async () => {
+    const {eventId} = await createNewEvent({eventName, password: parseInt(password)});
+
+    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`);
+  };
+
+  const submitPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    await fetch({queryFunction: createEventAndNavigate});
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    const {isValid, errorMessage} = validateEventPassword(newValue);
+
+    setCanSubmit(newValue.length === RULE.maxEventPasswordLength);
+
+    if (isValid) {
+      setPassword(newValue);
+      setErrorMessage('');
+    } else {
+      event.target.value = password;
+      setErrorMessage(errorMessage ?? '');
+    }
+  };
+
+  return {
+    password,
+    errorMessage,
+    canSubmit,
+    submitPassword,
+    handleChange,
+  };
+};
+
+export default useSetPassword;

--- a/client/src/hooks/useSetPassword.ts
+++ b/client/src/hooks/useSetPassword.ts
@@ -1,11 +1,9 @@
 import {useState} from 'react';
-import {useNavigate} from 'react-router-dom';
 
 import validateEventPassword from '@utils/validate/validateEventPassword';
 
 import {useFetch} from '@apis/useFetch';
 
-import {ROUTER_URLS} from '@constants/routerUrls';
 import RULE from '@constants/rule';
 
 import useEvent from './useEvent';
@@ -16,18 +14,12 @@ const useSetPassword = (eventName: string) => {
   const [errorMessage, setErrorMessage] = useState('');
   const [canSubmit, setCanSubmit] = useState(false);
   const {createNewEvent} = useEvent();
-  const navigate = useNavigate();
-
-  const createEventAndNavigate = async () => {
-    const {eventId} = await createNewEvent({eventName, password: parseInt(password)});
-
-    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`);
-  };
 
   const submitPassword = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    await fetch({queryFunction: createEventAndNavigate});
+    const {eventId} = await fetch({queryFunction: () => createNewEvent({eventName, password: parseInt(password)})});
+    return eventId;
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/hooks/useSetPassword.ts
+++ b/client/src/hooks/useSetPassword.ts
@@ -22,7 +22,7 @@ const useSetPassword = (eventName: string) => {
     return eventId;
   };
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
     const {isValid, errorMessage} = validateEventPassword(newValue);
 
@@ -42,7 +42,7 @@ const useSetPassword = (eventName: string) => {
     errorMessage,
     canSubmit,
     submitPassword,
-    handleChange,
+    handlePasswordChange,
   };
 };
 

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -19,13 +19,19 @@ const SetEventPasswordPage = () => {
 
   const {password, errorMessage, canSubmit, submitPassword, handleChange} = useSetPassword(location.state?.eventName);
 
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    const eventId = await submitPassword(event);
+
+    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`);
+  };
+
   return (
     <MainLayout>
       <TopNav>
         <Back />
       </TopNav>
       <Title title="행사 비밀번호 설정" description="행사 관리에 필요한 4 자리의 숫자 비밀번호를 입력해 주세요." />
-      <form onSubmit={submitPassword} style={{padding: '0 1rem'}}>
+      <form onSubmit={onSubmit} style={{padding: '0 1rem'}}>
         <LabelInput
           labelText="비밀번호"
           errorText={errorMessage}

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -8,19 +8,16 @@ import RULE from '@constants/rule';
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 const SetEventPasswordPage = () => {
-  const [eventName, setEventName] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
     if (!location.state) {
       navigate(ROUTER_URLS.main);
-    } else {
-      setEventName(location.state.eventName);
     }
-  }, []);
+  }, [location.state]);
 
-  const {password, errorMessage, canSubmit, submitPassword, handleChange} = useSetPassword(eventName);
+  const {password, errorMessage, canSubmit, submitPassword, handleChange} = useSetPassword(location.state?.eventName);
 
   return (
     <MainLayout>

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -17,7 +17,9 @@ const SetEventPasswordPage = () => {
     }
   }, [location.state]);
 
-  const {password, errorMessage, canSubmit, submitPassword, handleChange} = useSetPassword(location.state?.eventName);
+  const {password, errorMessage, canSubmit, submitPassword, handlePasswordChange} = useSetPassword(
+    location.state?.eventName,
+  );
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     const eventId = await submitPassword(event);
@@ -39,7 +41,7 @@ const SetEventPasswordPage = () => {
           type="secret"
           maxLength={RULE.maxEventPasswordLength}
           placeholder="비밀번호"
-          onChange={e => handleChange(e)}
+          onChange={handlePasswordChange}
           isError={!!errorMessage}
           autoFocus
         />

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -2,20 +2,13 @@ import {useEffect, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {FixedButton, MainLayout, LabelInput, Title, TopNav, Back} from 'haengdong-design';
 
-import validateEventPassword from '@utils/validate/validateEventPassword';
-import {requestPostNewEvent} from '@apis/request/event';
-
-import useEvent from '@hooks/useEvent';
+import useSetPassword from '@hooks/useSetPassword';
 
 import RULE from '@constants/rule';
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 const SetEventPasswordPage = () => {
   const [eventName, setEventName] = useState('');
-  const [password, setPassword] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [canSubmit, setCanSubmit] = useState(false);
-  const {createNewEvent} = useEvent();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -27,28 +20,8 @@ const SetEventPasswordPage = () => {
     }
   }, []);
 
-  const submitPassword = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const {password, errorMessage, canSubmit, submitPassword, handleChange} = useSetPassword(eventName);
 
-    const {eventId} = await createNewEvent({eventName, password: parseInt(password)});
-
-    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`);
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    const validation = validateEventPassword(newValue);
-
-    setCanSubmit(newValue.length === RULE.maxEventPasswordLength);
-
-    if (validation.isValid) {
-      setPassword(newValue);
-      setErrorMessage('');
-    } else {
-      event.target.value = password;
-      setErrorMessage(validation.errorMessage ?? '');
-    }
-  };
   return (
     <MainLayout>
       <TopNav>
@@ -66,7 +39,7 @@ const SetEventPasswordPage = () => {
           onChange={e => handleChange(e)}
           isError={!!errorMessage}
           autoFocus
-        ></LabelInput>
+        />
         <FixedButton disabled={!canSubmit}>행동 개시!</FixedButton>
       </form>
     </MainLayout>

--- a/client/src/pages/CreateEventPage/index.ts
+++ b/client/src/pages/CreateEventPage/index.ts
@@ -1,2 +1,3 @@
 export {default as SetEventNamePage} from './SetEventNamePage';
+export {default as SetEventPasswordPage} from './SetEventPasswordPage';
 export {default as CompleteCreateEventPage} from './CompleteCreateEventPage';

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -3,10 +3,9 @@ import {createBrowserRouter} from 'react-router-dom';
 import {AdminPage} from '@pages/EventPage/AdminPage';
 import {HomePage} from '@pages/EventPage/HomePage';
 import ErrorPage from '@pages/ErrorPage/ErrorPage';
-import SetEventPasswordPage from '@pages/CreateEventPage/SetEventPasswordPage';
 import EventLoginPage from '@pages/EventPage/AdminPage/EventLoginPage';
 
-import {CompleteCreateEventPage, SetEventNamePage} from '@pages/CreateEventPage';
+import {CompleteCreateEventPage, SetEventNamePage, SetEventPasswordPage} from '@pages/CreateEventPage';
 import {MainPage} from '@pages/MainPage';
 import {EventPage} from '@pages/EventPage';
 


### PR DESCRIPTION
## issue
- close #351 

## 구현 사항
비밀번호 입력 페이지에 있는 로직을 커스텀 훅으로 분리했습니다.

useSetPassword.ts

location state가 없을 때 홈으로 리디렉션 시키는 코드는 비정상적인 접근에 대한 처리입니다.
비밀번호를 입력하는 기능과 큰 관련이 없다고 판단해서 UI 컴포넌트에 로직을 남겨두었습니다.

useSetPassword 훅은 비밀번호 입력 값, 에러 메시지, 제출 가능 여부, 제출 함수, input change 핸들러 다섯 가지를 제공해줍니다.

또한 event name 상태도 location.state.eventName을 바로 꺼내 쓰는 방식으로 변경하여, eventName 상태를 지웠습니다. useEffect로 location.state가 비어있는 상태에서는 홈으로 리디렉션 시키기 때문에 해당 페이지에 정상적으로 접근했을 때는 location.state.eventName이 있다고 판단할 수 있어서 useState를 지웠습니다. 


## 🫡 참고사항
