### PR TITLE
[FE] 인원 탈주 검색이 되지 않는 버그

### DIFF
--- a/client/src/apis/request/member.ts
+++ b/client/src/apis/request/member.ts
@@ -73,7 +73,7 @@ export const requestDeleteAllMemberList = async ({eventId, memberName}: WithEven
 };
 
 export type ResponseGetCurrentInMemberList = {
-  members: Array<{name: string}>;
+  memberNames: string[];
 };
 
 export const requestGetCurrentInMemberList = async (eventId: string) => {

--- a/client/src/hooks/useSearchInMemberList.ts
+++ b/client/src/hooks/useSearchInMemberList.ts
@@ -23,7 +23,7 @@ const useSearchInMemberList = (
   const [currentInputIndex, setCurrentInputIndex] = useState(-1);
 
   // 서버에서 가져온 전체 리스트
-  const [currentInMemberList, setCurrentInMemberList] = useState<Array<{name: string}>>([]);
+  const [currentInMemberList, setCurrentInMemberList] = useState<Array<string>>([]);
 
   // 검색된 리스트 (따로 둔 이유는 검색 후 클릭했을 때 리스트를 비워주어야하기 때문)
   const [filteredInMemberList, setFilteredInMemberList] = useState<Array<string>>([]);
@@ -31,7 +31,7 @@ const useSearchInMemberList = (
   useEffect(() => {
     const getCurrentInMembers = async () => {
       const currentInMemberListFromServer = await fetch({queryFunction: () => requestGetCurrentInMemberList(eventId)});
-      setCurrentInMemberList(currentInMemberListFromServer.members);
+      setCurrentInMemberList(currentInMemberListFromServer.memberNames);
     };
 
     getCurrentInMembers();
@@ -40,11 +40,9 @@ const useSearchInMemberList = (
   const filterMatchItems = (keyword: string) => {
     if (keyword.trim() === '') return [];
 
-    const MatchItems = currentInMemberList.map(({name}) => name);
-
-    return MatchItems.filter(
-      matchItem => matchItem.toLocaleLowerCase().indexOf(keyword.toLocaleLowerCase()) > -1,
-    ).slice(0, 3);
+    return currentInMemberList
+      .filter(member => member.toLocaleLowerCase().indexOf(keyword.toLocaleLowerCase()) > -1)
+      .slice(0, 3);
   };
 
   const chooseMember = (inputIndex: number, name: string) => {


### PR DESCRIPTION
## issue
- close #367 

## 구현 사항
인원 탈주 검색이 되지 않는 버그가 있습니다.
원래는 검색 리스트가 나와서 선택할 수 있어야 하지만 그렇지 않았어요

버그의 원인은 api 명세의 변경이었습니다.
members -> memberNames 변동과 Array<{name: string}> -> Array<string>의 형식 변화를 알아채지 못해서 이 형식을 아래와 같이 수정해주니 정상적으로 돌아가요~~~

```ts

export type ResponseGetCurrentInMemberList = {
  memberNames: string[];
};

export const requestGetCurrentInMemberList = async (eventId: string) => {
  return await requestGet<ResponseGetCurrentInMemberList>({
    baseUrl: BASE_URL.HD,
    endpoint: `${TEMP_PREFIX}/${eventId}/members/current`,
  });
};
```

## 🫡 참고사항
