### PR TITLE
[FE] 멤버 액션 삭제 훅 리팩토링

### DIFF
--- a/client/src/components/Modal/SetActionModal/AddBillActionListModalContent/AddBillActionListModalContent.tsx
+++ b/client/src/components/Modal/SetActionModal/AddBillActionListModalContent/AddBillActionListModalContent.tsx
@@ -17,7 +17,6 @@ const AddBillActionListModalContent = ({setIsOpenBottomSheet}: AddBillActionList
     inputPairList,
     inputRefList,
     errorMessage,
-    errorIndexList,
     handleInputChange,
     getFilledInputPairList,
     deleteEmptyInputPairElementOnBlur,
@@ -48,7 +47,6 @@ const AddBillActionListModalContent = ({setIsOpenBottomSheet}: AddBillActionList
                 onBlur={() => deleteEmptyInputPairElementOnBlur()} // TODO: (@weadie) 이 블러프롭이 내부적으로 index를 넘기고 있기 때문에 화살표 함수로 써야만하내요..
                 placeholder="지출 내역"
                 ref={el => (inputRefList.current[index * 2] = el)}
-                isError={errorIndexList.includes(index)}
               />
               <LabelGroupInput.Element
                 elementKey={`${index}`}
@@ -59,7 +57,6 @@ const AddBillActionListModalContent = ({setIsOpenBottomSheet}: AddBillActionList
                 onBlur={() => deleteEmptyInputPairElementOnBlur()}
                 placeholder="금액"
                 ref={el => (inputRefList.current[index * 2 + 1] = el)}
-                isError={errorIndexList.includes(index)}
               />
             </div>
           ))}

--- a/client/src/hooks/useDeleteMemberAction/useDeleteMemberAction.test.tsx
+++ b/client/src/hooks/useDeleteMemberAction/useDeleteMemberAction.test.tsx
@@ -53,7 +53,7 @@ describe('useDeleteMemberAction', () => {
       expect(result.current.stepListResult.stepList).not.toStrictEqual([]);
     });
 
-    await act(async () => {
+    act(() => {
       const memberAction = {
         actionId: 1,
         name: '망쵸',

--- a/client/src/hooks/useDeleteMemberAction/useDeleteMemberAction.tsx
+++ b/client/src/hooks/useDeleteMemberAction/useDeleteMemberAction.tsx
@@ -22,7 +22,7 @@ const useDeleteMemberAction = ({
   showToastExistSameMemberFromAfterStep,
 }: UseDeleteMemberActionProps) => {
   const {stepList, refreshStepList} = useStepList();
-  const [aliveActionList, setAliveActionList] = useState<MemberAction[]>(memberActionList);
+  const [deleteActionList, setDeleteActionList] = useState<MemberAction[]>([]);
   const eventId = getEventIdByUrl();
   const {fetch} = useFetch();
 
@@ -34,20 +34,15 @@ const useDeleteMemberAction = ({
         setIsBottomSheetOpened(false);
       },
       onError: () => {
-        setAliveActionList(memberActionList);
+        setDeleteActionList([]);
       },
     });
   };
 
   // TODO: (@cookie: 추후에 반복문으로 delete하는 것이 아니라 한 번에 모아서 delete 처리하기 (backend에 문의))
   const deleteMemberActionList = async () => {
-    const aliveActionIdList = aliveActionList.map(({actionId}) => actionId);
-    const deleteMemberActionIdList = memberActionList
-      .filter(({actionId}) => !aliveActionIdList.includes(actionId))
-      .map(({actionId}) => actionId);
-
-    for (const deleteMemberActionId of deleteMemberActionIdList) {
-      await deleteMemberAction(deleteMemberActionId);
+    for (const {actionId} of deleteActionList) {
+      await deleteMemberAction(actionId);
     }
   };
 
@@ -66,7 +61,7 @@ const useDeleteMemberAction = ({
   const addDeleteMemberAction = (memberAction: MemberAction) => {
     checkAlreadyExistMemberAction(memberAction, showToastAlreadyExistMemberAction);
     checkExistSameMemberFromAfterStep(memberAction, () => showToastExistSameMemberFromAfterStep(memberAction.name));
-    setAliveActionList(prev => prev.filter(aliveMember => aliveMember.actionId !== memberAction.actionId));
+    setDeleteActionList(prev => [...prev, memberAction]);
   };
 
   const isExistSameMemberFromAfterStep = (memberAction: MemberAction) => {
@@ -81,6 +76,9 @@ const useDeleteMemberAction = ({
     return memberNameList.filter(member => member === memberAction.name).length >= 2;
   };
 
+  const aliveActionList = memberActionList.filter(
+    memberAction => !deleteActionList.some(deleteAction => deleteAction.actionId === memberAction.actionId),
+  );
   return {aliveActionList, deleteMemberActionList, addDeleteMemberAction};
 };
 


### PR DESCRIPTION
## issue
- close #382 

## 구현 사항
현재는 삭제 대상 리스트를 전체에서 - 지운 리스트를 제외한 현재 남아있는 리스트 aliveMemberList로 관리되고 있습니다. 하지만 이를 삭제 인원을 담는 deleteMemberList로 변경해서 삭제 관련 로직을 더 직관적으로 작성했습니다.

관리 대상을 삭제로 바꾸니 오히려 코드 가독성이 올라간 것 같아요! (알려준 웨디 당신은 도대체ㄷㄷㄷ)

## 🫡 참고사항
AddBillActionListModalContent.tsx 에서 사용되고 있는 useDynamicBillActionInput 내부에서 errorIndexList가 사용되지 않고 export도 되고 있지 않아요;; 그래서 지워버렸습니다. 나중에 추가가 될 때 넣어줘도 좋을 것 같지만 이 부분 디자인 변경 예정이라 제 생각에는 불필요하다고 생각하긴 합니다

