### PR TITLE
[FE] 총액 업데이트 로직을 store안으로 이동

### DIFF
--- a/client/src/hooks/queries/useRequestGetStepList.ts
+++ b/client/src/hooks/queries/useRequestGetStepList.ts
@@ -21,8 +21,7 @@ const useRequestGetStepList = () => {
 
   useEffect(() => {
     if (queryResult.isSuccess && queryResult.data) {
-      const totalExpenseAmount = getTotalExpenseAmount(queryResult.data);
-      updateTotalExpenseAmount(totalExpenseAmount);
+      updateTotalExpenseAmount(queryResult.data);
     }
   }, [queryResult.data, queryResult.isSuccess, updateTotalExpenseAmount]);
 

--- a/client/src/hooks/queries/useRequestGetStepList.ts
+++ b/client/src/hooks/queries/useRequestGetStepList.ts
@@ -6,7 +6,6 @@ import {requestGetStepList} from '@apis/request/stepList';
 import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
-import {getTotalExpenseAmount} from '@utils/caculateExpense';
 
 import QUERY_KEYS from '@constants/queryKeys';
 

--- a/client/src/store/totalExpenseAmountStore.ts
+++ b/client/src/store/totalExpenseAmountStore.ts
@@ -1,14 +1,18 @@
 import {create} from 'zustand';
 
+import {BillStep, MemberStep} from 'types/serviceType';
+
+import {getTotalExpenseAmount} from '@utils/caculateExpense';
+
 type State = {
   totalExpenseAmount: number;
 };
 
 type Action = {
-  updateTotalExpenseAmount: (totalExpenseAmount: State['totalExpenseAmount']) => void;
+  updateTotalExpenseAmount: (stepList: (MemberStep | BillStep)[]) => void;
 };
 
 export const useTotalExpenseAmountStore = create<State & Action>(set => ({
   totalExpenseAmount: 0,
-  updateTotalExpenseAmount: totalExpenseAmount => set(() => ({totalExpenseAmount})),
+  updateTotalExpenseAmount: stepList => set({totalExpenseAmount: getTotalExpenseAmount(stepList)}),
 }));


### PR DESCRIPTION
## issue
- close #400 

## 구현 사항
총액 업데이트 함수를 사용하는 곳에서 총액 계산 로직을 부르는 것보다 store안에서 부르는 것이 사용하는 입장에선 더 직관적이고 편할 것 같아 그렇게 수정해보았습니다.

