### PR TITLE
[FE] 전체 인원 수정 '삭제' api 로직 롤백 수정

### DIFF
--- a/client/src/hooks/useDynamicInput.tsx
+++ b/client/src/hooks/useDynamicInput.tsx
@@ -44,7 +44,7 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
 
   const handleInputChange = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
     const {value} = event.target;
-    console.log(value);
+
     makeNewInputWhenFirstCharacterInput(index, value);
     handleChange(index, value);
   };

--- a/client/src/hooks/useInput.tsx
+++ b/client/src/hooks/useInput.tsx
@@ -35,6 +35,10 @@ const useInput = <T extends InputValue>({validateFunc, initialInputList}: UseInp
     changeCanSubmit();
   }, [errorMessage, errorIndexList]);
 
+  useEffect(() => {
+    setInputList(prev => prev.map((value, index) => ({...value, index})));
+  }, [inputList.length]);
+
   const handleChange = (index: number = 0, value: string) => {
     const {isValid, errorMessage: validationResultMessage} = validateFunc(value);
 


### PR DESCRIPTION
## issue
- close #404

## 문제 상황

1. 삭제 버튼을 클릭하면 바로 삭제 api 요청을 보내는 것을 확인함.
삭제 버튼을 클릭하고 수정완료 버튼을 클릭해야 삭제 api 요청이 전송되어야 함.
2. 삭제 버튼을 클릭한 후 삭제한 input의 이후 input들을 수정하면 값이 변동되지 않는 것을 확인함. 
변동되지 않는 input의 다음 Input을 입력하면 값이 해당 값으로 변경됨

## 원인

- 삭제 버튼을 클릭하면 바로 삭제 api 요청
merge를 하는 과정에서 이전 로직이 추가된 것을 확인함.
- 삭제 버튼 클릭 후 발생하는 버그
    
    useInput에서 가져오는 inputList(editedAllMemberList)의 index와 useSetAllMemberList의 index가 일치하지 않아서 발생하는 에러였다.
    
    `[소하,웨디,쿠키,토다리]`가 존재할 때 index는 `0,1,2,3`이다. ‘웨디’를 삭제하면 index가 재정렬되지 않고 그대로 `[소하,쿠키,토다리]`가 `0,2,3`으로 존재한다. 그러나 useSetAllMemberList에서는 index가 재정렬되면서 `[소하,쿠키,토다리]`가 `0,1,2`으로 변한다. (이때, 진짜 재정렬이 된다기 보다는 useSetAllMemberList에서 handleChange에 index를 넣어주는데, 이 index는 input을 렌더링하는 컴포넌트의 index이다. 즉, 삭제가 반영된 index이다.)
    
    만약 토다리의 이름을 변경하려고 한다고 가정하자.
    재정렬된 토다리의 index는 2이다. 하지만 재정렬되지 않는 index 2는 쿠키이다.
    useInput에서 사용하는 `handleChange`의 `input.index === index`의 조건에 부합하기 때문에 토다리 input을 변경했지만 쿠키의 input이 변하게 되었다.
    
    ```tsx
    const updateInputList = (index: number, value: string) => {
      setInputList(prev => {
        const newList = [...prev];
        const targetInput = newList.find(input => input.index === index);
        if (targetInput) {
          targetInput.value = value;
        }
        return newList;
      });
    };
    ```
    

## 해결

- 삭제 버튼을 클릭하면 바로 삭제 api 요청
    
    `handleClickDeleteButton`에서는 set만 실행해여 state의 값을 변경시켜준다.
    `handlePutAllMemberList`을 클릭하면 삭제해야 할 state를 map을 돌아 삭제 api를 요청한다.
    
- 삭제 버튼 클릭 후 발생하는 버그
    
    useSetAllMemberList에서는 변경된 index로 잘 적용되어 있다. 그렇기에 두 index를 동일하게 맞추고자 useInput에서 다음과 같은 코드를 추가했다.
    
    ```tsx
    useEffect(() => {
      setInputList(prev => prev.map((value, index) => ({...value, index})));
    }, [inputList.length]);
    ```
    
    inputList의 길이가 변한다는 것은 member를 삭제했다는 것이다. 그렇기에 useEffect의 의존성으로 inputList의 length를 넣어준다. 
    member가 삭제되면 `setInputList`를 실행한다. 이때, index를 재정렬해준다.
    
    만약, `[소하,웨디,쿠키,토다리]` index `0,1,2,3` 이었다가 웨디를 삭제하면 `[소하,쿠키,토다리]` index `0,2,3`이 된다. `inputList.length`가 변했으므로 index를 재정렬한다. `[소하,쿠키,토다리]` index `0,1,2`로 재정렬된다.

