### PR TITLE
[BE] 수정된 지출 상세의 상태 저장

### DIFF
--- a/server/src/main/java/server/haengdong/application/BillActionDetailService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionDetailService.java
@@ -27,7 +27,7 @@ public class BillActionDetailService {
         BillAction billAction = billActionRepository.findByAction_Id(actionId)
                 .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_NOT_FOUND));
         validateToken(token, billAction);
-        
+
         List<BillActionDetail> billActionDetails = billActionDetailRepository.findAllByBillAction(billAction);
 
         return BillActionDetailsAppResponse.of(billActionDetails);
@@ -52,6 +52,7 @@ public class BillActionDetailService {
                     .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BILL_ACTION_DETAIL_NOT_FOUND));
 
             detailToUpdate.updatePrice(updateRequest.price());
+            detailToUpdate.updateIsFixed(updateRequest.isFixed());
         }
     }
 

--- a/server/src/main/java/server/haengdong/application/BillActionService.java
+++ b/server/src/main/java/server/haengdong/application/BillActionService.java
@@ -57,7 +57,7 @@ public class BillActionService {
     private void saveBillActionDetails(BillAction billAction, CurrentMembers currentMembers) {
         long pricePerMember = billAction.getPrice() / currentMembers.size();
         currentMembers.getMembers().stream()
-                .map(memberName -> new BillActionDetail(billAction, memberName, pricePerMember))
+                .map(memberName -> new BillActionDetail(billAction, memberName, pricePerMember, false))
                 .forEach(billActionDetailRepository::save);
     }
 

--- a/server/src/main/java/server/haengdong/application/request/BillActionDetailUpdateAppRequest.java
+++ b/server/src/main/java/server/haengdong/application/request/BillActionDetailUpdateAppRequest.java
@@ -2,6 +2,7 @@ package server.haengdong.application.request;
 
 public record BillActionDetailUpdateAppRequest(
         String name,
-        Long price
+        Long price,
+        boolean isFixed
 ) {
 }

--- a/server/src/main/java/server/haengdong/application/response/BillActionDetailAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/BillActionDetailAppResponse.java
@@ -4,10 +4,15 @@ import server.haengdong.domain.action.BillActionDetail;
 
 public record BillActionDetailAppResponse(
         String name,
-        Long price
+        Long price,
+        boolean isFixed
 ) {
 
     public static BillActionDetailAppResponse of(BillActionDetail billActionDetail) {
-        return new BillActionDetailAppResponse(billActionDetail.getMemberName(), billActionDetail.getPrice());
+        return new BillActionDetailAppResponse(
+                billActionDetail.getMemberName(),
+                billActionDetail.getPrice(),
+                billActionDetail.isFixed()
+        );
     }
 }

--- a/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillActionDetail.java
@@ -26,26 +26,21 @@ public class BillActionDetail {
 
     private Long price;
 
-    public BillActionDetail(String memberName, Long price) {
-        this.memberName = memberName;
-        this.price = price;
-    }
+    private boolean isFixed;
 
-    public BillActionDetail(BillAction billAction, String memberName, Long price) {
+    public BillActionDetail(BillAction billAction, String memberName, Long price, boolean isFixed) {
         this.billAction = billAction;
         this.memberName = memberName;
         this.price = price;
-    }
-
-    public BillActionDetail(Long id, BillAction billAction, String memberName, Long price) {
-        this.id = id;
-        this.billAction = billAction;
-        this.memberName = memberName;
-        this.price = price;
+        this.isFixed = isFixed;
     }
 
     public void updatePrice(Long price) {
         this.price = price;
+    }
+
+    public void updateIsFixed(boolean isFixed) {
+        this.isFixed = isFixed;
     }
 
     public boolean hasMemberName(String memberName) {

--- a/server/src/main/java/server/haengdong/presentation/request/BillActionDetailUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillActionDetailUpdateRequest.java
@@ -10,9 +10,12 @@ public record BillActionDetailUpdateRequest(
         String name,
 
         @NotNull(message = "지출 금액은 공백일 수 없습니다.")
-        Long price
+        Long price,
+
+        @NotNull(message = "지출 금액은 공백일 수 없습니다.")
+        boolean isFixed
 ) {
     public BillActionDetailUpdateAppRequest toAppRequest() {
-        return new BillActionDetailUpdateAppRequest(this.name, this.price);
+        return new BillActionDetailUpdateAppRequest(this.name, this.price, this.isFixed);
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/BillActionDetailResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/BillActionDetailResponse.java
@@ -4,10 +4,15 @@ import server.haengdong.application.response.BillActionDetailAppResponse;
 
 public record BillActionDetailResponse(
         String name,
-        Long price
+        Long price,
+        boolean isFixed
 ) {
 
     public static BillActionDetailResponse of(BillActionDetailAppResponse billActionDetailAppResponse) {
-        return new BillActionDetailResponse(billActionDetailAppResponse.name(), billActionDetailAppResponse.price());
+        return new BillActionDetailResponse(
+                billActionDetailAppResponse.name(),
+                billActionDetailAppResponse.price(),
+                billActionDetailAppResponse.isFixed()
+        );
     }
 }

--- a/server/src/test/java/server/haengdong/application/ActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/ActionServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static server.haengdong.domain.action.MemberActionStatus.IN;
 import static server.haengdong.domain.action.MemberActionStatus.OUT;
+import static server.haengdong.support.fixture.Fixture.BILL_ACTION;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -54,15 +55,15 @@ class ActionServiceTest extends ServiceTestSupport {
         );
         billActions.get(0).addDetails(
                 List.of(
-                        new BillActionDetail("소하", 10_000L),
-                        new BillActionDetail("감자", 40_000L),
-                        new BillActionDetail("쿠키", 10_000L)
+                        new BillActionDetail(BILL_ACTION, "소하", 10_000L, false),
+                        new BillActionDetail(BILL_ACTION, "감자", 40_000L, true),
+                        new BillActionDetail(BILL_ACTION, "쿠키", 10_000L, false)
                 )
         );
         billActions.get(1).addDetails(
                 List.of(
-                        new BillActionDetail("소하", 5_000L),
-                        new BillActionDetail("쿠키", 15_000L)
+                        new BillActionDetail(BILL_ACTION, "소하", 5_000L, true),
+                        new BillActionDetail(BILL_ACTION, "쿠키", 15_000L, true)
                 )
         );
         memberActionRepository.saveAll(memberActions);

--- a/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionDetailServiceTest.java
@@ -44,8 +44,8 @@ class BillActionDetailServiceTest extends ServiceTestSupport {
         Action action = new Action(event1, 1L);
         BillAction billAction = new BillAction(action, "뽕족", 10000L);
         billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 6000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 4000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "토다리", 6000L, true);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "쿠키", 4000L, true);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
 
         BillActionDetailsAppResponse response = billActionDetailService.findBillActionDetails(
@@ -67,13 +67,13 @@ class BillActionDetailServiceTest extends ServiceTestSupport {
         Action action = new Action(event1, 1L);
         BillAction billAction = new BillAction(action, "뽕족", 10000L);
         billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 5000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 5000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "토다리", 5000L, false);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "쿠키", 5000L, false);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
 
         BillActionDetailsUpdateAppRequest request = new BillActionDetailsUpdateAppRequest(List.of(
-                new BillActionDetailUpdateAppRequest("토다리", 3000L),
-                new BillActionDetailUpdateAppRequest("쿠키", 4000L)
+                new BillActionDetailUpdateAppRequest("토다리", 3000L, true),
+                new BillActionDetailUpdateAppRequest("쿠키", 4000L, true)
         ));
         assertThatCode(
                 () -> billActionDetailService.updateBillActionDetails(event1.getToken(), action.getId(), request))
@@ -89,13 +89,13 @@ class BillActionDetailServiceTest extends ServiceTestSupport {
         Action action = new Action(event1, 1L);
         BillAction billAction = new BillAction(action, "뽕족", 10000L);
         billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(1L, billAction, "토다리", 5000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(2L, billAction, "쿠키", 5000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "토다리", 5000L, false);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "쿠키", 5000L, false);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
 
         BillActionDetailsUpdateAppRequest request = new BillActionDetailsUpdateAppRequest(List.of(
-                new BillActionDetailUpdateAppRequest("토다리", 3000L),
-                new BillActionDetailUpdateAppRequest("쿠키", 7000L)
+                new BillActionDetailUpdateAppRequest("토다리", 3000L, true),
+                new BillActionDetailUpdateAppRequest("쿠키", 7000L, true)
         ));
         billActionDetailService.updateBillActionDetails(event1.getToken(), action.getId(), request);
 

--- a/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillActionServiceTest.java
@@ -161,10 +161,10 @@ class BillActionServiceTest extends ServiceTestSupport {
         Event savedEvent = eventRepository.save(event);
         Action action = Action.createFirst(savedEvent);
         BillAction billAction = new BillAction(action, "뽕족", 10_000L);
-        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "감자", 3000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "고구마", 2000L);
-        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "당근", 3000L);
-        BillActionDetail billActionDetail4 = new BillActionDetail(billAction, "양파", 2000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "감자", 3000L, true);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "고구마", 2000L, true);
+        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "당근", 3000L, true);
+        BillActionDetail billActionDetail4 = new BillActionDetail(billAction, "양파", 2000L, true);
         billAction.addDetails(List.of(billActionDetail1, billActionDetail2, billActionDetail3, billActionDetail4));
         BillAction savedBillAction = billActionRepository.save(billAction);
 
@@ -208,8 +208,8 @@ class BillActionServiceTest extends ServiceTestSupport {
         MemberAction memberAction1 = new MemberAction(new Action(event, 1L), "백호", MemberActionStatus.IN, 1L);
         MemberAction memberAction2 = new MemberAction(new Action(event, 2L), "망쵸", MemberActionStatus.IN, 2L);
         BillAction billAction = new BillAction(new Action(event, 3L), "커피", 50_900L);
-        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "백호", 25_450L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "망쵸", 25_450L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "백호", 25_450L, false);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "망쵸", 25_450L, false);
         memberActionRepository.saveAll(List.of(memberAction1, memberAction2));
         billActionRepository.save(billAction);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));

--- a/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberActionServiceTest.java
@@ -146,10 +146,12 @@ class MemberActionServiceTest extends ServiceTestSupport {
         );
         BillAction billAction = new BillAction(new Action(event, 6L), "뽕족", 100_000L);
         billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "쿠키", 40_000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "웨디", 30_000L);
-        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "감자", 30_000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "쿠키", 40_000L, true);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "웨디", 30_000L, false);
+        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "감자", 30_000L, false);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2, billActionDetail3));
+        List<BillActionDetail> allByBillAction = billActionDetailRepository.findAllByBillAction(billAction);
+        System.out.println("allByBillAction = " + allByBillAction.isEmpty());
 
         memberActionService.deleteMember(event.getToken(), "쿠키");
 
@@ -220,9 +222,9 @@ class MemberActionServiceTest extends ServiceTestSupport {
         );
         BillAction billAction = new BillAction(new Action(event, 6L), "뽕족", 100_000L);
         billActionRepository.save(billAction);
-        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "쿠키", 40_000L);
-        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "웨디", 30_000L);
-        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "감자", 30_000L);
+        BillActionDetail billActionDetail1 = new BillActionDetail(billAction, "쿠키", 40_000L, true);
+        BillActionDetail billActionDetail2 = new BillActionDetail(billAction, "웨디", 30_000L, false);
+        BillActionDetail billActionDetail3 = new BillActionDetail(billAction, "감자", 30_000L, false);
         billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2, billActionDetail3));
 
         memberActionService.deleteMemberAction(event.getToken(), targetAction.getId());

--- a/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillActionDetailControllerDocsTest.java
@@ -47,7 +47,7 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
     @Test
     void findBillActionDetailsTest() throws Exception {
         BillActionDetailsAppResponse appResponse = new BillActionDetailsAppResponse(
-                List.of(new BillActionDetailAppResponse("토다리", 1000L)));
+                List.of(new BillActionDetailAppResponse("토다리", 1000L, false)));
         given(billActionDetailService.findBillActionDetails(anyString(), anyLong()))
                 .willReturn(appResponse);
 
@@ -58,6 +58,7 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.members").isArray())
                 .andExpect(jsonPath("$.members[0].name").value("토다리"))
                 .andExpect(jsonPath("$.members[0].price").value(1000L))
+                .andExpect(jsonPath("$.members[0].isFixed").value(false))
                 .andDo(
                         document("findBillActionDetailsTest",
                                 preprocessRequest(prettyPrint()),
@@ -73,7 +74,9 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
                                         fieldWithPath("members[0].name").type(JsonFieldType.STRING)
                                                 .description("참여자 이름"),
                                         fieldWithPath("members[0].price").type(JsonFieldType.NUMBER)
-                                                .description("참여자 정산 금액")
+                                                .description("참여자 정산 금액"),
+                                        fieldWithPath("members[0].isFixed").type(JsonFieldType.BOOLEAN)
+                                                .description("참여자 정산 금액 수정 여부")
                                 )
                         )
                 );
@@ -83,8 +86,8 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
     @Test
     void updateBillActionDetailsTest() throws Exception {
         List<BillActionDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
-                new BillActionDetailUpdateRequest("소하", 10000L),
-                new BillActionDetailUpdateRequest("웨디", 20000L)
+                new BillActionDetailUpdateRequest("소하", 10000L, true),
+                new BillActionDetailUpdateRequest("웨디", 20000L, true)
         );
         BillActionDetailsUpdateRequest request = new BillActionDetailsUpdateRequest(
                 billActionDetailUpdateRequests);
@@ -114,7 +117,9 @@ public class BillActionDetailControllerDocsTest extends RestDocsSupport {
                                         fieldWithPath("members[0].name").type(JsonFieldType.STRING)
                                                 .description("참여자 이름"),
                                         fieldWithPath("members[0].price").type(JsonFieldType.NUMBER)
-                                                .description("참여자 정산 금액")
+                                                .description("참여자 정산 금액"),
+                                        fieldWithPath("members[0].isFixed").type(JsonFieldType.BOOLEAN)
+                                                .description("참여자 정산 금액 수정 여부")
                                 )
                         )
                 );

--- a/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/BillActionTest.java
@@ -3,6 +3,7 @@ package server.haengdong.domain.action;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static server.haengdong.support.fixture.Fixture.BILL_ACTION;
 import static server.haengdong.support.fixture.Fixture.EVENT1;
 
 import java.util.List;
@@ -64,8 +65,8 @@ class BillActionTest {
         BillAction fixedBillAction = new BillAction(new Action(EVENT1, 1L), "인생네컷", 2_000L);
 
         List<BillActionDetail> unfixedBillActionDetails = List.of(
-                new BillActionDetail("감자", 1_000L),
-                new BillActionDetail("고구마", 1_000L)
+                new BillActionDetail(BILL_ACTION, "감자", 1_000L, false),
+                new BillActionDetail(BILL_ACTION, "고구마", 1_000L, false)
         );
         fixedBillAction.addDetails(unfixedBillActionDetails);
 
@@ -78,8 +79,8 @@ class BillActionTest {
         BillAction fixedBillAction = new BillAction(new Action(EVENT1, 1L), "인생네컷", 5_000L);
 
         List<BillActionDetail> unfixedBillActionDetails = List.of(
-                new BillActionDetail("감자", 4_000L),
-                new BillActionDetail("고구마", 1_000L)
+                new BillActionDetail(BILL_ACTION, "감자", 4_000L, true),
+                new BillActionDetail(BILL_ACTION, "고구마", 1_000L, true)
         );
         fixedBillAction.addDetails(unfixedBillActionDetails);
 

--- a/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
+++ b/server/src/test/java/server/haengdong/domain/action/MemberBillReportTest.java
@@ -3,6 +3,7 @@ package server.haengdong.domain.action;
 import static org.assertj.core.api.Assertions.assertThat;
 import static server.haengdong.domain.action.MemberActionStatus.IN;
 import static server.haengdong.domain.action.MemberActionStatus.OUT;
+import static server.haengdong.support.fixture.Fixture.BILL_ACTION;
 
 import java.util.List;
 import java.util.Map;
@@ -23,15 +24,15 @@ class MemberBillReportTest {
         );
         billActions.get(0).addDetails(
                 List.of(
-                        new BillActionDetail("소하", 10_000L),
-                        new BillActionDetail("감자", 40_000L),
-                        new BillActionDetail("쿠키", 10_000L)
+                        new BillActionDetail(BILL_ACTION, "소하", 10_000L, false),
+                        new BillActionDetail(BILL_ACTION, "감자", 40_000L, true),
+                        new BillActionDetail(BILL_ACTION, "쿠키", 10_000L, false)
                 )
         );
         billActions.get(1).addDetails(
                 List.of(
-                        new BillActionDetail("소하", 5_000L),
-                        new BillActionDetail("쿠키", 15_000L)
+                        new BillActionDetail(BILL_ACTION, "소하", 5_000L, true),
+                        new BillActionDetail(BILL_ACTION, "쿠키", 15_000L, true)
                 )
         );
         List<MemberAction> memberActions = List.of(

--- a/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillActionDetailControllerTest.java
@@ -24,7 +24,7 @@ class BillActionDetailControllerTest extends ControllerTestSupport {
     @Test
     void findBillActionDetails() throws Exception {
         BillActionDetailsAppResponse appResponse = new BillActionDetailsAppResponse(
-                List.of(new BillActionDetailAppResponse("토다리", 1000L)));
+                List.of(new BillActionDetailAppResponse("토다리", 1000L, false)));
         given(billActionDetailService.findBillActionDetails(anyString(), anyLong()))
                 .willReturn(appResponse);
 
@@ -39,8 +39,8 @@ class BillActionDetailControllerTest extends ControllerTestSupport {
     @Test
     void updateBillActionDetailsTest() throws Exception {
         List<BillActionDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
-                new BillActionDetailUpdateRequest("소하", 10000L),
-                new BillActionDetailUpdateRequest("웨디", 20000L)
+                new BillActionDetailUpdateRequest("소하", 10000L, true),
+                new BillActionDetailUpdateRequest("웨디", 20000L, true)
         );
         BillActionDetailsUpdateRequest request = new BillActionDetailsUpdateRequest(
                 billActionDetailUpdateRequests);

--- a/server/src/test/java/server/haengdong/support/fixture/Fixture.java
+++ b/server/src/test/java/server/haengdong/support/fixture/Fixture.java
@@ -1,6 +1,8 @@
 package server.haengdong.support.fixture;
 
 import jakarta.servlet.http.Cookie;
+import server.haengdong.domain.action.Action;
+import server.haengdong.domain.action.BillAction;
 import server.haengdong.domain.event.Event;
 
 public class Fixture {
@@ -8,4 +10,6 @@ public class Fixture {
     public static final Event EVENT1 = new Event("쿠키", "1234", "TOKEN1");
     public static final Event EVENT2 = new Event("웨디", "1234", "TOKEN2");
     public static final Cookie EVENT_COOKIE = new Cookie("eventToken", "토큰토큰");
+    public static final Action ACTION = new Action(EVENT1, 1L);
+    public static final BillAction BILL_ACTION = new BillAction(ACTION, "뽕족", 30_000L);
 }


### PR DESCRIPTION
## issue
- close #403 

## 구현 사항
BillActionDetail에 isFixed 필드를 추가해서,
관리자에 의해 수정된 지출 상세인지 상태를 관리합니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
