### PR TITLE
[BE] 참여자별 정산 현황 조회 및 액션 이력 조회 수정

### DIFF
--- a/server/src/main/java/server/haengdong/application/ActionService.java
+++ b/server/src/main/java/server/haengdong/application/ActionService.java
@@ -3,6 +3,7 @@ package server.haengdong.application;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import server.haengdong.application.response.MemberBillReportAppResponse;
 import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionRepository;
@@ -15,6 +16,7 @@ import server.haengdong.exception.HaengdongErrorCode;
 import server.haengdong.exception.HaengdongException;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class ActionService {
 

--- a/server/src/main/java/server/haengdong/application/BillActionService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionService.java
@@ -70,8 +70,7 @@ public class BillActionService {
 
         resetBillActionDetail(billAction, request.price());
 
-        BillAction updatedBillAction = billAction.update(request.title(), request.price());
-        billActionRepository.save(updatedBillAction);
+        billAction.update(request.title(), request.price());
     }
 
     private void resetBillActionDetail(BillAction billAction, Long updatePrice) {

--- a/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/ActionAppResponse.java
@@ -9,8 +9,13 @@ public record ActionAppResponse(
         String name,
         Long price,
         Long sequence,
+        boolean isFixed,
         ActionType actionType
 ) {
+
+    public ActionAppResponse(Long actionId, String name, Long price, Long sequence, ActionType actionType) {
+        this(actionId, name, price, sequence, false, actionType);
+    }
 
     public static ActionAppResponse of(BillAction billAction) {
         return new ActionAppResponse(
@@ -18,7 +23,8 @@ public record ActionAppResponse(
                 billAction.getTitle(),
                 billAction.getPrice(),
                 billAction.getSequence(),
-                ActionType.BILL
+                billAction.isFixed(),
+                ActionAppResponse.ActionType.BILL
         );
     }
 
@@ -30,7 +36,8 @@ public record ActionAppResponse(
                 memberAction.getMemberName(),
                 null,
                 memberAction.getSequence(),
-                ActionType.of(status)
+                false,
+                ActionAppResponse.ActionType.of(status)
         );
     }
 

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -41,20 +41,27 @@ public class BillAction implements Comparable<BillAction> {
 
     private Long price;
 
+    private boolean isFixed;
+
     @OneToMany(mappedBy = "billAction", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<BillActionDetail> billActionDetails = new ArrayList<>();
 
     public BillAction(Action action, String title, Long price) {
-        this(null, action, title, price);
+        this(null, action, title, price, false); // TODO: 수정 필요
     }
 
-    private BillAction(Long id, Action action, String title, Long price) {
+    public BillAction(Action action, String title, Long price, boolean isFixed) {
+        this(null, action, title, price, isFixed);
+    }
+
+    private BillAction(Long id, Action action, String title, Long price, boolean isFixed) {
         validateTitle(title);
         validatePrice(price);
         this.id = id;
         this.action = action;
         this.title = title.trim();
         this.price = price;
+        this.isFixed = isFixed;
     }
 
     private void validateTitle(String title) {
@@ -71,7 +78,7 @@ public class BillAction implements Comparable<BillAction> {
     }
 
     public BillAction update(String title, Long price) {
-        return new BillAction(id, action, title, price);
+        return new BillAction(id, action, title, price, isFixed);
     }
 
     public Long getSequence() {

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -84,7 +84,7 @@ public class BillAction implements Comparable<BillAction> {
 
     public Long findPriceByMemberName(String memberName) {
         return billActionDetails.stream()
-                .filter(billActionDetail -> billActionDetail.isMemberMatch(memberName))
+                .filter(billActionDetail -> billActionDetail.hasMemberName(memberName))
                 .map(BillActionDetail::getPrice)
                 .findFirst()
                 .orElse(DEFAULT_PRICE);

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -41,27 +41,20 @@ public class BillAction implements Comparable<BillAction> {
 
     private Long price;
 
-    private boolean isFixed;
-
     @OneToMany(mappedBy = "billAction", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<BillActionDetail> billActionDetails = new ArrayList<>();
 
     public BillAction(Action action, String title, Long price) {
-        this(null, action, title, price, false); // TODO: 수정 필요
+        this(null, action, title, price);
     }
 
-    public BillAction(Action action, String title, Long price, boolean isFixed) {
-        this(null, action, title, price, isFixed);
-    }
-
-    private BillAction(Long id, Action action, String title, Long price, boolean isFixed) {
+    private BillAction(Long id, Action action, String title, Long price) {
         validateTitle(title);
         validatePrice(price);
         this.id = id;
         this.action = action;
         this.title = title.trim();
         this.price = price;
-        this.isFixed = isFixed;
     }
 
     private void validateTitle(String title) {
@@ -78,7 +71,7 @@ public class BillAction implements Comparable<BillAction> {
     }
 
     public BillAction update(String title, Long price) {
-        return new BillAction(id, action, title, price, isFixed);
+        return new BillAction(id, action, title, price);
     }
 
     public Long getSequence() {
@@ -95,6 +88,13 @@ public class BillAction implements Comparable<BillAction> {
                 .map(BillActionDetail::getPrice)
                 .findFirst()
                 .orElse(DEFAULT_PRICE);
+    }
+
+    public boolean isFixed() {
+        return billActionDetails.stream()
+                .map(BillActionDetail::getPrice)
+                .distinct()
+                .count() != 1L;
     }
 
     public void addDetails(List<BillActionDetail> billActionDetails) {

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -70,8 +70,11 @@ public class BillAction implements Comparable<BillAction> {
         }
     }
 
-    public BillAction update(String title, Long price) {
-        return new BillAction(id, action, title, price);
+    public void update(String title, Long price) {
+        validateTitle(title);
+        validatePrice(price);
+        this.title = title;
+        this.price = price;
     }
 
     public Long getSequence() {

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
@@ -25,4 +25,17 @@ public class BillActionDetail {
     private String memberName;
 
     private Long price;
+
+    public BillActionDetail(String memberName, Long price) {
+        this.memberName = memberName;
+        this.price = price;
+    }
+
+    public void setBillAction(BillAction billAction) {
+        this.billAction = billAction;
+    }
+
+    public boolean isMemberMatch(String memberName) {
+        return this.memberName.equals(memberName);
+    }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
@@ -35,7 +35,7 @@ public class BillActionDetail {
         this.billAction = billAction;
     }
 
-    public boolean isMemberMatch(String memberName) {
+    public boolean hasMemberName(String memberName) {
         return this.memberName.equals(memberName);
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/MemberBillReport.java
+++ b/server/src/main/java/server/haengdong/domain/action/MemberBillReport.java
@@ -66,9 +66,9 @@ public class MemberBillReport {
             return;
         }
 
-        Long pricePerMember = billAction.getPrice() / currentMembers.size();
         for (String currentMember : currentMembers.getMembers()) {
-            Long price = memberBillReports.get(currentMember) + pricePerMember;
+            Long currentPrice = billAction.findPriceByMemberName(currentMember);
+            Long price = memberBillReports.get(currentMember) + currentPrice;
             memberBillReports.put(currentMember, price);
         }
     }

--- a/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/ActionResponse.java
@@ -6,15 +6,21 @@ public record ActionResponse(
         Long actionId,
         String name,
         Long price,
-        Long sequence
+        Long sequence,
+        boolean isFixed
 ) {
+    
+    public ActionResponse(Long actionId, String name, Long price, Long sequence) {
+        this(actionId, name, price, sequence, false);
+    }
 
     public static ActionResponse of(ActionAppResponse actionAppResponse) {
         return new ActionResponse(
                 actionAppResponse.actionId(),
                 actionAppResponse.name(),
                 actionAppResponse.price(),
-                actionAppResponse.sequence()
+                actionAppResponse.sequence(),
+                actionAppResponse.isFixed()
         );
     }
 }

--- a/server/src/test/java/server/haengdong/application/ActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/ActionServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import server.haengdong.application.response.MemberBillReportAppResponse;
 import server.haengdong.domain.action.Action;
 import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.BillActionDetail;
 import server.haengdong.domain.action.BillActionRepository;
 import server.haengdong.domain.action.MemberAction;
 import server.haengdong.domain.action.MemberActionRepository;
@@ -49,8 +50,20 @@ class ActionServiceTest extends ServiceTestSupport {
         );
         List<BillAction> billActions = List.of(
                 new BillAction(new Action(savedEvent, 4L), "뽕족", 60_000L),
-                new BillAction(new Action(savedEvent, 6L), "인생맥주", 40_000L),
                 new BillAction(new Action(savedEvent, 7L), "인생네컷", 20_000L)
+        );
+        billActions.get(0).addDetails(
+                List.of(
+                        new BillActionDetail("소하", 10_000L),
+                        new BillActionDetail("감자", 40_000L),
+                        new BillActionDetail("쿠키", 10_000L)
+                )
+        );
+        billActions.get(1).addDetails(
+                List.of(
+                        new BillActionDetail("소하", 5_000L),
+                        new BillActionDetail("쿠키", 15_000L)
+                )
         );
         memberActionRepository.saveAll(memberActions);
         billActionRepository.saveAll(billActions);
@@ -61,9 +74,9 @@ class ActionServiceTest extends ServiceTestSupport {
                 .hasSize(3)
                 .extracting(MemberBillReportAppResponse::name, MemberBillReportAppResponse::price)
                 .containsExactlyInAnyOrder(
-                        tuple("감자", 20_000L),
-                        tuple("쿠키", 50_000L),
-                        tuple("소하", 50_000L)
+                        tuple("감자", 40_000L),
+                        tuple("쿠키", 25_000L),
+                        tuple("소하", 15_000L)
                 );
     }
 

--- a/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
@@ -161,14 +161,12 @@ class BillActionServiceTest extends ServiceTestSupport {
         Event savedEvent = eventRepository.save(event);
         Action action = Action.createFirst(savedEvent);
         BillAction billAction = new BillAction(action, "뽕족", 10_000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "감자", 3000L);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "고구마", 2000L);
+        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "당근", 3000L);
+        BillActionDetail billActionDetail4 = new BillActionDetail(billAction, "양파", 2000L);
+        billAction.addDetails(List.of(billActionDetail1, billActionDetail2, billActionDetail3, billActionDetail4));
         BillAction savedBillAction = billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(savedBillAction, "감자", 3000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(savedBillAction, "고구마", 2000L);
-        BillActionDetail billActionDetail3 = new BillActionDetail(savedBillAction, "당근", 3000L);
-        BillActionDetail billActionDetail4 = new BillActionDetail(savedBillAction, "양파", 2000L);
-
-        billActionDetailRepository.saveAll(
-                List.of(billActionDetail1, billActionDetail2, billActionDetail3, billActionDetail4));
 
         Long actionId = savedBillAction.getAction().getId();
         BillActionUpdateAppRequest request = new BillActionUpdateAppRequest("인생맥주", 20_000L);

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -72,27 +72,27 @@ public class EventControllerDocsTest extends RestDocsSupport {
         given(authService.getTokenName()).willReturn("eventToken");
 
         mockMvc.perform(post("/api/events")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(cookie().value("eventToken", "jwtToken"))
                 .andExpect(jsonPath("$.eventId").value("쿠키 토큰"))
                 .andDo(
                         document("createEvent",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 requestFields(
-                                         fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름"),
-                                         fieldWithPath("password").type(JsonFieldType.STRING).description("행사 비밀 번호")
-                                 ),
-                                 responseFields(
-                                         fieldWithPath("eventId").type(JsonFieldType.STRING)
-                                                 .description("행사 ID")
-                                 ),
-                                 responseCookies(
-                                         cookieWithName("eventToken").description("행사 관리자용 토큰")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestFields(
+                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("행사 비밀 번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("eventId").type(JsonFieldType.STRING)
+                                                .description("행사 ID")
+                                ),
+                                responseCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
                         )
                 );
     }
@@ -110,14 +110,14 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.eventName").value("행동대장 회식"))
                 .andDo(
                         document("getEvent",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 responseFields(
-                                         fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름")
+                                )
                         )
                 );
     }
@@ -178,8 +178,10 @@ public class EventControllerDocsTest extends RestDocsSupport {
                                 ),
                                 requestFields(
                                         fieldWithPath("members").type(JsonFieldType.ARRAY).description("수정할 참여자 목록"),
-                                        fieldWithPath("members[].before").type(JsonFieldType.STRING).description("수정 전 참여자 이름"),
-                                        fieldWithPath("members[].after").type(JsonFieldType.STRING).description("수정 후 참여자 이름")
+                                        fieldWithPath("members[].before").type(JsonFieldType.STRING)
+                                                .description("수정 전 참여자 이름"),
+                                        fieldWithPath("members[].after").type(JsonFieldType.STRING)
+                                                .description("수정 후 참여자 이름")
                                 )
                         )
                 );
@@ -278,7 +280,9 @@ public class EventControllerDocsTest extends RestDocsSupport {
                                         fieldWithPath("steps[].actions[].price").type(JsonFieldType.NUMBER).optional()
                                                 .description("참여자 액션일 경우 null, 지출 액션일 경우 지출 금액"),
                                         fieldWithPath("steps[].actions[].sequence").type(JsonFieldType.NUMBER)
-                                                .description("액션 순서")
+                                                .description("액션 순서"),
+                                        fieldWithPath("steps[].actions[].isFixed").type(JsonFieldType.BOOLEAN)
+                                                .description("지출 액션의 지출 고정 금액이 설정 여부")
                                 )
                         )
                 );
@@ -289,20 +293,20 @@ public class EventControllerDocsTest extends RestDocsSupport {
     void authenticateTest() throws Exception {
         String token = "TOKEN";
         mockMvc.perform(post("/api/events/{eventId}/auth", token)
-                                .cookie(EVENT_COOKIE))
+                        .cookie(EVENT_COOKIE))
                 .andDo(print())
                 .andExpect(status().isOk())
 
                 .andDo(
                         document("authenticateEvent",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 requestCookies(
-                                         cookieWithName("eventToken").description("행사 관리자 토큰").optional()
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자 토큰").optional()
+                                )
                         )
                 );
     }

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -136,15 +136,15 @@ public class EventControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.memberNames[1]").value("쿠키"))
                 .andDo(
                         document("findAllEventMember",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 responseFields(
-                                         fieldWithPath("memberNames").type(JsonFieldType.ARRAY)
-                                                 .description("행사 참여자 목록")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("memberNames").type(JsonFieldType.ARRAY)
+                                                .description("행사 참여자 목록")
+                                )
                         )
                 );
     }
@@ -161,28 +161,28 @@ public class EventControllerDocsTest extends RestDocsSupport {
         String requestBody = objectMapper.writeValueAsString(memberNameUpdateRequest);
 
         mockMvc.perform(put("/api/events/{eventId}/members/nameChange", token)
-                                .cookie(EVENT_COOKIE)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody))
+                        .cookie(EVENT_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(
                         document("updateEventMemberName",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 requestCookies(
-                                         cookieWithName("eventToken").description("행사 관리자 토큰")
-                                 ),
-                                 requestFields(
-                                         fieldWithPath("members").type(JsonFieldType.ARRAY).description("수정할 참여자 목록"),
-                                         fieldWithPath("members[].before").type(JsonFieldType.STRING)
-                                                 .description("수정 전 참여자 이름"),
-                                         fieldWithPath("members[].after").type(JsonFieldType.STRING)
-                                                 .description("수정 후 참여자 이름")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자 토큰")
+                                ),
+                                requestFields(
+                                        fieldWithPath("members").type(JsonFieldType.ARRAY).description("수정할 참여자 목록"),
+                                        fieldWithPath("members[].before").type(JsonFieldType.STRING)
+                                                .description("수정 전 참여자 이름"),
+                                        fieldWithPath("members[].after").type(JsonFieldType.STRING)
+                                                .description("수정 후 참여자 이름")
+                                )
                         )
                 );
     }
@@ -197,25 +197,25 @@ public class EventControllerDocsTest extends RestDocsSupport {
         given(authService.getTokenName()).willReturn("eventToken");
 
         mockMvc.perform(post("/api/events/{eventId}/login", token)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
                 .andDo(print())
                 .andExpect(cookie().value("eventToken", "jwtToken"))
                 .andExpect(status().isOk())
                 .andDo(
                         document("eventLogin",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 requestFields(
-                                         fieldWithPath("password").type(JsonFieldType.STRING)
-                                                 .description("행사 비밀 번호")
-                                 ),
-                                 responseCookies(
-                                         cookieWithName("eventToken").description("행사 관리자용 토큰")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("password").type(JsonFieldType.STRING)
+                                                .description("행사 비밀 번호")
+                                ),
+                                responseCookies(
+                                        cookieWithName("eventToken").description("행사 관리자용 토큰")
+                                )
                         )
                 );
     }
@@ -233,7 +233,7 @@ public class EventControllerDocsTest extends RestDocsSupport {
         given(eventService.findActions(token)).willReturn(actionAppResponses);
 
         mockMvc.perform(get("/api/events/{eventId}/actions", token)
-                                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.steps[0].type").value(equalTo("IN")))
@@ -263,25 +263,6 @@ public class EventControllerDocsTest extends RestDocsSupport {
 
                 .andDo(
                         document("findActions",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 responseFields(
-                                         fieldWithPath("steps[].type").type(JsonFieldType.STRING)
-                                                 .description("액션 유형 [BILL, IN, OUT]"),
-                                         fieldWithPath("steps[].members").type(JsonFieldType.ARRAY)
-                                                 .description("해당 step에 참여한 참여자 목록"),
-                                         fieldWithPath("steps[].actions[].actionId").type(JsonFieldType.NUMBER)
-                                                 .description("액션 ID"),
-                                         fieldWithPath("steps[].actions[].name").type(JsonFieldType.STRING)
-                                                 .description("참여자 액션일 경우 참여자 이름, 지출 액션일 경우 지출 내역 이름"),
-                                         fieldWithPath("steps[].actions[].price").type(JsonFieldType.NUMBER).optional()
-                                                 .description("참여자 액션일 경우 null, 지출 액션일 경우 지출 금액"),
-                                         fieldWithPath("steps[].actions[].sequence").type(JsonFieldType.NUMBER)
-                                                 .description("액션 순서")
-                                 )
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -301,7 +282,7 @@ public class EventControllerDocsTest extends RestDocsSupport {
                                         fieldWithPath("steps[].actions[].sequence").type(JsonFieldType.NUMBER)
                                                 .description("액션 순서"),
                                         fieldWithPath("steps[].actions[].isFixed").type(JsonFieldType.BOOLEAN)
-                                                .description("지출 액션의 지출 고정 금액이 설정 여부")
+                                                .description("지출 내역의 멤버별 고정 지출 금액 생성 여부")
                                 )
                         )
                 );
@@ -320,7 +301,7 @@ public class EventControllerDocsTest extends RestDocsSupport {
         given(eventService.findActions(token)).willReturn(actionAppResponses);
 
         mockMvc.perform(get("/api/events/{eventId}/actions/v2", token)
-                                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.actions[0].actionId").value(equalTo(1)))
@@ -349,23 +330,23 @@ public class EventControllerDocsTest extends RestDocsSupport {
 
                 .andDo(
                         document("findActions",
-                                 preprocessRequest(prettyPrint()),
-                                 preprocessResponse(prettyPrint()),
-                                 pathParameters(
-                                         parameterWithName("eventId").description("행사 ID")
-                                 ),
-                                 responseFields(
-                                         fieldWithPath("actions[].actionId").type(JsonFieldType.NUMBER)
-                                                 .description("액션 ID"),
-                                         fieldWithPath("actions[].name").type(JsonFieldType.STRING)
-                                                 .description("참여자 액션일 경우 참여자 이름, 지출 액션일 경우 지출 내역 이름"),
-                                         fieldWithPath("actions[].price").type(JsonFieldType.NUMBER).optional()
-                                                 .description("참여자 액션일 경우 null, 지출 액션일 경우 지출 금액"),
-                                         fieldWithPath("actions[].sequence").type(JsonFieldType.NUMBER)
-                                                 .description("액션 순서"),
-                                         fieldWithPath("actions[].type").type(JsonFieldType.STRING)
-                                                 .description("액션 타입")
-                                 )
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("actions[].actionId").type(JsonFieldType.NUMBER)
+                                                .description("액션 ID"),
+                                        fieldWithPath("actions[].name").type(JsonFieldType.STRING)
+                                                .description("참여자 액션일 경우 참여자 이름, 지출 액션일 경우 지출 내역 이름"),
+                                        fieldWithPath("actions[].price").type(JsonFieldType.NUMBER).optional()
+                                                .description("참여자 액션일 경우 null, 지출 액션일 경우 지출 금액"),
+                                        fieldWithPath("actions[].sequence").type(JsonFieldType.NUMBER)
+                                                .description("액션 순서"),
+                                        fieldWithPath("actions[].type").type(JsonFieldType.STRING)
+                                                .description("액션 타입")
+                                )
                         )
                 );
     }

--- a/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
@@ -3,14 +3,15 @@ package server.haengdong.domain.action;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static server.haengdong.support.fixture.Fixture.EVENT1;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import server.haengdong.domain.event.Event;
 import server.haengdong.exception.HaengdongException;
-import server.haengdong.support.fixture.Fixture;
 
 class BillActionTest {
 
@@ -18,7 +19,7 @@ class BillActionTest {
     @ParameterizedTest
     @ValueSource(strings = {"", " ", "1234567890123456789012345678901"})
     void validateTitle(String title) {
-        Event event = Fixture.EVENT1;
+        Event event = EVENT1;
         Action action = new Action(event, 1L);
         Long price = 100L;
 
@@ -31,7 +32,7 @@ class BillActionTest {
     @ParameterizedTest
     @ValueSource(longs = {0, 10_000_001, 20_000_000})
     void validatePrice(long price) {
-        Event event = Fixture.EVENT1;
+        Event event = EVENT1;
         Action action = new Action(event, 1L);
         String title = "title";
 
@@ -43,7 +44,7 @@ class BillActionTest {
     @DisplayName("지출 내역을 올바르게 생성한다.")
     @Test
     void createBillAction() {
-        Event event = Fixture.EVENT1;
+        Event event = EVENT1;
         Action action = new Action(event, 1L);
         String title = "title";
         Long price = 1_000L;
@@ -55,5 +56,33 @@ class BillActionTest {
                 () -> assertThat(billAction.getTitle()).isEqualTo(title),
                 () -> assertThat(billAction.getPrice()).isEqualTo(price)
         );
+    }
+
+    @DisplayName("지출 액션에 멤버별 고정 금액이 설정되어 있는지 확인한다.")
+    @Test
+    void isFixed1() {
+        BillAction fixedBillAction = new BillAction(new Action(EVENT1, 1L), "인생네컷", 2_000L);
+
+        List<BillActionDetail> unfixedBillActionDetails = List.of(
+                new BillActionDetail("감자", 1_000L),
+                new BillActionDetail("고구마", 1_000L)
+        );
+        fixedBillAction.addDetails(unfixedBillActionDetails);
+
+        assertThat(fixedBillAction.isFixed()).isEqualTo(false);
+    }
+
+    @DisplayName("지출 액션에 멤버별 고정 금액이 설정되어 있는지 확인한다.")
+    @Test
+    void isFixed2() {
+        BillAction fixedBillAction = new BillAction(new Action(EVENT1, 1L), "인생네컷", 5_000L);
+
+        List<BillActionDetail> unfixedBillActionDetails = List.of(
+                new BillActionDetail("감자", 4_000L),
+                new BillActionDetail("고구마", 1_000L)
+        );
+        fixedBillAction.addDetails(unfixedBillActionDetails);
+
+        assertThat(fixedBillAction.isFixed()).isEqualTo(true);
     }
 }

--- a/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
@@ -19,8 +19,20 @@ class MemberBillReportTest {
         Event event = Fixture.EVENT1;
         List<BillAction> billActions = List.of(
                 new BillAction(new Action(event, 4L), "뽕족", 60_000L),
-                new BillAction(new Action(event, 6L), "인생맥주", 40_000L),
                 new BillAction(new Action(event, 7L), "인생네컷", 20_000L)
+        );
+        billActions.get(0).addDetails(
+                List.of(
+                        new BillActionDetail("소하", 10_000L),
+                        new BillActionDetail("감자", 40_000L),
+                        new BillActionDetail("쿠키", 10_000L)
+                )
+        );
+        billActions.get(1).addDetails(
+                List.of(
+                        new BillActionDetail("소하", 5_000L),
+                        new BillActionDetail("쿠키", 15_000L)
+                )
         );
         List<MemberAction> memberActions = List.of(
                 new MemberAction(new Action(event, 1L), "소하", IN, 1L),
@@ -34,9 +46,9 @@ class MemberBillReportTest {
         assertThat(memberBillReport.getReports())
                 .containsAllEntriesOf(
                         Map.of(
-                                "감자", 20_000L,
-                                "쿠키", 50_000L,
-                                "소하", 50_000L
+                                "감자", 40_000L,
+                                "쿠키", 25_000L,
+                                "소하", 15_000L
                         )
                 );
     }


### PR DESCRIPTION
## issue
- close #374 

## 구현 사항
- 참여자별 정산 현황 조회 시 BillActionDetail을 통해 각 참여자의 정산 금액을 계산하도록 수정
- 액션 이력 조회 시 지출 액션 고정 금액 설정 여부 필드 추가
