### PR TITLE
[FE] 이벤트 생성 페이지 리팩토링

### DIFF
--- a/client/src/hooks/useSetEventName.ts
+++ b/client/src/hooks/useSetEventName.ts
@@ -1,0 +1,32 @@
+import {useState} from 'react';
+
+import validateEventName from '@utils/validate/validateEventName';
+
+const useSetEventName = () => {
+  const [eventName, setEventName] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [canSubmit, setCanSubmit] = useState(false);
+
+  const handleEventNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    const validation = validateEventName(newValue);
+
+    setCanSubmit(newValue.length !== 0);
+    setErrorMessage(validation.errorMessage);
+
+    if (validation.isValid) {
+      setEventName(newValue);
+    } else {
+      event.target.value = eventName;
+    }
+  };
+
+  return {
+    eventName,
+    errorMessage,
+    canSubmit,
+    handleEventNameChange,
+  };
+};
+
+export default useSetEventName;

--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -22,7 +22,7 @@ const CompleteCreateEventPage = () => {
 
   return (
     <MainLayout>
-      <TopNav children={<></>} />
+      <TopNav />
       <Title
         title="행사 개시"
         description="행사가 성공적으로 개시됐어요 :) 행사 링크를 통해서 지출 내역 공유와 참여자 관리가 가능해요."

--- a/client/src/pages/CreateEventPage/SetEventNamePage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventNamePage.tsx
@@ -12,7 +12,7 @@ const SetEventNamePage = () => {
   const submitEventName = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    navigate(ROUTER_URLS.eventCreatePassword, {state: {eventName}});
+    navigate(ROUTER_URLS.eventCreatePassword, {state: {eventName}, replace: true});
   };
 
   return (

--- a/client/src/pages/CreateEventPage/SetEventNamePage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventNamePage.tsx
@@ -1,36 +1,18 @@
-import {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {FixedButton, MainLayout, LabelInput, Title, TopNav, Back} from 'haengdong-design';
 
-import validateEventName from '@utils/validate/validateEventName';
+import useSetEventName from '@hooks/useSetEventName';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 const SetEventNamePage = () => {
-  const [eventName, setEventName] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [canSubmit, setCanSubmit] = useState(false);
   const navigate = useNavigate();
+  const {eventName, errorMessage, canSubmit, handleEventNameChange} = useSetEventName();
 
-  const submitEventName = async (event: React.FormEvent<HTMLFormElement>) => {
+  const submitEventName = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     navigate(ROUTER_URLS.eventCreatePassword, {state: {eventName}});
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    const validation = validateEventName(newValue);
-
-    setCanSubmit(newValue.length !== 0);
-
-    if (validation.isValid) {
-      setEventName(newValue);
-      setErrorMessage('');
-    } else {
-      event.target.value = eventName;
-      setErrorMessage(validation.errorMessage ?? '');
-    }
   };
 
   return (
@@ -46,7 +28,7 @@ const SetEventNamePage = () => {
           value={eventName}
           type="text"
           placeholder="행사 이름"
-          onChange={e => handleChange(e)}
+          onChange={handleEventNameChange}
           isError={!!errorMessage}
           autoFocus
         ></LabelInput>

--- a/client/src/pages/CreateEventPage/SetEventNamePage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventNamePage.tsx
@@ -12,7 +12,7 @@ const SetEventNamePage = () => {
   const submitEventName = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    navigate(ROUTER_URLS.eventCreatePassword, {state: {eventName}, replace: true});
+    navigate(ROUTER_URLS.eventCreatePassword, {state: {eventName}});
   };
 
   return (

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -25,7 +25,7 @@ const SetEventPasswordPage = () => {
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     const eventId = await submitPassword(event);
 
-    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`);
+    navigate(`${ROUTER_URLS.eventCreateComplete}?${new URLSearchParams({eventId})}`, {replace: true});
   };
 
   return (


### PR DESCRIPTION
## issue
- close #384 

## 구현 사항
이벤트 이름 입력받는 부분 커스텀 훅으로 분리했습니다.
useSetEventName 훅은 input value (eventName), 에러 메시지, 제출 가능 상태, 이벤트 이름 입력 핸들러 네 가지를 제공합니다.

UI 컴포넌트는 navigate 기능만 남겨두었습니다.

추가로 비밀번호에서 생성 완료 페이지로 navigate 시킬 때 replace true 옵션을 추가했습니다. navigate를 할 때 페이지를 대체시킴으로써 뒤로 가기를 물리적으로 막았습니다. 비밀번호에서 이름은 뒤로가기가 가능합니다. (뒤로가기 버튼이 존재하기 때문)

navigate state를 지우는 방향으로 하고 싶었지만 생각보다 잘 되지 않아서.. 이 방법으로 가능하다면 알려주세요;;;


## 🫡 참고사항
