### PR TITLE
[BE]  액션 이력 조회 v2 기능 구현

### DIFF
--- a/server/src/main/java/server/haengdong/presentation/EventController.java
+++ b/server/src/main/java/server/haengdong/presentation/EventController.java
@@ -1,6 +1,7 @@
 package server.haengdong.presentation;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -15,10 +16,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.AuthService;
 import server.haengdong.application.EventService;
+import server.haengdong.application.response.ActionAppResponse;
 import server.haengdong.infrastructure.auth.CookieProperties;
 import server.haengdong.presentation.request.EventLoginRequest;
 import server.haengdong.presentation.request.EventSaveRequest;
 import server.haengdong.presentation.request.MemberNamesUpdateRequest;
+import server.haengdong.presentation.response.ActionsResponse;
 import server.haengdong.presentation.response.EventDetailResponse;
 import server.haengdong.presentation.response.EventResponse;
 import server.haengdong.presentation.response.MembersResponse;
@@ -58,6 +61,14 @@ public class EventController {
         StepsResponse stepsResponse = StepsResponse.of(eventService.findActions(token));
 
         return ResponseEntity.ok(stepsResponse);
+    }
+
+    @GetMapping("/api/events/{eventId}/actions/v2")
+    public ResponseEntity<ActionsResponse> findActions2(@PathVariable("eventId") String token) {
+        List<ActionAppResponse> actions = eventService.findActions(token);
+        ActionsResponse actionsResponse = ActionsResponse.of(actions);
+
+        return ResponseEntity.ok(actionsResponse);
     }
 
     @GetMapping("/api/events/{eventId}/members")

--- a/server/src/main/java/server/haengdong/presentation/response/ActionResponse2.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionResponse2.java
@@ -1,0 +1,22 @@
+package server.haengdong.presentation.response;
+
+import server.haengdong.application.response.ActionAppResponse;
+
+public record ActionResponse2(
+        Long actionId,
+        String name,
+        Long price,
+        Long sequence,
+        String type
+) {
+
+    public static ActionResponse2 of(ActionAppResponse actionAppResponse) {
+        return new ActionResponse2(
+                actionAppResponse.actionId(),
+                actionAppResponse.name(),
+                actionAppResponse.price(),
+                actionAppResponse.sequence(),
+                actionAppResponse.actionType().name()
+        );
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionsResponse.java
@@ -1,0 +1,14 @@
+package server.haengdong.presentation.response;
+
+import java.util.List;
+import server.haengdong.application.response.ActionAppResponse;
+
+public record ActionsResponse(
+        List<ActionResponse2> actions
+) {
+    public static ActionsResponse of(List<ActionAppResponse> actions) {
+        return new ActionsResponse(actions.stream()
+                .map(ActionResponse2::of)
+                .toList());
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -284,6 +284,69 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 );
     }
 
+    @DisplayName("행사 전체 액션 이력 조회 v2")
+    @Test
+    void findActions2() throws Exception {
+        String token = "TOKEN";
+        List<ActionAppResponse> actionAppResponses = List.of(
+                new ActionAppResponse(1L, "망쵸", null, 1L, ActionType.IN),
+                new ActionAppResponse(2L, "족발", 100L, 2L, ActionType.BILL),
+                new ActionAppResponse(3L, "인생네컷", 1000L, 3L, ActionType.BILL),
+                new ActionAppResponse(4L, "망쵸", null, 4L, ActionType.OUT)
+        );
+        given(eventService.findActions(token)).willReturn(actionAppResponses);
+
+        mockMvc.perform(get("/api/events/{eventId}/actions/v2", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.actions[0].actionId").value(equalTo(1)))
+                .andExpect(jsonPath("$.actions[0].name").value(equalTo("망쵸")))
+                .andExpect(jsonPath("$.actions[0].price").value(equalTo(null)))
+                .andExpect(jsonPath("$.actions[0].sequence").value(equalTo(1)))
+                .andExpect(jsonPath("$.actions[0].type").value(equalTo("IN")))
+
+                .andExpect(jsonPath("$.actions[1].actionId").value(equalTo(2)))
+                .andExpect(jsonPath("$.actions[1].name").value(equalTo("족발")))
+                .andExpect(jsonPath("$.actions[1].price").value(equalTo(100)))
+                .andExpect(jsonPath("$.actions[1].sequence").value(equalTo(2)))
+                .andExpect(jsonPath("$.actions[1].type").value(equalTo("BILL")))
+
+                .andExpect(jsonPath("$.actions[2].actionId").value(equalTo(3)))
+                .andExpect(jsonPath("$.actions[2].name").value(equalTo("인생네컷")))
+                .andExpect(jsonPath("$.actions[2].price").value(equalTo(1000)))
+                .andExpect(jsonPath("$.actions[2].sequence").value(equalTo(3)))
+                .andExpect(jsonPath("$.actions[2].type").value(equalTo("BILL")))
+
+                .andExpect(jsonPath("$.actions[3].actionId").value(equalTo(4)))
+                .andExpect(jsonPath("$.actions[3].name").value(equalTo("망쵸")))
+                .andExpect(jsonPath("$.actions[3].price").value(equalTo(null)))
+                .andExpect(jsonPath("$.actions[3].sequence").value(equalTo(4)))
+                .andExpect(jsonPath("$.actions[3].type").value(equalTo("OUT")))
+
+                .andDo(
+                        document("findActions",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("actions[].actionId").type(JsonFieldType.NUMBER)
+                                                .description("액션 ID"),
+                                        fieldWithPath("actions[].name").type(JsonFieldType.STRING)
+                                                .description("참여자 액션일 경우 참여자 이름, 지출 액션일 경우 지출 내역 이름"),
+                                        fieldWithPath("actions[].price").type(JsonFieldType.NUMBER).optional()
+                                                .description("참여자 액션일 경우 null, 지출 액션일 경우 지출 금액"),
+                                        fieldWithPath("actions[].sequence").type(JsonFieldType.NUMBER)
+                                                .description("액션 순서"),
+                                        fieldWithPath("actions[].type").type(JsonFieldType.STRING)
+                                                .description("액션 타입")
+                                )
+                        )
+                );
+    }
+
     @DisplayName("행사 어드민 권한을 확인한다.")
     @Test
     void authenticateTest() throws Exception {


### PR DESCRIPTION
## issue
- close #372 

## 구현 사항

액션 이력 조회 v2로 플랫한 형태로 기능 구현했습니다.

### API
/api/events/{eventId}/actions/v2

### 응답
```
{
    "actions": [
        {
            "actionId": 2221,
            "name": "감자탕",
            "price": "10,000",
            "order": 1,
            "type": "BILL"
        },
        {
            "actionId": 22,
            "name": "인생네컷",
            "price": "10,000",
            "order": 2,
            "type": "BILL"
        },
        {
            "actionId": 13,
            "name": "망쵸",
            "price": null,
            "order": 3,
            "type": "IN"
        },
        {
            "actionId": 34,
            "name": "백호",
            "price": null,
            "order": 4,
            "type": "IN"
        },
        {
            "actionId": 54,
            "name": "망쵸",
            "price": null,
            "order": 5,
            "type": "OUT"
        },
        {
            "actionId": 612,
            "name": "백호",
            "price": null,
            "order": 6,
            "type": "OUT"
        },
        {
            "actionId": 137231,
            "name": "노래방",
            "price": "20,000",
            "order": 7,
            "type": "BILL"
        }
    ]
}
```
