### PR TITLE
[FE] 사용성 개선 - 지출 내역 입력 아이템 구현

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.69",
+  "version": "0.1.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.69",
+      "version": "0.1.73",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.69",
+  "version": "0.1.73",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -1,0 +1,72 @@
+import {TextSize} from '@components/Text/Text.type';
+import {css} from '@emotion/react';
+import {Theme} from '@theme/theme.type';
+import TYPOGRAPHY from '@token/typography';
+
+interface InputWrapperStyleProps {
+  theme: Theme;
+  hasFocus: boolean;
+  hasError: boolean;
+}
+
+interface InputStyleProps {
+  theme: Theme;
+  textSize: TextSize;
+}
+
+interface InputSizeStyleProps {
+  textSize: TextSize;
+}
+
+interface InputBaseStyleProps {
+  theme: Theme;
+}
+
+export const inputWrapperStyle = ({theme, hasFocus, hasError}: InputWrapperStyleProps) =>
+  css({
+    position: 'relative',
+    display: 'inline-block',
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: '0.125rem',
+      backgroundColor: hasFocus ? theme.colors.primary : hasError ? theme.colors.error : 'transparent',
+      transition: 'background-color 0.2s',
+      transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
+    },
+  });
+
+export const inputStyle = ({theme, textSize}: InputStyleProps) => [inputSizeStyle({textSize}), inputBaseStyle({theme})];
+
+const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
+  const style = {
+    head: css(TYPOGRAPHY.head),
+    title: css(TYPOGRAPHY.title),
+    subTitle: css(TYPOGRAPHY.subTitle),
+    bodyBold: css(TYPOGRAPHY.bodyBold),
+    body: css(TYPOGRAPHY.body),
+    smallBodyBold: css(TYPOGRAPHY.smallBodyBold),
+    smallBody: css(TYPOGRAPHY.smallBody),
+    captionBold: css(TYPOGRAPHY.captionBold),
+    caption: css(TYPOGRAPHY.caption),
+    tiny: css(TYPOGRAPHY.tiny),
+  };
+
+  return [style[textSize]];
+};
+
+const inputBaseStyle = ({theme}: InputBaseStyleProps) =>
+  css({
+    border: 'none',
+    outline: 'none',
+    paddingBottom: '0.125rem',
+
+    color: theme.colors.black,
+    '&:placeholder': {
+      color: theme.colors.gray,
+    },
+  });

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -1,6 +1,9 @@
-import {TextSize} from '@components/Text/Text.type';
 import {css} from '@emotion/react';
+
+import {TextSize} from '@components/Text/Text.type';
+
 import {Theme} from '@theme/theme.type';
+
 import TYPOGRAPHY from '@token/typography';
 
 interface InputWrapperStyleProps {

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -1,0 +1,26 @@
+/** @jsxImportSource @emotion/react */
+import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
+
+import {InputProps} from '@components/EditableItem/EditableItem.Input.type';
+
+import {useTheme} from '@theme/HDesignProvider';
+import {inputStyle, inputWrapperStyle} from './EditableItem.Input.style';
+import useEditableItemInput from './useEditableItemInput';
+
+export const EditableItemInput: React.FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {textSize = 'body', hasError = false, ...htmlProps},
+  ref,
+) {
+  const {theme} = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {hasFocus} = useEditableItemInput({inputRef});
+  useImperativeHandle(ref, () => inputRef.current!);
+
+  return (
+    <div css={inputWrapperStyle({theme, hasFocus, hasError})}>
+      <input css={inputStyle({theme, textSize})} ref={inputRef} {...htmlProps} />
+    </div>
+  );
+});
+
+export default EditableItemInput;

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -4,6 +4,7 @@ import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} fro
 import {InputProps} from '@components/EditableItem/EditableItem.Input.type';
 
 import {useTheme} from '@theme/HDesignProvider';
+
 import {inputStyle, inputWrapperStyle} from './EditableItem.Input.style';
 import useEditableItemInput from './useEditableItemInput';
 

--- a/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
@@ -1,0 +1,17 @@
+import {TextSize} from '@components/Text/Text.type';
+import {Theme} from '@theme/theme.type';
+
+export interface InputStyleProps {
+  hasError?: boolean;
+  textSize?: TextSize;
+}
+
+export interface InputCustomProps {}
+
+export interface InputStylePropsWithTheme extends InputStyleProps {
+  theme: Theme;
+}
+
+export type InputOptionProps = InputStyleProps & InputCustomProps;
+
+export type InputProps = React.ComponentProps<'input'> & InputOptionProps;

--- a/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
@@ -1,4 +1,5 @@
 import {TextSize} from '@components/Text/Text.type';
+
 import {Theme} from '@theme/theme.type';
 
 export interface InputStyleProps {

--- a/HDesign/src/components/EditableItem/EditableItem.context.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.context.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource @emotion/react */
+import {createContext, PropsWithChildren, useContext, useState} from 'react';
+
+interface EditableItemContextProps {
+  hasAnyFocus: boolean;
+  setHasAnyFocus: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const EditableItemContext = createContext<EditableItemContextProps | null>(null);
+
+export const useEditableItemContext = () => {
+  const context = useContext(EditableItemContext);
+  if (!context) {
+    throw new Error('useEditableItemContext must be used within an EditableItemProvider');
+  }
+  return context;
+};
+
+export const EditableItmProvider: React.FC<PropsWithChildren> = ({children}: React.PropsWithChildren) => {
+  const [hasAnyFocus, setHasAnyFocus] = useState(false);
+
+  return <EditableItemContext.Provider value={{hasAnyFocus, setHasAnyFocus}}>{children}</EditableItemContext.Provider>;
+};

--- a/HDesign/src/components/EditableItem/EditableItem.context.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.context.tsx
@@ -16,7 +16,7 @@ export const useEditableItemContext = () => {
   return context;
 };
 
-export const EditableItmProvider: React.FC<PropsWithChildren> = ({children}: React.PropsWithChildren) => {
+export const EditableItemProvider: React.FC<PropsWithChildren> = ({children}: React.PropsWithChildren) => {
   const [hasAnyFocus, setHasAnyFocus] = useState(false);
 
   return <EditableItemContext.Provider value={{hasAnyFocus, setHasAnyFocus}}>{children}</EditableItemContext.Provider>;

--- a/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import EditableItemInput from '@components/EditableItem/EditableItem.Input';
 
 import EditableItem from './EditableItem';
-import {EditableItmProvider} from './EditableItem.context';
+import {EditableItemProvider} from './EditableItem.context';
 
 const meta = {
   title: 'Components/EditableItemInput',
@@ -36,9 +36,9 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   render: ({...args}) => {
     return (
-      <EditableItmProvider>
+      <EditableItemProvider>
         <EditableItem.Input {...args} />
-      </EditableItmProvider>
+      </EditableItemProvider>
     );
   },
 };

--- a/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
@@ -2,6 +2,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 
 import EditableItemInput from '@components/EditableItem/EditableItem.Input';
+
 import EditableItem from './EditableItem';
 import {EditableItmProvider} from './EditableItem.context';
 

--- a/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
@@ -1,0 +1,43 @@
+/** @jsxImportSource @emotion/react */
+import type {Meta, StoryObj} from '@storybook/react';
+
+import EditableItemInput from '@components/EditableItem/EditableItem.Input';
+import EditableItem from './EditableItem';
+import {EditableItmProvider} from './EditableItem.context';
+
+const meta = {
+  title: 'Components/EditableItemInput',
+  component: EditableItemInput,
+  tags: ['autodocs'],
+  parameters: {},
+  argTypes: {
+    textSize: {
+      description: '',
+      control: {type: 'select'},
+    },
+    hasError: {
+      description: '',
+      control: {type: 'boolean'},
+    },
+  },
+  args: {
+    placeholder: '지출 내역',
+    textSize: 'body',
+    hasError: false,
+    autoFocus: true,
+  },
+} satisfies Meta<typeof EditableItemInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItmProvider>
+        <EditableItem.Input {...args} />
+      </EditableItmProvider>
+    );
+  },
+};

--- a/HDesign/src/components/EditableItem/EditableItem.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.stories.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @emotion/react */
+import type {Meta, StoryObj} from '@storybook/react';
+
+import EditableItem from '@components/EditableItem/EditableItem';
+import Flex from '@components/Flex/Flex';
+import Text from '@components/Text/Text';
+
+const meta = {
+  title: 'Components/EditableItem',
+  component: EditableItem,
+  tags: ['autodocs'],
+  parameters: {},
+  argTypes: {
+    backgroundColor: {
+      description: '',
+      control: {type: 'select'},
+    },
+  },
+  args: {
+    backgroundColor: 'lightGrayContainer',
+  },
+} satisfies Meta<typeof EditableItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};

--- a/HDesign/src/components/EditableItem/EditableItem.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.style.ts
@@ -1,0 +1,14 @@
+import {css} from '@emotion/react';
+
+import {Theme} from '@theme/theme.type';
+
+import {ColorKeys} from '@token/colors';
+
+export const editableItemStyle = (theme: Theme, backgroundColor: ColorKeys) =>
+  css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '0.5rem',
+    borderRadius: '0.5rem',
+    backgroundColor: theme.colors[backgroundColor],
+  });

--- a/HDesign/src/components/EditableItem/EditableItem.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.tsx
@@ -6,7 +6,7 @@ import {useTheme} from '@theme/HDesignProvider';
 import {editableItemStyle} from './EditableItem.style';
 import EditableItemInput from './EditableItem.Input';
 import {EditableItemProps} from './EditableItem.type';
-import {EditableItmProvider, useEditableItemContext} from './EditableItem.context';
+import {EditableItemProvider} from './EditableItem.context';
 import useEditableItem from './useEditableItem';
 
 const EditableItemBase = ({
@@ -29,9 +29,9 @@ const EditableItemBase = ({
 
 export const EditableItem = (props: EditableItemProps) => {
   return (
-    <EditableItmProvider>
+    <EditableItemProvider>
       <EditableItemBase {...props} />
-    </EditableItmProvider>
+    </EditableItemProvider>
   );
 };
 

--- a/HDesign/src/components/EditableItem/EditableItem.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.tsx
@@ -4,7 +4,6 @@ import React, {useEffect} from 'react';
 import {useTheme} from '@theme/HDesignProvider';
 
 import {editableItemStyle} from './EditableItem.style';
-
 import EditableItemInput from './EditableItem.Input';
 import {EditableItemProps} from './EditableItem.type';
 import {EditableItmProvider, useEditableItemContext} from './EditableItem.context';

--- a/HDesign/src/components/EditableItem/EditableItem.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.tsx
@@ -1,0 +1,41 @@
+/** @jsxImportSource @emotion/react */
+import React, {useEffect} from 'react';
+
+import {useTheme} from '@theme/HDesignProvider';
+
+import {editableItemStyle} from './EditableItem.style';
+
+import EditableItemInput from './EditableItem.Input';
+import {EditableItemProps} from './EditableItem.type';
+import {EditableItmProvider, useEditableItemContext} from './EditableItem.context';
+import useEditableItem from './useEditableItem';
+
+const EditableItemBase = ({
+  onInputFocus,
+  onInputBlur,
+  backgroundColor = 'white',
+  children,
+  ...htmlProps
+}: EditableItemProps) => {
+  const {theme} = useTheme();
+
+  useEditableItem({onInputFocus, onInputBlur});
+
+  return (
+    <div css={editableItemStyle(theme, backgroundColor)} {...htmlProps}>
+      {children}
+    </div>
+  );
+};
+
+export const EditableItem = (props: EditableItemProps) => {
+  return (
+    <EditableItmProvider>
+      <EditableItemBase {...props} />
+    </EditableItmProvider>
+  );
+};
+
+EditableItem.Input = EditableItemInput;
+
+export default EditableItem;

--- a/HDesign/src/components/EditableItem/EditableItem.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.type.ts
@@ -1,4 +1,5 @@
 import {Theme} from '@theme/theme.type';
+
 import {ColorKeys} from '@token/colors';
 
 export interface EditableItemStyleProps {

--- a/HDesign/src/components/EditableItem/EditableItem.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.type.ts
@@ -1,0 +1,19 @@
+import {Theme} from '@theme/theme.type';
+import {ColorKeys} from '@token/colors';
+
+export interface EditableItemStyleProps {
+  backgroundColor: ColorKeys;
+}
+
+export interface EditableItemCustomProps {
+  onInputFocus?: () => void;
+  onInputBlur?: () => void;
+}
+
+export interface EditableItemStylePropsWithTheme extends EditableItemStyleProps {
+  theme: Theme;
+}
+
+export type EditableItemOptionProps = EditableItemStyleProps & EditableItemCustomProps;
+
+export type EditableItemProps = React.ComponentProps<'div'> & EditableItemOptionProps;

--- a/HDesign/src/components/EditableItem/useEditableItem.ts
+++ b/HDesign/src/components/EditableItem/useEditableItem.ts
@@ -1,0 +1,22 @@
+import {useEffect} from 'react';
+import {useEditableItemContext} from './EditableItem.context';
+
+interface UseEditableItemProps {
+  onInputFocus?: () => void;
+  onInputBlur?: () => void;
+}
+
+const useEditableItem = ({onInputFocus, onInputBlur}: UseEditableItemProps) => {
+  const {hasAnyFocus} = useEditableItemContext();
+
+  useEffect(() => {
+    if (hasAnyFocus && onInputFocus) {
+      onInputFocus();
+    }
+    if (!hasAnyFocus && onInputBlur) {
+      onInputBlur();
+    }
+  }, [hasAnyFocus, onInputFocus, onInputBlur]);
+};
+
+export default useEditableItem;

--- a/HDesign/src/components/EditableItem/useEditableItem.ts
+++ b/HDesign/src/components/EditableItem/useEditableItem.ts
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+
 import {useEditableItemContext} from './EditableItem.context';
 
 interface UseEditableItemProps {

--- a/HDesign/src/components/EditableItem/useEditableItemInput.ts
+++ b/HDesign/src/components/EditableItem/useEditableItemInput.ts
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useState} from 'react';
+
 import {useEditableItemContext} from './EditableItem.context';
 
 interface UseEditableItemInputProps {

--- a/HDesign/src/components/EditableItem/useEditableItemInput.ts
+++ b/HDesign/src/components/EditableItem/useEditableItemInput.ts
@@ -1,0 +1,45 @@
+import {useCallback, useEffect, useState} from 'react';
+import {useEditableItemContext} from './EditableItem.context';
+
+interface UseEditableItemInputProps {
+  inputRef: React.RefObject<HTMLInputElement>;
+}
+
+const useEditableItemInput = ({inputRef}: UseEditableItemInputProps) => {
+  const [hasFocus, setHasFocus] = useState(false);
+  const {setHasAnyFocus} = useEditableItemContext();
+
+  const handleFocus = useCallback(() => {
+    setHasFocus(true);
+    setHasAnyFocus(true);
+  }, [setHasAnyFocus]);
+
+  const handleBlur = useCallback(() => {
+    setHasFocus(false);
+    setHasAnyFocus(false);
+  }, [setHasAnyFocus]);
+
+  useEffect(() => {
+    const input = inputRef.current;
+
+    if (input) {
+      input.addEventListener('focus', handleFocus);
+      input.addEventListener('blur', handleBlur);
+
+      return () => {
+        input.removeEventListener('focus', handleFocus);
+        input.removeEventListener('blur', handleBlur);
+      };
+    }
+  }, [handleFocus, handleBlur, inputRef]);
+
+  useEffect(() => {
+    if (document.activeElement === inputRef.current) {
+      handleFocus();
+    }
+  }, [handleFocus, inputRef]);
+
+  return {hasFocus};
+};
+
+export default useEditableItemInput;

--- a/HDesign/src/index.tsx
+++ b/HDesign/src/index.tsx
@@ -2,6 +2,7 @@ import BottomSheet from '@components/BottomSheet/BottomSheet';
 import Button from '@components/Button/Button';
 import DragHandleItem from '@components/DragHandleItem/DragHandleItem';
 import DragHandleItemContainer from '@components/DragHandleItemContainer/DragHandleItemContainer';
+import EditableItem from '@components/EditableItem/EditableItem';
 import ExpenseList from '@components/ExpenseList/ExpenseList';
 import FixedButton from '@components/FixedButton/FixedButton';
 import Flex from '@components/Flex/Flex';
@@ -33,6 +34,7 @@ export {
   Button,
   DragHandleItem,
   DragHandleItemContainer,
+  EditableItem,
   ExpenseList,
   FixedButton,
   Flex,


### PR DESCRIPTION
## issue
- close #353 

## 구현 목적
- 현재 가장 비중있는 이벤트가 지출 내역 등록인데, 이 과정이 직관적이지 않고 불필요한 많은 동직이 필요합니다.
- 현재 플로우는 "행동 추가 버튼" 클릭 -> 바텀시트에서 인원과 지출 중 선택 -> 지출내역 및 금액 입력 -> 추가 완료 버튼 클릭
- 플로우가 길기도 하며, 그 과정에서 유저들이 올바른 길로 가지 못하게 헷갈리는 과정이 많습니다.
- 예를 들어, 지출과 인원을 골라야 하는 점, 지출내역과 금액의 input이 서로 헷갈리는 점, 여러개의 인풋이 가능한걸 인지하지 못하는 점 등
- 이에 따라 기존의 화면을 벗어나지 않고, 익숙한 UI에서 바로 지출내역과 금액을 입력할 수 있는 Component를 구현합니다.

## 고려 사항
- `EditableItem`의 사용처에서도 Input의 value에 접근할 수 있도록 합성컴포넌트 도입을 고려합니다.
- children(`EditableItemInput`)이 focus되었는지 혹은 모든 focus가 없어졌는지에 따라 실행시킬 함수를 prop으로 받도록 고려합니다.
- children(`EditableItemInput`)이 focus되었는지 혹은 모든 focus가 없어졌는지를 파악하기 위해서 provider 구현을 고려합니다.
- `EditableItemInput`의 폰트 크기를 다양하게 쓸 수 있도록, `textSize` prop을 optional로 받도록 고려합니다.
- `EditableItemInput`에 error 상태를 표시하기 위해, `hasError`를 optional로 받도록 고려합니다.

## 구현 내용
### 1. `EditableItemInput`
```tsx
// EditableItem.Input.tsx
export const EditableItemInput: React.FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(function Input(
  {textSize = 'body', hasError = false, ...htmlProps},
  ref,
) {
  const {theme} = useTheme();
  const inputRef = useRef<HTMLInputElement>(null);
  const {hasFocus} = useEditableItemInput({inputRef});
  useImperativeHandle(ref, () => inputRef.current!);

  return (
    <div css={inputWrapperStyle({theme, hasFocus, hasError})}>
      <input css={inputStyle({theme, textSize})} ref={inputRef} {...htmlProps} />
    </div>
  );
});
```
- 기본 input에 style만 적용
- `textSize` 와 `hasError`를 prop으로 받아 스타일링

```tsx
// useEditableItemInput.ts

// ~~
  const handleFocus = useCallback(() => {
    setHasFocus(true);
    setHasAnyFocus(true);
  }, [setHasAnyFocus]);

  const handleBlur = useCallback(() => {
    setHasFocus(false);
    setHasAnyFocus(false);
  }, [setHasAnyFocus]);
// ~~
```
- `EditableItemInput`에서 focus되거나 blur되는 경우, `EditableItemContext`의 `setHasAnyFocus`를 이용해 `hasAnyFocus`를 변경해줍니다.
- 이 `hasAnyFocus`를 통해 EditableItem이 `onInputFocus`, `onInputBlur` 함수를 호출합니다.

### 2.` EditableItemContext`
```tsx
// EditableItem.context.tsx

const EditableItemContext = createContext<EditableItemContextProps | null>(null);

export const useEditableItemContext = () => {
  const context = useContext(EditableItemContext);
  if (!context) {
    throw new Error('useEditableItemContext must be used within an EditableItemProvider');
  }
  return context;
};

export const EditableItmProvider: React.FC<PropsWithChildren> = ({children}: React.PropsWithChildren) => {
  const [hasAnyFocus, setHasAnyFocus] = useState(false);

  return <EditableItemContext.Provider value={{hasAnyFocus, setHasAnyFocus}}>{children}</EditableItemContext.Provider>;
};
```

- chilren(`EditableItemInput`)의 focus 상태를 부모인 EditableItem에서 파악할 수 있도록 `hasAnyFocus`, `setHasAnyFocus`를 value로 가지고 있는 provider를 구현했습니다.

### 3. `EditableItem`
```tsx
// EditableItem.tsx
const EditableItemBase = ({
  onInputFocus,
  onInputBlur,
  backgroundColor = 'white',
  children,
  ...htmlProps
}: EditableItemProps) => {
  const {theme} = useTheme();

  useEditableItem({onInputFocus, onInputBlur});

  return (
    <div css={editableItemStyle(theme, backgroundColor)} {...htmlProps}>
      {children}
    </div>
  );
};

export const EditableItem = (props: EditableItemProps) => {
  return (
    <EditableItmProvider>
      <EditableItemBase {...props} />
    </EditableItmProvider>
  );
};

EditableItem.Input = EditableItemInput;

export default EditableItem;
```

- `EditableItemProvider`로 `EditableItemBase`를 감싸서 `EditableItem`구현

```tsx
// useEditableItem.ts
const useEditableItem = ({onInputFocus, onInputBlur}: UseEditableItemProps) => {
  const {hasAnyFocus} = useEditableItemContext();

  useEffect(() => {
    if (hasAnyFocus && onInputFocus) {
      onInputFocus();
    }
    if (!hasAnyFocus && onInputBlur) {
      onInputBlur();
    }
  }, [hasAnyFocus, onInputFocus, onInputBlur]);
};

export default useEditableItem;
```

- `EditableItemProvider`의 `hasAnyFocus`상태가 변경함에 따라, prop으로 받은 `onInputFocus`, `onInputBlur` 함수를 실행시킴


## 논의하고 싶은 부분(선택)
provider를 사용하지 않고 구현하고 싶었는데 별다른 방법이 생각나지 않았습니다.
혹시 좋은 아이디어가 있다면 얘기해주세용~

