### PR TITLE
[BE] 참여자 개별 지출 금액 수정 및 조회 기능 구현

### DIFF
--- a/server/src/docs/asciidoc/billActionDetail.adoc
+++ b/server/src/docs/asciidoc/billActionDetail.adoc
@@ -1,5 +1,45 @@
 == 지출 상세
 
+=== 지출 상세 조회
+
+operation::findBillActionDetailsTest[snippets="path-parameters,http-request,http-response,request-cookies"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+  {
+    "code": "EVENT_NOT_FOUND",
+    "message": "존재하지 않는 행사입니다."
+  },
+  {
+    "code": "BILL_ACTION_NOT_FOUND",
+    "message": "존재하지 않는 지출 액션입니다."
+  },
+  {
+    "code": "BILL_ACTION_DETAIL_NOT_FOUND",
+    "message": "존재하지 않는 참여자 지출입니다."
+  },
+  {
+    "code": "TOKEN_NOT_FOUND",
+    "message": "토큰이 존재하지 않습니다."
+  },
+  {
+    "code": "TOKEN_EXPIRED",
+    "message": "만료된 토큰입니다."
+  },
+  {
+    "code": "TOKEN_INVALID",
+    "message": "유효하지 않은 토큰입니다."
+  },
+  {
+    "code": "FORBIDDEN",
+    "message": "접근할 수 없는 행사입니다."
+  }
+]
+----
+
 === 지출 상세 수정
 
 operation::updateBillActionDetailsTest[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]

--- a/server/src/docs/asciidoc/billActionDetail.adoc
+++ b/server/src/docs/asciidoc/billActionDetail.adoc
@@ -1,0 +1,53 @@
+== 지출 상세
+
+=== 지출 상세 수정
+
+operation::updateBillActionDetailsTest[snippets="path-parameters,http-request,request-body,request-fields,http-response,request-cookies"]
+
+==== [.red]#Exceptions#
+
+[source,json,options="nowrap"]
+----
+[
+  {
+    "code": "REQUEST_EMPTY",
+    "message": "멤버 이름은 공백일 수 없습니다."
+  },
+  {
+    "code": "REQUEST_EMPTY",
+    "message": "지출 금액은 공백일 수 없습니다."
+  },
+  {
+    "code": "EVENT_NOT_FOUND",
+    "message": "존재하지 않는 행사입니다."
+  },
+  {
+    "code": "BILL_ACTION_NOT_FOUND",
+    "message": "존재하지 않는 지출 액션입니다."
+  },
+  {
+    "code": "BILL_ACTION_DETAIL_NOT_FOUND",
+    "message": "존재하지 않는 참여자 지출입니다."
+  },
+  {
+    "code": "BILL_ACTION_PRICE_NOT_MATCHED",
+    "message": "지출 총액이 일치하지 않습니다."
+  },
+  {
+    "code": "TOKEN_NOT_FOUND",
+    "message": "토큰이 존재하지 않습니다."
+  },
+  {
+    "code": "TOKEN_EXPIRED",
+    "message": "만료된 토큰입니다."
+  },
+  {
+    "code": "TOKEN_INVALID",
+    "message": "유효하지 않은 토큰입니다."
+  },
+  {
+    "code": "FORBIDDEN",
+    "message": "접근할 수 없는 행사입니다."
+  }
+]
+----

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -1,15 +1,12 @@
-:source-highlighter: highlightjs
-:hardbreaks:
-:toc: left
-:doctype: book
-:icons: font
-:toc-title: 전체 API 목록
-:toclevels: 2
-:sectlinks:
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= 행동대장
+:source-highlighter: highlightjs :hardbreaks:
+:toc: left :doctype: book :icons: font :toc-title: 전체 API 목록 :toclevels: 2 :sectlinks:
 :sectnums:
 :sectnumlevels: 2
 
-= 행동대장
 
 include::{docdir}/event.adoc[]
 include::{docdir}/memberBillReport.adoc[]

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -12,4 +12,4 @@ include::{docdir}/event.adoc[]
 include::{docdir}/memberBillReport.adoc[]
 include::{docdir}/memberAction.adoc[]
 include::{docdir}/billAction.adoc[]
-
+include::{docdir}/billActionDetail.adoc[]

--- a/server/src/main/java/server/haengdong/application/BillActionDetailService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionDetailService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.haengdong.application.request.BillActionDetailUpdateAppRequest;
 import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
 import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionDetail;
 import server.haengdong.domain.action.BillActionDetailRepository;
@@ -21,6 +22,16 @@ public class BillActionDetailService {
 
     private final BillActionDetailRepository billActionDetailRepository;
     private final BillActionRepository billActionRepository;
+
+    public BillActionDetailsAppResponse findBillActionDetails(String token, Long actionId) {
+        BillAction billAction = billActionRepository.findByAction_Id(actionId)
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND));
+        validateToken(token, billAction);
+        
+        List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
+
+        return BillActionDetailsAppResponse.of(billActionDetails);
+    }
 
     @Transactional
     public void updateBillActionDetails(String token, Long actionId, BillActionDetailsUpdateAppRequest request) {

--- a/server/src/main/java/server/haengdong/application/BillActionDetailService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionDetailService.java
@@ -1,12 +1,62 @@
 package server.haengdong.application;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.haengdong.application.request.BillActionDetailUpdateAppRequest;
+import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.BillActionDetail;
+import server.haengdong.domain.action.BillActionDetailRepository;
 import server.haengdong.domain.action.BillActionRepository;
+import server.haengdong.domain.event.Event;
+import server.haengdong.exception.HaengdongErrorCode;
+import server.haengdong.exception.HaengdongException;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class BillActionDetailService {
 
+    private final BillActionDetailRepository billActionDetailRepository;
     private final BillActionRepository billActionRepository;
+
+    @Transactional
+    public void updateBillActionDetails(String token, Long actionId, BillActionDetailsUpdateAppRequest request) {
+        BillAction billAction = billActionRepository.findByAction_Id(actionId)
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND));
+
+        validateToken(token, billAction);
+        List<BillActionDetailUpdateAppRequest> billActionDetailUpdateAppRequests = request.billActionDetailUpdateAppRequests();
+
+        Long requestsPriceSum = billActionDetailUpdateAppRequests.stream()
+                .map(BillActionDetailUpdateAppRequest::price)
+                .reduce(0L, Long::sum);
+        if (!billAction.getPrice().equals(requestsPriceSum)) {
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_PRICE_NOT_MATCHED);
+        }
+
+        List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
+
+        List<BillActionDetail> updatedBillActionDetails = new ArrayList<>();
+        for (BillActionDetailUpdateAppRequest updateRequest : billActionDetailUpdateAppRequests) {
+            BillActionDetail detailToUpdate = billActionDetails.stream()
+                    .filter(detail -> detail.getMemberName().equals(updateRequest.name()))
+                    .findFirst()
+                    .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_DETAIL_NOT_FOUND));
+
+            updatedBillActionDetails.add(detailToUpdate.update(updateRequest.price()));
+        }
+
+        billActionDetailRepository.saveAll(updatedBillActionDetails);
+    }
+
+    private void validateToken(String token, BillAction billAction) {
+        Event event = billAction.getEvent();
+        if (event.isTokenMismatch(token)) {
+            throw new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND);
+        }
+    }
 }

--- a/server/src/main/java/server/haengdong/application/BillActionService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionService.java
@@ -75,7 +75,7 @@ public class BillActionService {
 
     private void resetBillActionDetail(BillAction billAction, Long updatePrice) {
         if (billAction.getPrice() != updatePrice) {
-            List<BillActionDetail> billActionDetails = billActionDetailRepository.findByBillAction(billAction);
+            List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
             int memberCount = billActionDetails.size();
             if (memberCount != 0) {
                 Long eachPrice = updatePrice / memberCount;

--- a/server/src/main/java/server/haengdong/application/request/BillActionDetailUpdateAppRequest.java
+++ b/server/src/main/java/server/haengdong/application/request/BillActionDetailUpdateAppRequest.java
@@ -1,0 +1,7 @@
+package server.haengdong.application.request;
+
+public record BillActionDetailUpdateAppRequest(
+        String name,
+        Long price
+) {
+}

--- a/server/src/main/java/server/haengdong/application/request/BillActionDetailsUpdateAppRequest.java
+++ b/server/src/main/java/server/haengdong/application/request/BillActionDetailsUpdateAppRequest.java
@@ -1,0 +1,8 @@
+package server.haengdong.application.request;
+
+import java.util.List;
+
+public record BillActionDetailsUpdateAppRequest(
+        List<BillActionDetailUpdateAppRequest> billActionDetailUpdateAppRequests
+) {
+}

--- a/server/src/main/java/server/haengdong/application/response/BillActionDetailAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/BillActionDetailAppResponse.java
@@ -1,0 +1,13 @@
+package server.haengdong.application.response;
+
+import server.haengdong.domain.action.BillActionDetail;
+
+public record BillActionDetailAppResponse(
+        String name,
+        Long price
+) {
+
+    public static BillActionDetailAppResponse of(BillActionDetail billActionDetail) {
+        return new BillActionDetailAppResponse(billActionDetail.getMemberName(), billActionDetail.getPrice());
+    }
+}

--- a/server/src/main/java/server/haengdong/application/response/BillActionDetailsAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/BillActionDetailsAppResponse.java
@@ -1,0 +1,14 @@
+package server.haengdong.application.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import server.haengdong.domain.action.BillActionDetail;
+
+public record BillActionDetailsAppResponse(List<BillActionDetailAppResponse> billActionDetailAppResponses) {
+
+    public static BillActionDetailsAppResponse of(List<BillActionDetail> billActionDetails) {
+        return billActionDetails.stream()
+                .map(BillActionDetailAppResponse::of)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), BillActionDetailsAppResponse::new));
+    }
+}

--- a/server/src/main/java/server/haengdong/domain/action/BillAction.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillAction.java
@@ -67,6 +67,10 @@ public class BillAction implements Comparable<BillAction> {
         return new BillAction(id, action, title, price);
     }
 
+    public boolean isSamePrice(Long price) {
+        return this.price.equals(price);
+    }
+
     public Long getSequence() {
         return action.getSequence();
     }

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
@@ -33,7 +33,11 @@ public class BillActionDetail {
         this.price = price;
     }
 
-    public BillActionDetail update(Long price) {
-        return new BillActionDetail(id, billAction, memberName, price);
+    public void updatePrice(Long price) {
+        this.price = price;
+    }
+
+    public boolean isSameName(String memberName) {
+        return this.memberName.equals(memberName);
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
@@ -25,4 +25,15 @@ public class BillActionDetail {
     private String memberName;
 
     private Long price;
+
+    public BillActionDetail(Long id, BillAction billAction, String memberName, Long price) {
+        this.id = id;
+        this.billAction = billAction;
+        this.memberName = memberName;
+        this.price = price;
+    }
+
+    public BillActionDetail update(Long price) {
+        return new BillActionDetail(id, billAction, memberName, price);
+    }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetailRepository.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetailRepository.java
@@ -1,7 +1,10 @@
 package server.haengdong.domain.action;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import server.haengdong.domain.event.Event;
 
 @Repository
 public interface BillActionDetailRepository extends JpaRepository<BillActionDetail, Long> {
@@ -12,8 +15,6 @@ public interface BillActionDetailRepository extends JpaRepository<BillActionDeta
             where bd.billAction = :billAction
             """)
     List<BillActionDetail> findAllByBillAction(BillAction billAction);
-
-    List<BillActionDetail> findByBillAction(BillAction billAction);
 
     void deleteAllByBillAction(BillAction billAction);
 

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetailRepository.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetailRepository.java
@@ -1,8 +1,17 @@
 package server.haengdong.domain.action;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BillActionDetailRepository extends JpaRepository<BillActionDetail, Long> {
+
+    @Query("""
+            select bd
+            from BillActionDetail bd
+            where bd.billAction = :billAction
+            """)
+    List<BillActionDetail> findAllByBillAction(BillAction billAction);
 }

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -35,6 +35,8 @@ public enum HaengdongErrorCode {
             BillAction.MIN_TITLE_LENGTH,
             BillAction.MAX_TITLE_LENGTH)),
     BILL_ACTION_PRICE_INVALID(String.format("지출 금액은 %,d 이하의 자연수여야 합니다.", BillAction.MAX_PRICE)),
+    BILL_ACTION_DETAIL_NOT_FOUND("존재하지 않는 참여자 지출입니다."),
+    BILL_ACTION_PRICE_NOT_MATCHED("지출 총액이 일치하지 않습니다."),
 
     /* Authentication */
 
@@ -55,7 +57,8 @@ public enum HaengdongErrorCode {
     MESSAGE_NOT_READABLE("읽을 수 없는 요청입니다."),
     REQUEST_METHOD_NOT_SUPPORTED("지원하지 않는 요청 메서드입니다."),
     NO_RESOURCE_REQUEST("존재하지 않는 자원입니다."),
-    INTERNAL_SERVER_ERROR("서버 내부에서 에러가 발생했습니다.");
+    INTERNAL_SERVER_ERROR("서버 내부에서 에러가 발생했습니다."),
+    ;
 
     private final String message;
 

--- a/server/src/main/java/server/haengdong/presentation/BillActionDetailController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillActionDetailController.java
@@ -3,18 +3,31 @@ package server.haengdong.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.BillActionDetailService;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
 import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
+import server.haengdong.presentation.response.BillActionDetailsResponse;
 
 @RequiredArgsConstructor
 @RestController
 public class BillActionDetailController {
 
     private final BillActionDetailService billActionDetailService;
+
+    @GetMapping("/api/events/{eventId}/bill-actions/{actionId}/fixed")
+    public ResponseEntity<BillActionDetailsResponse> findBillActionDetails(
+            @PathVariable("eventId") String token,
+            @PathVariable("actionId") Long actionId
+    ) {
+        BillActionDetailsAppResponse appResponse = billActionDetailService.findBillActionDetails(token, actionId);
+
+        return ResponseEntity.ok(BillActionDetailsResponse.of(appResponse));
+    }
 
     @PutMapping("/api/events/{eventId}/bill-actions/{actionId}/fixed")
     public ResponseEntity<Void> updateBillActionDetails(

--- a/server/src/main/java/server/haengdong/presentation/BillActionDetailController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillActionDetailController.java
@@ -1,12 +1,29 @@
 package server.haengdong.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.haengdong.application.BillActionDetailService;
+import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
 
 @RequiredArgsConstructor
 @RestController
 public class BillActionDetailController {
 
     private final BillActionDetailService billActionDetailService;
+
+    @PutMapping("/api/events/{eventId}/bill-actions/{actionId}/fixed")
+    public ResponseEntity<Void> updateBillActionDetails(
+            @PathVariable("eventId") String token,
+            @PathVariable("actionId") Long actionId,
+            @Valid @RequestBody BillActionDetailsUpdateRequest request
+    ) {
+        billActionDetailService.updateBillActionDetails(token, actionId, request.toAppRequest());
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionDetailUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionDetailUpdateRequest.java
@@ -1,0 +1,18 @@
+package server.haengdong.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import server.haengdong.application.request.BillActionDetailUpdateAppRequest;
+
+public record BillActionDetailUpdateRequest(
+
+        @NotBlank(message = "맴버 이름은 공백일 수 없습니다.")
+        String name,
+
+        @NotNull(message = "지출 금액은 공백일 수 없습니다.")
+        Long price
+) {
+    public BillActionDetailUpdateAppRequest toAppRequest() {
+        return new BillActionDetailUpdateAppRequest(this.name, this.price);
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionDetailsUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionDetailsUpdateRequest.java
@@ -1,0 +1,15 @@
+package server.haengdong.presentation.request;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+
+public record BillActionDetailsUpdateRequest(
+        @Valid List<BillActionDetailUpdateRequest> requests
+) {
+    public BillActionDetailsUpdateAppRequest toAppRequest() {
+        return new BillActionDetailsUpdateAppRequest(requests.stream()
+                .map(BillActionDetailUpdateRequest::toAppRequest)
+                .toList());
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionDetailsUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionDetailsUpdateRequest.java
@@ -5,10 +5,10 @@ import java.util.List;
 import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
 
 public record BillActionDetailsUpdateRequest(
-        @Valid List<BillActionDetailUpdateRequest> requests
+        @Valid List<BillActionDetailUpdateRequest> members
 ) {
     public BillActionDetailsUpdateAppRequest toAppRequest() {
-        return new BillActionDetailsUpdateAppRequest(requests.stream()
+        return new BillActionDetailsUpdateAppRequest(members.stream()
                 .map(BillActionDetailUpdateRequest::toAppRequest)
                 .toList());
     }

--- a/server/src/main/java/server/haengdong/presentation/response/BillActionDetailResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/BillActionDetailResponse.java
@@ -1,0 +1,13 @@
+package server.haengdong.presentation.response;
+
+import server.haengdong.application.response.BillActionDetailAppResponse;
+
+public record BillActionDetailResponse(
+        String name,
+        Long price
+) {
+
+    public static BillActionDetailResponse of(BillActionDetailAppResponse billActionDetailAppResponse) {
+        return new BillActionDetailResponse(billActionDetailAppResponse.name(), billActionDetailAppResponse.price());
+    }
+}

--- a/server/src/main/java/server/haengdong/presentation/response/BillActionDetailsResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/BillActionDetailsResponse.java
@@ -1,0 +1,16 @@
+package server.haengdong.presentation.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
+
+public record BillActionDetailsResponse(
+        List<BillActionDetailResponse> members
+) {
+
+    public static BillActionDetailsResponse of(BillActionDetailsAppResponse billActionDetailsAppResponse) {
+        return billActionDetailsAppResponse.billActionDetailAppResponses().stream()
+                .map(BillActionDetailResponse::of)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), BillActionDetailsResponse::new));
+    }
+}

--- a/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import server.haengdong.application.request.BillActionDetailUpdateAppRequest;
 import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+import server.haengdong.application.response.BillActionDetailAppResponse;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
 import server.haengdong.domain.action.Action;
 import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.action.BillActionDetail;
@@ -33,6 +35,29 @@ class BillActionDetailServiceTest extends ServiceTestSupport {
 
     @Autowired
     private BillActionDetailRepository billActionDetailRepository;
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillActionDetailsTest() {
+        Event event1 = Fixture.EVENT1;
+        eventRepository.save(event1);
+        Action action = new Action(event1, 1L);
+        BillAction billAction = new BillAction(action, "뽕족", 10000L);
+        billActionRepository.save(billAction);
+        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 6000L);
+        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 4000L);
+        billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
+
+        BillActionDetailsAppResponse response = billActionDetailService.findBillActionDetails(
+                event1.getToken(), action.getId());
+
+        assertThat(response.billActionDetailAppResponses()).hasSize(2)
+                .extracting(BillActionDetailAppResponse::name, BillActionDetailAppResponse::price)
+                .containsExactly(
+                        tuple("토다리", 6000L),
+                        tuple("쿠키", 4000L)
+                );
+    }
 
     @DisplayName("지출 금액 수정 요청의 총합이 지출 금액과 일치하지 않으면 예외가 발생한다.")
     @Test
@@ -77,7 +102,7 @@ class BillActionDetailServiceTest extends ServiceTestSupport {
         List<BillActionDetail> results = billActionDetailRepository.findAll();
 
         assertThat(results).hasSize(2)
-                .extracting("memberName", "price")
+                .extracting(BillActionDetail::getMemberName, BillActionDetail::getPrice)
                 .containsExactly(
                         tuple("토다리", 3000L),
                         tuple("쿠키", 7000L)

--- a/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
@@ -1,0 +1,86 @@
+package server.haengdong.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import server.haengdong.application.request.BillActionDetailUpdateAppRequest;
+import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+import server.haengdong.domain.action.Action;
+import server.haengdong.domain.action.BillAction;
+import server.haengdong.domain.action.BillActionDetail;
+import server.haengdong.domain.action.BillActionDetailRepository;
+import server.haengdong.domain.action.BillActionRepository;
+import server.haengdong.domain.event.Event;
+import server.haengdong.domain.event.EventRepository;
+import server.haengdong.exception.HaengdongException;
+import server.haengdong.support.fixture.Fixture;
+
+class BillActionDetailServiceTest extends ServiceTestSupport {
+
+    @Autowired
+    private BillActionDetailService billActionDetailService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private BillActionRepository billActionRepository;
+
+    @Autowired
+    private BillActionDetailRepository billActionDetailRepository;
+
+    @DisplayName("지출 금액 수정 요청의 총합이 지출 금액과 일치하지 않으면 예외가 발생한다.")
+    @Test
+    void updateBillActionDetailsTest1() {
+        Event event1 = Fixture.EVENT1;
+        eventRepository.save(event1);
+        Action action = new Action(event1, 1L);
+        BillAction billAction = new BillAction(action, "뽕족", 10000L);
+        billActionRepository.save(billAction);
+        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 5000L);
+        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 5000L);
+        billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
+
+        BillActionDetailsUpdateAppRequest request = new BillActionDetailsUpdateAppRequest(List.of(
+                new BillActionDetailUpdateAppRequest("토다리", 3000L),
+                new BillActionDetailUpdateAppRequest("쿠키", 4000L)
+        ));
+        assertThatCode(
+                () -> billActionDetailService.updateBillActionDetails(event1.getToken(), action.getId(), request))
+                .isInstanceOf(HaengdongException.class)
+                .hasMessage("지출 총액이 일치하지 않습니다.");
+    }
+
+    @DisplayName("지출 고정 금액을 수정한다.")
+    @Test
+    void updateBillActionDetailsTest2() {
+        Event event1 = Fixture.EVENT1;
+        eventRepository.save(event1);
+        Action action = new Action(event1, 1L);
+        BillAction billAction = new BillAction(action, "뽕족", 10000L);
+        billActionRepository.save(billAction);
+        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 5000L);
+        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 5000L);
+        billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
+
+        BillActionDetailsUpdateAppRequest request = new BillActionDetailsUpdateAppRequest(List.of(
+                new BillActionDetailUpdateAppRequest("토다리", 3000L),
+                new BillActionDetailUpdateAppRequest("쿠키", 7000L)
+        ));
+        billActionDetailService.updateBillActionDetails(event1.getToken(), action.getId(), request);
+
+        List<BillActionDetail> results = billActionDetailRepository.findAll();
+
+        assertThat(results).hasSize(2)
+                .extracting("memberName", "price")
+                .containsExactly(
+                        tuple("토다리", 3000L),
+                        tuple("쿠키", 7000L)
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
@@ -174,7 +174,7 @@ class BillActionServiceTest extends ServiceTestSupport {
         billActionService.updateBillAction(event.getToken(), actionId, request);
 
         BillAction updatedBillAction = billActionRepository.findById(savedBillAction.getId()).get();
-        List<BillActionDetail> billActionDetails = billActionDetailRepository.findByBillAction(updatedBillAction);
+        List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(updatedBillAction);
 
         assertThat(billActionDetails).hasSize(4)
                 .extracting("memberName", "price")

--- a/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
@@ -153,7 +153,7 @@ class MemberActionServiceTest extends ServiceTestSupport {
 
         memberActionService.deleteMember(event.getToken(), "쿠키");
 
-        List<BillActionDetail> billActionDetails = billActionDetailRepository.findByBillAction(billAction);
+        List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
 
         assertThat(billActionDetails).hasSize(2)
                 .extracting("memberName", "price")
@@ -226,7 +226,7 @@ class MemberActionServiceTest extends ServiceTestSupport {
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2, billActionDetail3));
 
         memberActionService.deleteMemberAction(event.getToken(), targetAction.getId());
-        List<BillActionDetail> billActionDetails = billActionDetailRepository.findByBillAction(billAction);
+        List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
 
         assertThat(billActionDetails).hasSize(4)
                 .extracting("memberName", "price")

--- a/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
@@ -1,0 +1,79 @@
+package server.haengdong.docs;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import server.haengdong.application.BillActionDetailService;
+import server.haengdong.presentation.BillActionDetailController;
+import server.haengdong.presentation.request.BillActionDetailUpdateRequest;
+import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
+
+public class BillActionDetailControllerDocsTest extends RestDocsSupport {
+
+    private final BillActionDetailService billActionDetailService = mock(BillActionDetailService.class);
+
+    @Override
+    protected Object initController() {
+        return new BillActionDetailController(billActionDetailService);
+    }
+
+    @DisplayName("참여자별 지출 금액을 수정한다.")
+    @Test
+    void updateBillActionDetailsTest() throws Exception {
+        List<BillActionDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
+                new BillActionDetailUpdateRequest("소하", 10000L),
+                new BillActionDetailUpdateRequest("웨디", 20000L)
+        );
+        BillActionDetailsUpdateRequest request = new BillActionDetailsUpdateRequest(
+                billActionDetailUpdateRequests);
+
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(
+                        put("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L)
+                                .cookie(EVENT_COOKIE)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(json))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(
+                        document("updateBillActionDetailsTest",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("actionId").description("액션 ID")
+                                ),
+                                requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자 토큰")
+                                ),
+                                requestFields(
+                                        fieldWithPath("members").type(JsonFieldType.ARRAY)
+                                                .description("전체 정산 수정 요청 목록"),
+                                        fieldWithPath("members[0].name").type(JsonFieldType.STRING)
+                                                .description("참여자 이름"),
+                                        fieldWithPath("members[0].price").type(JsonFieldType.NUMBER)
+                                                .description("참여자 정산 금액")
+                                )
+                        )
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
@@ -1,18 +1,24 @@
 package server.haengdong.docs;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
 
@@ -22,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import server.haengdong.application.BillActionDetailService;
+import server.haengdong.application.response.BillActionDetailAppResponse;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
 import server.haengdong.presentation.BillActionDetailController;
 import server.haengdong.presentation.request.BillActionDetailUpdateRequest;
 import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
@@ -33,6 +41,42 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
     @Override
     protected Object initController() {
         return new BillActionDetailController(billActionDetailService);
+    }
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillActionDetailsTest() throws Exception {
+        BillActionDetailsAppResponse appResponse = new BillActionDetailsAppResponse(
+                List.of(new BillActionDetailAppResponse("토다리", 1000L)));
+        given(billActionDetailService.findBillActionDetails(anyString(), anyLong()))
+                .willReturn(appResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members[0].name").value("토다리"))
+                .andExpect(jsonPath("$.members[0].price").value(1000L))
+                .andDo(
+                        document("findBillActionDetailsTest",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("actionId").description("액션 ID")
+                                ), requestCookies(
+                                        cookieWithName("eventToken").description("행사 관리자 토큰")
+                                ), responseFields(
+                                        fieldWithPath("members").type(JsonFieldType.ARRAY)
+                                                .description("전체 정산 수정 요청 목록"),
+                                        fieldWithPath("members[0].name").type(JsonFieldType.STRING)
+                                                .description("참여자 이름"),
+                                        fieldWithPath("members[0].price").type(JsonFieldType.NUMBER)
+                                                .description("참여자 정산 금액")
+                                )
+                        )
+                );
     }
 
     @DisplayName("참여자별 지출 금액을 수정한다.")
@@ -47,11 +91,10 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
 
         String json = objectMapper.writeValueAsString(request);
 
-        mockMvc.perform(
-                        put("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L)
-                                .cookie(EVENT_COOKIE)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(json))
+        mockMvc.perform(put("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L)
+                        .cookie(EVENT_COOKIE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(

--- a/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
@@ -1,17 +1,39 @@
 package server.haengdong.presentation;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import server.haengdong.application.response.BillActionDetailAppResponse;
+import server.haengdong.application.response.BillActionDetailsAppResponse;
 import server.haengdong.presentation.request.BillActionDetailUpdateRequest;
 import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
 
 class BillActionDetailControllerTest extends ControllerTestSupport {
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillActionDetails() throws Exception {
+        BillActionDetailsAppResponse appResponse = new BillActionDetailsAppResponse(
+                List.of(new BillActionDetailAppResponse("토다리", 1000L)));
+        given(billActionDetailService.findBillActionDetails(anyString(), anyLong()))
+                .willReturn(appResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members[0].name").value("토다리"))
+                .andExpect(jsonPath("$.members[0].price").value(1000L));
+    }
 
     @DisplayName("참여자별 지출 금액을 수정한다.")
     @Test

--- a/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
@@ -1,9 +1,5 @@
 package server.haengdong.presentation;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,7 +8,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
 import server.haengdong.presentation.request.BillActionDetailUpdateRequest;
 import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
 
@@ -30,10 +25,7 @@ class BillActionDetailControllerTest extends ControllerTestSupport {
 
         String json = objectMapper.writeValueAsString(request);
 
-        doNothing().when(billActionDetailService)
-                .updateBillActionDetails(anyString(), anyLong(), any(BillActionDetailsUpdateAppRequest.class));
-
-        mockMvc.perform(put("/api/events/TOKEN/bill-actions/1/fixed")
+        mockMvc.perform(put("/api/events/{eventId}/bill-actions/{actionId}/fixed", "TOKEN", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
                 .andDo(print())

--- a/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
@@ -1,0 +1,42 @@
+package server.haengdong.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import server.haengdong.application.request.BillActionDetailsUpdateAppRequest;
+import server.haengdong.presentation.request.BillActionDetailUpdateRequest;
+import server.haengdong.presentation.request.BillActionDetailsUpdateRequest;
+
+class BillActionDetailControllerTest extends ControllerTestSupport {
+
+    @DisplayName("참여자별 지출 금액을 수정한다.")
+    @Test
+    void updateBillActionDetailsTest() throws Exception {
+        List<BillActionDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
+                new BillActionDetailUpdateRequest("소하", 10000L),
+                new BillActionDetailUpdateRequest("웨디", 20000L)
+        );
+        BillActionDetailsUpdateRequest request = new BillActionDetailsUpdateRequest(
+                billActionDetailUpdateRequests);
+
+        String json = objectMapper.writeValueAsString(request);
+
+        doNothing().when(billActionDetailService)
+                .updateBillActionDetails(anyString(), anyLong(), any(BillActionDetailsUpdateAppRequest.class));
+
+        mockMvc.perform(put("/api/events/TOKEN/bill-actions/1/fixed")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/server/src/test/java/server/haengdong/presentation/ControllerTestSupport.java
+++ b/server/src/test/java/server/haengdong/presentation/ControllerTestSupport.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import server.haengdong.application.ActionService;
 import server.haengdong.application.AuthService;
+import server.haengdong.application.BillActionDetailService;
 import server.haengdong.application.BillActionService;
 import server.haengdong.application.EventService;
 import server.haengdong.application.MemberActionService;
@@ -19,7 +20,8 @@ import server.haengdong.application.MemberActionService;
                 EventController.class,
                 ActionController.class,
                 BillActionController.class,
-                MemberActionController.class
+                MemberActionController.class,
+                BillActionDetailController.class
         },
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {WebMvcConfigurer.class})}
 )
@@ -27,6 +29,7 @@ abstract class ControllerTestSupport {
 
     @Autowired
     protected MockMvc mockMvc;
+
     @Autowired
     protected ObjectMapper objectMapper;
 
@@ -44,4 +47,7 @@ abstract class ControllerTestSupport {
 
     @MockBean
     protected BillActionService billActionService;
+
+    @MockBean
+    protected BillActionDetailService billActionDetailService;
 }


### PR DESCRIPTION
## issue
- close #365 

## 구현 사항
### 조회
지출에 포함된 참여자들의 개별 지출 금액을 조회합니다.
EventId, actionId로 해당 행사와 지출 액션이 존재하는지 확인하고 존재하지 않으면 예외가 발생합니다.

### 수정
지출에 포함된 참여자들의 개별 지출 금액을 수정합니다.
BillAction이 가지고있는 총 금액과 비교하여 수정 요청 금액이 일치하지 않는 경우 예외를 던집니다.
수정 요청에 포함된 참여자의 이름으로 BillActionDetail을 조회하여 일치하지 않는 참여자가 있는 경우 예외를 던집니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
