### PR TITLE
[FE] 탭 클릭 시 탭 전체가 클릭 되는 현상

### DIFF
--- a/HDesign/src/components/Tabs/Tabs.style.ts
+++ b/HDesign/src/components/Tabs/Tabs.style.ts
@@ -10,6 +10,8 @@ export const tabListStyle = (theme: Theme) =>
 
     cursor: 'pointer',
 
+    WebkitTapHighlightColor: 'transparent',
+
     '&::after': {
       position: 'absolute',
       left: 0,


### PR DESCRIPTION
## issue
- close #355 

## 구현 사항
탭을 클릭했을 때 전체가 클릭 된 것처럼 보이는 현상 해결했습니다.

아래 css 한 줄 추가해주니깐 되네요;;;
WebkitTapHighlightColor: 'transparent',

이전
https://github.com/user-attachments/assets/e09da3c8-ef11-468b-913e-3ce2ed4f3f08

이후
https://github.com/user-attachments/assets/2419a808-357e-4e0b-b819-4a74e6db9ba6






## 🫡 참고사항
