### PR TITLE
[FE]  action 로그가 길어질 경우 배경색 높이가 잘리는 버그

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -136,7 +136,7 @@ export const GlobalStyle = css`
 
   body {
     max-width: 768px;
-    height: 100lvh;
+    height: 100%;
     margin: 0 auto;
 
     overflow-y: scroll;


### PR DESCRIPTION
## issue
- close #407 

## 구현 사항
- 변경 전: body의 height가 `100lvh` 일 때,
<img width="341" alt="스크린샷 2024-08-20 17 38 46" src="https://github.com/user-attachments/assets/b22302d4-35dd-4af4-ada0-921e376d3d93">

- 변경 후: height가 `100%`일 때,
<img width="341" alt="스크린샷 2024-08-20 17 39 04" src="https://github.com/user-attachments/assets/9643d5d3-1caf-4014-ac42-5a87fbb1e12a">
