### PR TITLE
[FE] 공통 input 코드를 useInput hook으로 분리

### DIFF
--- a/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
+++ b/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/OutMember.tsx
@@ -15,10 +15,10 @@ const OutMember = ({dynamicProps}: OutMemberProps) => {
     deleteEmptyInputElementOnBlur,
     focusNextInputOnEnter,
     handleInputChange,
-    validateAndSetTargetInput,
+    handleChange,
   } = dynamicProps;
   const {currentInputIndex, filteredInMemberList, handleCurrentInputIndex, searchCurrentInMember, chooseMember} =
-    useSearchInMemberList(validateAndSetTargetInput);
+    useSearchInMemberList(handleChange);
 
   const validationAndSearchOnChange = (inputIndex: number, event: React.ChangeEvent<HTMLInputElement>) => {
     handleCurrentInputIndex(inputIndex);

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -42,6 +42,7 @@ export const ERROR_MESSAGE = {
   purchasePrice: '10,000,000원 이하의 숫자만 입력이 가능해요',
   purchaseTitle: '지출 이름은 30자 이하의 한글, 영어, 숫자만 가능해요',
   preventEmpty: '값은 비어있을 수 없어요',
+  invalidInput: '올바르지 않은 입력이에요.',
 };
 
 export const UNKNOWN_ERROR = 'UNKNOWN_ERROR';

--- a/client/src/hooks/useDynamicInput.tsx
+++ b/client/src/hooks/useDynamicInput.tsx
@@ -2,6 +2,8 @@ import {useEffect, useRef, useState} from 'react';
 
 import {ValidateResult} from '@utils/validate/type';
 
+import useInput from './useInput';
+
 type InputValue = {
   value: string;
   index: number;
@@ -10,22 +12,25 @@ type InputValue = {
 export type ReturnUseDynamicInput = {
   inputList: InputValue[];
   inputRefList: React.MutableRefObject<(HTMLInputElement | null)[]>;
-  handleInputChange: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
-  deleteEmptyInputElementOnBlur: () => void;
   errorMessage: string;
-  getFilledInputList: (list?: InputValue[]) => InputValue[];
-  focusNextInputOnEnter: (e: React.KeyboardEvent<HTMLInputElement>, index: number) => void;
   canSubmit: boolean;
   errorIndexList: number[];
-  validateAndSetTargetInput: (index: number, value: string) => void;
+  handleChange: (index: number, value: string) => void;
+  handleInputChange: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
+  deleteEmptyInputElementOnBlur: () => void;
+  getFilledInputList: (list?: InputValue[]) => InputValue[];
+  focusNextInputOnEnter: (e: React.KeyboardEvent<HTMLInputElement>, index: number) => void;
+  setInputValueTargetIndex: (index: number, value: string) => void;
 };
 
 const useDynamicInput = (validateFunc: (name: string) => ValidateResult): ReturnUseDynamicInput => {
-  const [inputList, setInputList] = useState<InputValue[]>([{index: 0, value: ''}]);
+  const initialInputList = [{index: 0, value: ''}];
   const inputRefList = useRef<(HTMLInputElement | null)[]>([]);
-  const [errorMessage, setErrorMessage] = useState('');
-  const [errorIndexList, setErrorIndexList] = useState<number[]>([]);
-  const [canSubmit, setCanSubmit] = useState(false);
+
+  const {inputList, errorMessage, errorIndexList, canSubmit, handleChange, setInputList} = useInput({
+    validateFunc,
+    initialInputList,
+  });
 
   useEffect(() => {
     if (inputRefList.current.length <= 0) return;
@@ -37,14 +42,13 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     }
   }, [inputList]);
 
-  // event에서 value를 받아와서 새 인풋을 만들고 검증 후 set 하는 함수
   const handleInputChange = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
     const {value} = event.target;
+
     makeNewInputWhenFirstCharacterInput(index, value);
-    validateAndSetTargetInput(index, value);
+    handleChange(index, value);
   };
 
-  // 첫 번째 문자가 입력됐을 때 새로운 인풋이 생기는 기능 분리
   const makeNewInputWhenFirstCharacterInput = (index: number, value: string) => {
     if (isLastInputFilled(index, value) && value.trim().length !== 0) {
       // 마지막 인풋이 한 자라도 채워진다면 새로운 인풋을 생성해 간편한 다음 입력을 유도합니다.
@@ -59,47 +63,6 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     }
   };
 
-  // onChange와 setValue 둘 다 지원하기 위해서 validate를 분리
-  const validateAndSetTargetInput = (index: number, value: string) => {
-    const {isValid: isValidInput, errorMessage: validationResultMessage} = validateFunc(value);
-
-    if (isValidInput) {
-      // 입력된 값이 유효하면 데이터(inputList)를 변경합니다.
-      setErrorMessage('');
-
-      if (errorIndexList.includes(index)) {
-        setErrorIndexList(prev => prev.filter(i => i !== index));
-      }
-
-      changeInputListValue(index, value);
-    } else if (value.length === 0) {
-      // value의 값이 0이라면 errorMessage는 띄워지지 않지만 값은 변경됩니다. 또한 invalid한 값이기에 errorIndex에 추가합니다.
-
-      setErrorMessage('');
-      changeErrorIndex(index);
-
-      changeInputListValue(index, value);
-    } else {
-      // 유효성 검사에 실패한 입력입니다. 에러 메세지를 세팅합니다.
-
-      const targetInput = findInputByIndex(index);
-
-      setErrorMessage(validationResultMessage ?? '');
-      changeErrorIndex(targetInput.index);
-    }
-  };
-
-  // inputList가 변했을 때 canSubmit이 반영되도록
-  // setValue가 수행되기 전에 handleCanSubmit이 실행되어 새로운 입력값에 대한 검증이 되지 않는 버그를 해결
-  useEffect(() => {
-    handleCanSubmit();
-  }, [inputList]);
-
-  // 현재까지 입력된 값들로 submit을 할 수 있는지 여부를 핸들합니다.
-  const handleCanSubmit = () => {
-    setCanSubmit(inputList.length > 0 && getFilledInputList().length > 0 && errorIndexList.length === 0);
-  };
-
   const deleteEmptyInputElementOnBlur = () => {
     // 0, 1번 input이 값이 있는 상태에서 두 input의 값을 모두 x버튼으로 제거해도 input이 2개 남아있는 문제를 위해 조건문을 추가했습니다.
     if (getFilledInputList().length === 0 && inputList.length > 1) {
@@ -110,7 +73,6 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     // *표시 조건문은 처음에 input을 클릭했다가 블러시켰을 때 filledInputList가 아예 없어 .index에 접근할 때 오류가 납니다. 이를 위한 얼리리턴을 두었습니다.
     if (getFilledInputList().length === 0) return;
 
-    // *
     if (getFilledInputList().length !== inputList.length) {
       setInputList(inputList => {
         const filledInputList = getFilledInputList(inputList);
@@ -123,7 +85,7 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     }
   };
 
-  const changeInputListValue = (index: number, value: string) => {
+  const setInputValueTargetIndex = (index: number, value: string) => {
     setInputList(prevInputs => {
       const updatedInputList = [...prevInputs];
       const targetInput = findInputByIndex(index, updatedInputList);
@@ -134,15 +96,6 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     });
   };
 
-  const changeErrorIndex = (index: number) => {
-    setErrorIndexList(prev => {
-      if (!prev.includes(index)) {
-        return [...prev, index];
-      }
-      return prev;
-    });
-  };
-
   const focusNextInputOnEnter = (e: React.KeyboardEvent<HTMLInputElement>, index: number) => {
     if (e.nativeEvent.isComposing) return;
 
@@ -150,14 +103,11 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
       inputRefList.current[index + 1]?.focus();
     }
   };
-  // 아래부터는 이 훅에서 재사용되는 함수입니다.
 
-  // list 인자를 넘겨주면 그 인자로 찾고, 없다면 inputList state를 사용합니다.
   const findInputByIndex = (index: number, list?: InputValue[]) => {
     return (list ?? inputList).filter(input => input.index === index)[0];
   };
 
-  // list 인자를 넘겨주면 그 인자로 찾고, 없다면 inputList state를 사용합니다.
   const getFilledInputList = (list?: InputValue[]) => {
     return (list ?? inputList).filter(({value}) => value.trim().length !== 0);
   };
@@ -171,15 +121,15 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
   return {
     inputList,
     inputRefList,
-    handleInputChange,
-    deleteEmptyInputElementOnBlur,
     errorMessage,
-    getFilledInputList,
-    focusNextInputOnEnter,
     canSubmit,
     errorIndexList,
-    validateAndSetTargetInput,
-    // TODO: (@weadie) 네이밍 수정
+    handleInputChange,
+    handleChange,
+    deleteEmptyInputElementOnBlur,
+    getFilledInputList,
+    focusNextInputOnEnter,
+    setInputValueTargetIndex,
   };
 };
 

--- a/client/src/hooks/useInput.tsx
+++ b/client/src/hooks/useInput.tsx
@@ -2,6 +2,8 @@ import {useEffect, useState} from 'react';
 
 import {ValidateResult} from '@utils/validate/type';
 
+import {ERROR_MESSAGE} from '@constants/errorMessage';
+
 export type InputValue = {
   value: string;
   index: number;
@@ -33,17 +35,18 @@ const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInp
     const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
 
     if (isValid && value.length !== 0) {
+      // TODO: (@soha) 쿠키가 작업한 errorMessage를 위로 올리기 변경 추후에 merge후에 반영하기
       setErrorMessage('');
       updateInputList(index, value);
       removeErrorIndex(index);
       setCanSubmit(true);
     } else if (value.length === 0) {
       // TODO: (@soha) constants로 분리
-      setErrorMessage('공백은 입력할 수 없어요.');
+      setErrorMessage(ERROR_MESSAGE.preventEmpty);
       updateInputList(index, value);
       addErrorIndex(index);
     } else {
-      setErrorMessage(validationResultMessage ?? '올바르지 않은 입력이에요.');
+      setErrorMessage(validationResultMessage ?? ERROR_MESSAGE.invalidInput);
       addErrorIndex(index);
     }
   };

--- a/client/src/hooks/useInput.tsx
+++ b/client/src/hooks/useInput.tsx
@@ -1,0 +1,87 @@
+import {useEffect, useState} from 'react';
+
+import {ValidateResult} from '@utils/validate/type';
+
+export type InputValue = {
+  value: string;
+  index: number;
+};
+
+export type UseInputReturn<T = InputValue> = {
+  inputList: T[];
+  errorMessage: string;
+  errorIndexList: number[];
+  canSubmit: boolean;
+  handleChange: (index: number, value: string) => void;
+  setInputList: React.Dispatch<React.SetStateAction<T[]>>;
+  addErrorIndex: (index: number) => void;
+  setCanSubmit: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type UseInputProps<T = InputValue> = {
+  validateFunc: (value: string) => ValidateResult;
+  initialInputList: T[];
+};
+
+const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInputProps<T>): UseInputReturn<T> => {
+  const [inputList, setInputList] = useState<T[]>(initialInputList);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [errorIndexList, setErrorIndexList] = useState<number[]>([]);
+  const [canSubmit, setCanSubmit] = useState(false);
+
+  const handleChange = (index: number, value: string) => {
+    const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
+
+    if (isValid && value.length !== 0) {
+      setErrorMessage('');
+      updateInputList(index, value);
+      removeErrorIndex(index);
+      setCanSubmit(true);
+    } else if (value.length === 0) {
+      // TODO: (@soha) constants로 분리
+      setErrorMessage('공백은 입력할 수 없어요.');
+      updateInputList(index, value);
+      addErrorIndex(index);
+    } else {
+      setErrorMessage(validationResultMessage ?? '올바르지 않은 입력이에요.');
+      addErrorIndex(index);
+    }
+  };
+
+  const updateInputList = (index: number, value: string) => {
+    setInputList(prev => {
+      const newList = [...prev];
+      const targetInput = newList.find(input => input.index === index);
+      if (targetInput) {
+        targetInput.value = value;
+      }
+      return newList;
+    });
+  };
+
+  const removeErrorIndex = (index: number) => {
+    setErrorIndexList(prev => prev.filter(i => i !== index));
+  };
+
+  const addErrorIndex = (index: number) => {
+    setErrorIndexList(prev => {
+      if (!prev.includes(index)) {
+        return [...prev, index];
+      }
+      return prev;
+    });
+  };
+
+  return {
+    inputList,
+    errorMessage,
+    errorIndexList,
+    canSubmit,
+    handleChange,
+    setInputList,
+    addErrorIndex,
+    setCanSubmit,
+  };
+};
+
+export default useInput;

--- a/client/src/hooks/useInput.tsx
+++ b/client/src/hooks/useInput.tsx
@@ -6,7 +6,7 @@ import {ERROR_MESSAGE} from '@constants/errorMessage';
 
 export type InputValue = {
   value: string;
-  index: number;
+  index?: number;
 };
 
 export type UseInputReturn<T = InputValue> = {
@@ -35,7 +35,7 @@ const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInp
     changeCanSubmit();
   }, [errorMessage, errorIndexList]);
 
-  const handleChange = (index: number, value: string) => {
+  const handleChange = (index: number = 0, value: string) => {
     const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
 
     if (validationResultMessage === ERROR_MESSAGE.preventEmpty) {

--- a/client/src/hooks/useInput.tsx
+++ b/client/src/hooks/useInput.tsx
@@ -31,23 +31,22 @@ const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInp
   const [errorIndexList, setErrorIndexList] = useState<number[]>([]);
   const [canSubmit, setCanSubmit] = useState(false);
 
+  useEffect(() => {
+    changeCanSubmit();
+  }, [errorMessage, errorIndexList]);
+
   const handleChange = (index: number, value: string) => {
     const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
 
-    if (isValid && value.length !== 0) {
+    if (validationResultMessage === ERROR_MESSAGE.preventEmpty) {
+      setErrorMessage(validationResultMessage);
+      updateInputList(index, value);
+      addErrorIndex(index);
+    } else if (isValid && value.length !== 0) {
       // TODO: (@soha) 쿠키가 작업한 errorMessage를 위로 올리기 변경 추후에 merge후에 반영하기
       setErrorMessage('');
       updateInputList(index, value);
       removeErrorIndex(index);
-      setCanSubmit(true);
-    } else if (value.length === 0) {
-      // TODO: (@soha) constants로 분리
-      setErrorMessage(ERROR_MESSAGE.preventEmpty);
-      updateInputList(index, value);
-      addErrorIndex(index);
-    } else {
-      setErrorMessage(validationResultMessage ?? ERROR_MESSAGE.invalidInput);
-      addErrorIndex(index);
     }
   };
 
@@ -73,6 +72,10 @@ const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInp
       }
       return prev;
     });
+  };
+
+  const changeCanSubmit = () => {
+    setCanSubmit(errorIndexList.length || errorMessage.length ? false : true);
   };
 
   return {

--- a/client/src/hooks/useSearchInMemberList.ts
+++ b/client/src/hooks/useSearchInMemberList.ts
@@ -14,9 +14,7 @@ export type ReturnUseSearchInMemberList = {
   chooseMember: (inputIndex: number, name: string) => void;
 };
 
-const useSearchInMemberList = (
-  validateAndSetTargetInput: (index: number, value: string) => void,
-): ReturnUseSearchInMemberList => {
+const useSearchInMemberList = (handleChange: (index: number, value: string) => void): ReturnUseSearchInMemberList => {
   const eventId = getEventIdByUrl();
 
   const {fetch} = useFetch();
@@ -49,7 +47,7 @@ const useSearchInMemberList = (
 
   const chooseMember = (inputIndex: number, name: string) => {
     setFilteredInMemberList([]);
-    validateAndSetTargetInput(inputIndex, name);
+    handleChange(inputIndex, name);
   };
 
   const searchCurrentInMember = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/utils/isArraysEqual.ts
+++ b/client/src/utils/isArraysEqual.ts
@@ -1,4 +1,4 @@
-const isArraysEqual = (arr1: string[], arr2: string[]) => {
+const isArraysEqual = <T>(arr1: T[], arr2: T[]) => {
   if (arr1.length !== arr2.length) return false;
 
   // 배열을 정렬한 후 비교

--- a/client/src/utils/validate/validateMemberName.ts
+++ b/client/src/utils/validate/validateMemberName.ts
@@ -5,6 +5,7 @@ import RULE from '@constants/rule';
 import {ValidateResult} from './type';
 
 const validateMemberName = (name: string): ValidateResult => {
+  let errorMessage = null;
   const validateOnlyString = () => {
     if (!REGEXP.memberName.test(name)) return false;
     return true;
@@ -15,11 +16,19 @@ const validateMemberName = (name: string): ValidateResult => {
     return true;
   };
 
-  if (validateOnlyString() && validateLength()) {
+  const validateEmpty = () => {
+    if (!name.trim().length) {
+      errorMessage = ERROR_MESSAGE.preventEmpty;
+      return false;
+    }
+    return true;
+  };
+
+  if (validateOnlyString() && validateLength() && validateEmpty()) {
     return {isValid: true};
   }
 
-  return {isValid: false, errorMessage: ERROR_MESSAGE.memberName};
+  return {isValid: false, errorMessage: errorMessage || ERROR_MESSAGE.memberName};
 };
 
 export default validateMemberName;


### PR DESCRIPTION
## issue
- close #340

## 구현 사항
input과 관련된 훅은 useDynamicInput, useDynamicBillActionInput, useSetAllMemberList 3가지가 존재한다. 이 3가지 훅은 공통적으로 사용하는 부분이 존재한다.

- 입력된 값을 상태에 업데이트
- 올바르지 않은 입력 값일시, errorText와 error 테두리 띄우기
- 입력 값에 따라 canSubmit 관리

위와 같이 공통적으로 사용하는 코드가 3가지 정도 존재한다.
이때, 공통적으로 사용되는 코드 중 하나의 hook에서 버그가 발생하여 해결하면 다른 hook에서도 찾아서 똑같이 변경된 코드를 반영했다. 이런 일이 빈번히 일어나다 보니 불편함을 느끼게 되었다. 따라서 공통적으로 사용하는 로직은 useInput Hook으로 분리하여 각 hook에서 사용하도록 했다.

단, 여기서 useDynamicBillActionInput은 UI 변경에 따라 사용하지 않을 것으로 판단되어 수정하지 않았다. 수정된 파일은 useDynamicInput, useSetAllMemberList, useInput이다.

### useInput

- 공통적으로 사용하는 상태
    
    ```tsx
    const [inputList, setInputList] = useState<T[]>(initialInputList);
    const [errorMessage, setErrorMessage] = useState('');
    const [errorIndexList, setErrorIndexList] = useState<number[]>([]);
    const [canSubmit, setCanSubmit] = useState(false);
    ```
    
    - inputList
        
        input에 입력된 값들을 저장하는 상태이다. 어느 훅에서 사용하느냐에 따라 type이 달라지기 때문에 제네릭을 사용하여 inputList가 다양한 타입을 처리할 수 있도록 했다.
        
    - errorMessage
        
        입력된 input의 값이 invalid하다면 errorMessage가 client에 띄워져야 한다.
        각 input의 값이 invalid하다면 errorMessage에  invalid한 내용을 저장한다. 만약, 값이 valid하다면 errorMessage의 값을 빈 문자열(`’’`)이다.
        
    - errorIndexList
        
        입력된 input의 값이 invalid하다면 Input에 error를 나타내는 빨간 테두리가 client에 띄워져야 한다.
        각 input의 값이 invalid하다면 errorIndexList에 해당하는 input의 index를 저장한다. 만약 값이 valid하다면 errorIndexList에서 삭제 및 추가하지 않는다.
        
    - canSubmit
        
        errorMessage가 빈 문자열이고 errorIndexList에 아무런 값이 존재하지 않으면 true이다. 둘 중 하나의 조건도 만족하지 못한다면 false이다.
        
- updateInputList
    
    ```tsx
    const updateInputList = (index: number, value: string) => {
      setInputList(prev => {
        const newList = [...prev];
        const targetInput = newList.find(input => input.index === index);
        if (targetInput) {
          targetInput.value = value;
        }
        return newList;
      });
    };
    ```
    
    입력된 input의 값을 InputList 상태에 업데이트한다.
    
    targetInput: 해당 input의 index가 복제한 InputList(newList)에 있는지 찾는다.
    만약 targetInput이 존재한다면 targetInput의 value를 value로 변경한다.
    존재하지 않다면 newList를 반환한다.
    
- removeErrorIndex
    
    ```tsx
    const removeErrorIndex = (index: number) => {
      setErrorIndexList(prev => prev.filter(i => i !== index));
    };
    ```
    
    파라미터 index의 값(errorIndex에서 삭제할 값)이 errorIndexList에 존재하지 않은 것만 filter하여 errorIndexList를 업데이트한다.
    
- addErrorIndex
    
    ```tsx
    const addErrorIndex = (index: number) => {
      setErrorIndexList(prev => {
        if (!prev.includes(index)) {
          return [...prev, index];
        }
        return prev;
      });
    };
    ```
    
    errorIndexList에 index가 포함되지 않다면 새롭게 추가하여 return한다. 만약 존재하면 기존의 errorIndexList를 반환한다.
    
- handleChange
    
    ```tsx
    const handleChange = (index: number, value: string) => {
        const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
    
        if (validationResultMessage === ERROR_MESSAGE.preventEmpty) {
          setErrorMessage(validationResultMessage);
          updateInputList(index, value);
          addErrorIndex(index);
        } else if (isValid && value.length !== 0) {
          // TODO: (@soha) 쿠키가 작업한 errorMessage를 위로 올리기 변경 추후에 merge후에 반영하기
          setErrorMessage('');
          updateInputList(index, value);
          removeErrorIndex(index);
        }
      };
    
    ```
    
    조건에 맞춰 값을 업데이트하고 error 상태를 관리한다. 
    
    > Notion → 정책 → FE 참고
    잘못된 값을 입력하면 입력을 막기 때문에 errorText 및 errorIndexList를 띄우지 않고 canSubmit은 true이다.
    빈 문자열을 입력하면 errorText 및 errorIndexList(에러 테두리)가 띄워진다. 또한 canSubmit은 false이다.
    > 
    
    만약 validationResultMessage가 ERROR_MESSAGE.preventEmpty(`string.trim()`시 길이가 0인 빈 문자열)라면 errorMessage를 변경하고 inputList의 값을 변경한다. 또한 errorIndex에 값을 추가한다.
    
    그 외의 invalid한 값은 errorMessage와 errorIndex를 띄우지 않고 input에 값을 입력할 수 없도록 막는다.
    
    valid한 값일 경우에는 errorMessage를 초기화하고 혹시 모를 errorIndex가 존재하다면 삭제한다. 또한 inputList의 값을 업데이트한다.
    
- changeCanSubmit
    
    errorMessage와 errorIndexList의 값이 변하는 것에 따라 changeCanSubmit을 실행한다. 변화되는 상태에 즉각 반응하기 위함이다.
    
    ```
      // ...
      
      useEffect(() => {
        changeCanSubmit();
      }, [errorMessage, errorIndexList]);
      
      // ...
      
      const changeCanSubmit = () => {
        setCanSubmit(errorIndexList.length || errorMessage.length ? false : false);
      };
    ```
    
    빈 문자열이 들어올 경우에만 canSubmit은 false이다. 그 외의 모든 상황은 canSubmit은 true이다.

## 🫡 참고사항

생각보다 merge를 하다가 충돌나거나 쥐도 새도 모르게 사라질 경우가 발생할 것 같아서 유의해야 겠어요..!