### PR TITLE
[FE] EditableItem.Input이 동적인 width를 갖도록 수정

### DIFF
--- a/HDesign/package-lock.json
+++ b/HDesign/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haengdong-design",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/HDesign/package.json
+++ b/HDesign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haengdong-design",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -1,49 +1,33 @@
 import {css} from '@emotion/react';
 
 import {TextSize} from '@components/Text/Text.type';
-
-import {Theme} from '@theme/theme.type';
+import {WithTheme} from '@type/withTheme';
 
 import TYPOGRAPHY from '@token/typography';
 
-interface InputWrapperStyleProps {
-  theme: Theme;
+type UnderlineProps = {
   hasFocus: boolean;
   hasError: boolean;
-}
+};
 
-interface InputStyleProps {
-  theme: Theme;
+type InputSizeStyleProps = {
   textSize: TextSize;
-}
+};
 
-interface InputSizeStyleProps {
-  textSize: TextSize;
-}
+type InputBaseStyleProps = {
+  width: string;
+};
 
-interface InputBaseStyleProps {
-  theme: Theme;
-}
+type InputStyleProps = InputBaseStyleProps & InputSizeStyleProps;
 
-export const inputWrapperStyle = ({theme, hasFocus, hasError}: InputWrapperStyleProps) =>
-  css({
-    position: 'relative',
-    display: 'inline-block',
+export const inputWrapperStyle = css({
+  display: 'inline-block',
+});
 
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      height: '0.125rem',
-      backgroundColor: hasFocus ? theme.colors.primary : hasError ? theme.colors.error : 'transparent',
-      transition: 'background-color 0.2s',
-      transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
-    },
-  });
-
-export const inputStyle = ({theme, textSize}: InputStyleProps) => [inputSizeStyle({textSize}), inputBaseStyle({theme})];
+export const inputStyle = ({theme, textSize, width}: WithTheme<InputStyleProps>) => [
+  inputSizeStyle({textSize}),
+  inputBaseStyle({theme, width}),
+];
 
 const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
   const style = {
@@ -62,14 +46,60 @@ const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
   return [style[textSize]];
 };
 
-const inputBaseStyle = ({theme}: InputBaseStyleProps) =>
+const inputBaseStyle = ({theme, width}: WithTheme<InputBaseStyleProps>) =>
   css({
     border: 'none',
     outline: 'none',
     paddingBottom: '0.125rem',
 
     color: theme.colors.black,
+
     '&:placeholder': {
-      color: theme.colors.gray,
+      color: theme.colors.darkGray,
+    },
+
+    width,
+  });
+
+export const editingContainerStyle = css({
+  opacity: 0,
+  whiteSpace: 'pre',
+  position: 'absolute',
+  pointerEvents: 'none',
+  padding: 0,
+  margin: 0,
+});
+
+export const notEditingContainerStyle = css({
+  width: 'auto',
+  whiteSpace: 'nowrap',
+});
+
+export const isFixedIconStyle = ({theme}: WithTheme) =>
+  css({
+    color: theme.colors.error,
+    paddingRight: '0.25rem',
+  });
+
+export const underlineStyle = ({theme, hasFocus, hasError}: WithTheme<UnderlineProps>) =>
+  css({
+    position: 'relative',
+    display: 'inline-block',
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: '0.125rem',
+      backgroundColor: hasFocus ? theme.colors.primary : hasError ? theme.colors.error : 'transparent',
+      transition: 'background-color 0.2s',
+      transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
     },
   });
+
+export const notEditingTextStyle = css({
+  paddingBottom: '0.125rem',
+});

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -14,9 +14,7 @@ type InputSizeStyleProps = {
   textSize: TextSize;
 };
 
-type InputBaseStyleProps = {};
-
-type InputStyleProps = InputBaseStyleProps & InputSizeStyleProps;
+type InputStyleProps = InputSizeStyleProps;
 
 export const inputWrapperStyle = css({
   display: 'inline-block',
@@ -44,7 +42,7 @@ const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
   return [style[textSize]];
 };
 
-const inputBaseStyle = ({theme}: WithTheme<InputBaseStyleProps>) =>
+const inputBaseStyle = ({theme}: WithTheme) =>
   css({
     border: 'none',
     outline: 'none',

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -70,11 +70,6 @@ export const editingContainerStyle = css({
   margin: 0,
 });
 
-export const notEditingContainerStyle = css({
-  width: 'auto',
-  whiteSpace: 'nowrap',
-});
-
 export const isFixedIconStyle = ({theme}: WithTheme) =>
   css({
     color: theme.colors.error,
@@ -99,7 +94,3 @@ export const underlineStyle = ({theme, hasFocus, hasError}: WithTheme<UnderlineP
       transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
     },
   });
-
-export const notEditingTextStyle = css({
-  paddingBottom: '0.125rem',
-});

--- a/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.style.ts
@@ -14,9 +14,7 @@ type InputSizeStyleProps = {
   textSize: TextSize;
 };
 
-type InputBaseStyleProps = {
-  width: string;
-};
+type InputBaseStyleProps = {};
 
 type InputStyleProps = InputBaseStyleProps & InputSizeStyleProps;
 
@@ -24,9 +22,9 @@ export const inputWrapperStyle = css({
   display: 'inline-block',
 });
 
-export const inputStyle = ({theme, textSize, width}: WithTheme<InputStyleProps>) => [
+export const inputStyle = ({theme, textSize}: WithTheme<InputStyleProps>) => [
   inputSizeStyle({textSize}),
-  inputBaseStyle({theme, width}),
+  inputBaseStyle({theme}),
 ];
 
 const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
@@ -46,7 +44,7 @@ const inputSizeStyle = ({textSize}: InputSizeStyleProps) => {
   return [style[textSize]];
 };
 
-const inputBaseStyle = ({theme, width}: WithTheme<InputBaseStyleProps>) =>
+const inputBaseStyle = ({theme}: WithTheme<InputBaseStyleProps>) =>
   css({
     border: 'none',
     outline: 'none',
@@ -57,8 +55,6 @@ const inputBaseStyle = ({theme, width}: WithTheme<InputBaseStyleProps>) =>
     '&:placeholder': {
       color: theme.colors.darkGray,
     },
-
-    width,
   });
 
 export const editingContainerStyle = css({

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -48,7 +48,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
             ref={inputRef}
             autoFocus
             readOnly={readOnly}
-            disabled={readOnly}
             {...htmlProps}
             placeholder={htmlProps.placeholder}
           />

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -8,8 +8,26 @@ import {useTheme} from '@theme/HDesignProvider';
 import {inputStyle, inputWrapperStyle} from './EditableItem.Input.style';
 import useEditableItemInput from './useEditableItemInput';
 
-export const EditableItemInput: React.FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {textSize = 'body', hasError = false, ...htmlProps},
+// 실제 컴포넌트를 렌더링하고 그 width를 받아와 언더라인의 길이를 정확하게 표시할 수 있도록 함
+const calculateTextWidthWithVirtualElement = (text: string) => {
+  const element = document.createElement('div');
+  element.style.position = 'absolute';
+  element.style.whiteSpace = 'nowrap';
+  element.style.visibility = 'hidden';
+  element.textContent = text;
+
+  document.body.appendChild(element); // 렌더링
+
+  // 요소의 실제 너비 계산
+  const width = element.offsetWidth;
+
+  document.body.removeChild(element); // 제거
+
+  return `${width}px`;
+};
+
+export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {isFixed = false, textSize = 'body', hasError = false, value = '', readOnly = false, ...htmlProps},
   ref,
 ) {
   const {theme} = useTheme();

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -42,13 +42,11 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
           <input
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}
-            css={[
-              inputStyle({
-                theme,
-                textSize,
-                width: `${shadowRef.current?.offsetWidth}px`,
-              }),
-            ]}
+            css={inputStyle({
+              theme,
+              textSize,
+              width: `${shadowRef.current?.offsetWidth}px`,
+            })}
             ref={inputRef}
             autoFocus
             readOnly={readOnly}

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import {forwardRef, useEffect, useImperativeHandle, useRef} from 'react';
+import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
 
 import Flex from '@components/Flex/Flex';
 import Text from '@components/Text/Text';
@@ -17,7 +17,7 @@ import {InputProps} from './EditableItem.Input.type';
 import useEditableItemInput from './useEditableItemInput';
 
 export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {isFixed = false, textSize = 'body', value = '', hasError = false, readOnly = false, ...htmlProps},
+  {isFixed = false, textSize = 'body', hasError = false, readOnly = false, ...htmlProps},
   ref,
 ) {
   const {theme} = useTheme();
@@ -28,16 +28,15 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
 
   useEffect(() => {
     if (shadowRef.current && inputRef.current) {
-      // 보이지는 않지만 존재하며 value가 담겨있는 Shadow div의 크기를 기준으로 input의 너비를 설정
       inputRef.current.style.width = `${shadowRef.current.offsetWidth}px`;
     }
-  }, [value]);
+  }, [htmlProps.value]);
 
   return (
     <div css={inputWrapperStyle}>
       <Flex flexDirection="row">
         <div ref={shadowRef} css={editingContainerStyle}>
-          <Text size={textSize}>{value || htmlProps.placeholder}</Text>
+          <Text size={textSize}>{htmlProps.value || htmlProps.placeholder}</Text>
         </div>
         {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
         <div css={underlineStyle({theme, hasError, hasFocus})}>
@@ -45,7 +44,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
             css={inputStyle({
               theme,
               textSize,
-              width: `${shadowRef.current?.offsetWidth}px`,
             })}
             ref={inputRef}
             autoFocus
@@ -53,7 +51,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
             disabled={readOnly}
             {...htmlProps}
             placeholder={htmlProps.placeholder}
-            value={value}
           />
         </div>
       </Flex>

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import {forwardRef, useEffect, useRef, useState} from 'react';
+import {forwardRef, useEffect, useImperativeHandle, useRef} from 'react';
 
 import Flex from '@components/Flex/Flex';
 import Text from '@components/Text/Text';
@@ -14,6 +14,7 @@ import {
   underlineStyle,
 } from './EditableItem.Input.style';
 import {InputProps} from './EditableItem.Input.type';
+import useEditableItemInput from './useEditableItemInput';
 
 export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(function Input(
   {isFixed = false, textSize = 'body', value = '', hasError = false, readOnly = false, ...htmlProps},
@@ -22,7 +23,8 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
   const {theme} = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const shadowRef = useRef<HTMLDivElement>(null);
-  const [hasFocus, setHasFocus] = useState(false);
+  const {hasFocus} = useEditableItemInput({inputRef});
+  useImperativeHandle(ref, () => inputRef.current!);
 
   useEffect(() => {
     if (shadowRef.current && inputRef.current) {
@@ -40,8 +42,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
         {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
         <div css={underlineStyle({theme, hasError, hasFocus})}>
           <input
-            onFocus={() => setHasFocus(true)}
-            onBlur={() => setHasFocus(false)}
             css={inputStyle({
               theme,
               textSize,

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -11,48 +11,22 @@ import {
   inputStyle,
   inputWrapperStyle,
   isFixedIconStyle,
-  notEditingContainerStyle,
-  notEditingTextStyle,
   underlineStyle,
 } from './EditableItem.Input.style';
 import {InputProps} from './EditableItem.Input.type';
 
-// 실제 컴포넌트를 렌더링하고 그 width를 받아와 언더라인의 길이를 정확하게 표시할 수 있도록 함
-const calculateTextWidthWithVirtualElement = (text: string) => {
-  const element = document.createElement('div');
-  element.style.position = 'absolute';
-  element.style.whiteSpace = 'nowrap';
-  element.style.visibility = 'hidden';
-  element.textContent = text;
-
-  document.body.appendChild(element); // 렌더링
-
-  // 요소의 실제 너비 계산
-  const width = element.offsetWidth;
-
-  document.body.removeChild(element); // 제거
-
-  return `${width}px`;
-};
-
 export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {isFixed = false, textSize = 'body', hasError = false, value = '', readOnly = false, ...htmlProps},
+  {isFixed = false, textSize = 'body', value = '', hasError = false, readOnly = false, ...htmlProps},
   ref,
 ) {
   const {theme} = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const shadowRef = useRef<HTMLDivElement>(null);
   const [hasFocus, setHasFocus] = useState(false);
-  const [width, setWidth] = useState(
-    value
-      ? calculateTextWidthWithVirtualElement(String(value))
-      : calculateTextWidthWithVirtualElement(htmlProps.placeholder || ' '),
-  );
 
   useEffect(() => {
     if (shadowRef.current && inputRef.current) {
       // 보이지는 않지만 존재하며 value가 담겨있는 Shadow div의 크기를 기준으로 input의 너비를 설정
-      setWidth(`${shadowRef.current.offsetWidth}px`);
       inputRef.current.style.width = `${shadowRef.current.offsetWidth}px`;
     }
   }, [value]);
@@ -72,7 +46,7 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
               inputStyle({
                 theme,
                 textSize,
-                width,
+                width: `${shadowRef.current?.offsetWidth}px`,
               }),
             ]}
             ref={inputRef}

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -1,12 +1,21 @@
 /** @jsxImportSource @emotion/react */
-import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
+import {forwardRef, useEffect, useRef, useState} from 'react';
 
-import {InputProps} from '@components/EditableItem/EditableItem.Input.type';
+import Flex from '@components/Flex/Flex';
+import Text from '@components/Text/Text';
 
 import {useTheme} from '@theme/HDesignProvider';
 
-import {inputStyle, inputWrapperStyle} from './EditableItem.Input.style';
-import useEditableItemInput from './useEditableItemInput';
+import {
+  editingContainerStyle,
+  inputStyle,
+  inputWrapperStyle,
+  isFixedIconStyle,
+  notEditingContainerStyle,
+  notEditingTextStyle,
+  underlineStyle,
+} from './EditableItem.Input.style';
+import {InputProps} from './EditableItem.Input.type';
 
 // 실제 컴포넌트를 렌더링하고 그 width를 받아와 언더라인의 길이를 정확하게 표시할 수 있도록 함
 const calculateTextWidthWithVirtualElement = (text: string) => {
@@ -32,12 +41,68 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
 ) {
   const {theme} = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
-  const {hasFocus} = useEditableItemInput({inputRef});
-  useImperativeHandle(ref, () => inputRef.current!);
+  const shadowRef = useRef<HTMLDivElement>(null);
+  const [hasFocus, setHasFocus] = useState(false);
+  const [width, setWidth] = useState(
+    value
+      ? calculateTextWidthWithVirtualElement(String(value))
+      : calculateTextWidthWithVirtualElement(htmlProps.placeholder || ' '),
+  );
+
+  const handleDivClick = () => {
+    if (!readOnly) {
+      setHasFocus(true);
+    }
+  };
+
+  useEffect(() => {
+    if (shadowRef.current && inputRef.current) {
+      // 보이지는 않지만 존재하며 value가 담겨있는 Shadow div의 크기를 기준으로 input의 너비를 설정
+      setWidth(`${shadowRef.current.offsetWidth}px`);
+      inputRef.current.style.width = `${shadowRef.current.offsetWidth}px`;
+    }
+  }, [value]);
 
   return (
-    <div css={inputWrapperStyle({theme, hasFocus, hasError})}>
-      <input css={inputStyle({theme, textSize})} ref={inputRef} {...htmlProps} />
+    <div css={inputWrapperStyle}>
+      {hasFocus && !readOnly ? (
+        <Flex flexDirection="row">
+          <div ref={shadowRef} css={editingContainerStyle}>
+            <Text size={textSize}>{value || htmlProps.placeholder}</Text>
+          </div>
+          {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
+          <div css={underlineStyle({theme, hasError, hasFocus})}>
+            <input
+              onFocus={() => setHasFocus(true)}
+              onBlur={() => setHasFocus(false)}
+              css={[
+                inputStyle({
+                  theme,
+                  textSize,
+                  width,
+                }),
+              ]}
+              ref={inputRef}
+              autoFocus
+              readOnly={readOnly}
+              disabled={readOnly}
+              {...htmlProps}
+              placeholder={htmlProps.placeholder}
+              value={value}
+            />
+          </div>
+        </Flex>
+      ) : (
+        <div onClick={handleDivClick} ref={inputRef} css={notEditingContainerStyle}>
+          <Flex flexDirection="row">
+            {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
+
+            <Text textColor={value === '' ? 'darkGray' : 'black'} css={notEditingTextStyle} size={textSize}>
+              {value || htmlProps.placeholder}
+            </Text>
+          </Flex>
+        </div>
+      )}
     </div>
   );
 });

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -49,12 +49,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
       : calculateTextWidthWithVirtualElement(htmlProps.placeholder || ' '),
   );
 
-  const handleDivClick = () => {
-    if (!readOnly) {
-      setHasFocus(true);
-    }
-  };
-
   useEffect(() => {
     if (shadowRef.current && inputRef.current) {
       // 보이지는 않지만 존재하며 value가 담겨있는 Shadow div의 크기를 기준으로 input의 너비를 설정
@@ -65,44 +59,32 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
 
   return (
     <div css={inputWrapperStyle}>
-      {hasFocus && !readOnly ? (
-        <Flex flexDirection="row">
-          <div ref={shadowRef} css={editingContainerStyle}>
-            <Text size={textSize}>{value || htmlProps.placeholder}</Text>
-          </div>
-          {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
-          <div css={underlineStyle({theme, hasError, hasFocus})}>
-            <input
-              onFocus={() => setHasFocus(true)}
-              onBlur={() => setHasFocus(false)}
-              css={[
-                inputStyle({
-                  theme,
-                  textSize,
-                  width,
-                }),
-              ]}
-              ref={inputRef}
-              autoFocus
-              readOnly={readOnly}
-              disabled={readOnly}
-              {...htmlProps}
-              placeholder={htmlProps.placeholder}
-              value={value}
-            />
-          </div>
-        </Flex>
-      ) : (
-        <div onClick={handleDivClick} ref={inputRef} css={notEditingContainerStyle}>
-          <Flex flexDirection="row">
-            {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
-
-            <Text textColor={value === '' ? 'darkGray' : 'black'} css={notEditingTextStyle} size={textSize}>
-              {value || htmlProps.placeholder}
-            </Text>
-          </Flex>
+      <Flex flexDirection="row">
+        <div ref={shadowRef} css={editingContainerStyle}>
+          <Text size={textSize}>{value || htmlProps.placeholder}</Text>
         </div>
-      )}
+        {isFixed && <div css={isFixedIconStyle({theme})}>*</div>}
+        <div css={underlineStyle({theme, hasError, hasFocus})}>
+          <input
+            onFocus={() => setHasFocus(true)}
+            onBlur={() => setHasFocus(false)}
+            css={[
+              inputStyle({
+                theme,
+                textSize,
+                width,
+              }),
+            ]}
+            ref={inputRef}
+            autoFocus
+            readOnly={readOnly}
+            disabled={readOnly}
+            {...htmlProps}
+            placeholder={htmlProps.placeholder}
+            value={value}
+          />
+        </div>
+      </Flex>
     </div>
   );
 });

--- a/HDesign/src/components/EditableItem/EditableItem.Input.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.tsx
@@ -46,7 +46,6 @@ export const EditableItemInput = forwardRef<HTMLInputElement, InputProps>(functi
               textSize,
             })}
             ref={inputRef}
-            autoFocus
             readOnly={readOnly}
             {...htmlProps}
             placeholder={htmlProps.placeholder}

--- a/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.Input.type.ts
@@ -7,7 +7,11 @@ export interface InputStyleProps {
   textSize?: TextSize;
 }
 
-export interface InputCustomProps {}
+export interface InputCustomProps {
+  isFixed?: boolean;
+  value: string | number;
+  readOnly?: boolean;
+}
 
 export interface InputStylePropsWithTheme extends InputStyleProps {
   theme: Theme;

--- a/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.input.stories.tsx
@@ -26,6 +26,7 @@ const meta = {
     textSize: 'body',
     hasError: false,
     autoFocus: true,
+    value: '값',
   },
 } satisfies Meta<typeof EditableItemInput>;
 

--- a/HDesign/src/components/EditableItem/EditableItem.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.stories.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import type {Meta, StoryObj} from '@storybook/react';
 
+import {useState} from 'react';
+
 import EditableItem from '@components/EditableItem/EditableItem';
 import Flex from '@components/Flex/Flex';
 import Text from '@components/Text/Text';
@@ -27,15 +29,29 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {
   render: ({...args}) => {
+    const [value, setValue] = useState('');
+    const [value2, setValue2] = useState('');
+
     return (
       <EditableItem
         backgroundColor={args.backgroundColor}
         onFocus={() => console.log('focus')}
         onBlur={() => console.log('blur')}
       >
-        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <EditableItem.Input
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
         <Flex gap="0.25rem" alignItems="center">
-          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <EditableItem.Input
+            value={value2}
+            onChange={e => setValue2(e.target.value)}
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
           <Text size="caption">원</Text>
         </Flex>
       </EditableItem>
@@ -45,6 +61,9 @@ export const Playground: Story = {
 
 export const WithLabel: Story = {
   render: ({...args}) => {
+    const [value, setValue] = useState('');
+    const [value2, setValue2] = useState('');
+
     return (
       <EditableItem
         prefixLabelText="라벨"
@@ -52,9 +71,54 @@ export const WithLabel: Story = {
         onFocus={() => console.log('focus')}
         onBlur={() => console.log('blur')}
       >
-        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <EditableItem.Input
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
         <Flex gap="0.25rem" alignItems="center">
-          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <EditableItem.Input
+            value={value2}
+            onChange={e => setValue2(e.target.value)}
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};
+
+export const WithLabelAndIsFixedIcon: Story = {
+  render: ({...args}) => {
+    const [value, setValue] = useState('');
+    const [value2, setValue2] = useState('');
+
+    return (
+      <EditableItem
+        prefixLabelText="라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input
+            value={value2}
+            onChange={e => setValue2(e.target.value)}
+            isFixed={true}
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
           <Text size="caption">원</Text>
         </Flex>
       </EditableItem>
@@ -64,6 +128,9 @@ export const WithLabel: Story = {
 
 export const WithLabels: Story = {
   render: ({...args}) => {
+    const [value, setValue] = useState('');
+    const [value2, setValue2] = useState('');
+
     return (
       <EditableItem
         prefixLabelText="왼쪽 라벨"
@@ -72,9 +139,83 @@ export const WithLabels: Story = {
         onFocus={() => console.log('focus')}
         onBlur={() => console.log('blur')}
       >
-        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <EditableItem.Input
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
         <Flex gap="0.25rem" alignItems="center">
-          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <EditableItem.Input
+            value={value2}
+            onChange={e => setValue2(e.target.value)}
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};
+
+export const ReadOnly: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        prefixLabelText="왼쪽 라벨"
+        suffixLabelText="오른쪽 라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input
+          value={'훠궈무한리필'}
+          readOnly
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input
+            value={'10000'}
+            readOnly
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};
+
+export const ReadOnlyWithIsFixedIcon: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        prefixLabelText="왼쪽 라벨"
+        suffixLabelText="오른쪽 라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input
+          value={'훠궈무한리필'}
+          readOnly
+          placeholder="지출 내역"
+          textSize="bodyBold"
+        ></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input
+            isFixed
+            value={'10000'}
+            readOnly
+            placeholder="0"
+            type="number"
+            style={{textAlign: 'right'}}
+          ></EditableItem.Input>
           <Text size="caption">원</Text>
         </Flex>
       </EditableItem>
@@ -84,6 +225,9 @@ export const WithLabels: Story = {
 
 export const ListView: Story = {
   render: ({...args}) => {
+    const [value, setValue] = useState('');
+    const [value2, setValue2] = useState('');
+
     return (
       <EditableItem
         prefixLabelText="라벨"
@@ -94,9 +238,20 @@ export const ListView: Story = {
         <Flex flexDirection="column" width="100%" gap="1rem">
           {new Array(5).fill(0).map(() => (
             <Flex justifyContent="spaceBetween">
-              <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+              <EditableItem.Input
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                placeholder="지출 내역"
+                textSize="bodyBold"
+              ></EditableItem.Input>
               <Flex gap="0.25rem" alignItems="center">
-                <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+                <EditableItem.Input
+                  value={value2}
+                  onChange={e => setValue2(e.target.value)}
+                  placeholder="0"
+                  type="number"
+                  style={{textAlign: 'right'}}
+                ></EditableItem.Input>
                 <Text size="caption">원</Text>
               </Flex>
             </Flex>

--- a/HDesign/src/components/EditableItem/EditableItem.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.stories.tsx
@@ -225,8 +225,21 @@ export const ReadOnlyWithIsFixedIcon: Story = {
 
 export const ListView: Story = {
   render: ({...args}) => {
-    const [value, setValue] = useState('');
-    const [value2, setValue2] = useState('');
+    const LENGTH = 5;
+    const [valueList, setValueList] = useState(new Array(LENGTH).fill(''));
+    const [valueList2, setValueList2] = useState(new Array(LENGTH).fill(''));
+
+    const handleValueListChange = (index: number, newValue: string) => {
+      const updatedList = [...valueList];
+      updatedList[index] = newValue;
+      setValueList(updatedList);
+    };
+
+    const handleValueList2Change = (index: number, newValue: string) => {
+      const updatedList = [...valueList2];
+      updatedList[index] = newValue;
+      setValueList2(updatedList);
+    };
 
     return (
       <EditableItem
@@ -236,18 +249,18 @@ export const ListView: Story = {
         onBlur={() => console.log('blur')}
       >
         <Flex flexDirection="column" width="100%" gap="1rem">
-          {new Array(5).fill(0).map(() => (
-            <Flex justifyContent="spaceBetween">
+          {valueList.map((value, index) => (
+            <Flex key={index} justifyContent="spaceBetween">
               <EditableItem.Input
                 value={value}
-                onChange={e => setValue(e.target.value)}
+                onChange={e => handleValueListChange(index, e.target.value)}
                 placeholder="지출 내역"
                 textSize="bodyBold"
               ></EditableItem.Input>
               <Flex gap="0.25rem" alignItems="center">
                 <EditableItem.Input
-                  value={value2}
-                  onChange={e => setValue2(e.target.value)}
+                  value={valueList2[index]}
+                  onChange={e => handleValueList2Change(index, e.target.value)}
                   placeholder="0"
                   type="number"
                   style={{textAlign: 'right'}}

--- a/HDesign/src/components/EditableItem/EditableItem.stories.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.stories.tsx
@@ -42,3 +42,67 @@ export const Playground: Story = {
     );
   },
 };
+
+export const WithLabel: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        prefixLabelText="라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};
+
+export const WithLabels: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        prefixLabelText="왼쪽 라벨"
+        suffixLabelText="오른쪽 라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+        <Flex gap="0.25rem" alignItems="center">
+          <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+          <Text size="caption">원</Text>
+        </Flex>
+      </EditableItem>
+    );
+  },
+};
+
+export const ListView: Story = {
+  render: ({...args}) => {
+    return (
+      <EditableItem
+        prefixLabelText="라벨"
+        backgroundColor={args.backgroundColor}
+        onFocus={() => console.log('focus')}
+        onBlur={() => console.log('blur')}
+      >
+        <Flex flexDirection="column" width="100%" gap="1rem">
+          {new Array(5).fill(0).map(() => (
+            <Flex justifyContent="spaceBetween">
+              <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+              <Flex gap="0.25rem" alignItems="center">
+                <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+                <Text size="caption">원</Text>
+              </Flex>
+            </Flex>
+          ))}
+        </Flex>
+      </EditableItem>
+    );
+  },
+};

--- a/HDesign/src/components/EditableItem/EditableItem.style.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.style.ts
@@ -12,3 +12,10 @@ export const editableItemStyle = (theme: Theme, backgroundColor: ColorKeys) =>
     borderRadius: '0.5rem',
     backgroundColor: theme.colors[backgroundColor],
   });
+
+export const labelTextStyle = (theme: Theme, side: 'prefix' | 'suffix') =>
+  css({
+    color: theme.colors.gray,
+    paddingLeft: side === 'prefix' ? '0.375rem' : 0,
+    paddingRight: side === 'suffix' ? '0.375rem' : 0,
+  });

--- a/HDesign/src/components/EditableItem/EditableItem.tsx
+++ b/HDesign/src/components/EditableItem/EditableItem.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource @emotion/react */
-import React, {useEffect} from 'react';
+import Text from '@components/Text/Text';
+import Flex from '@components/Flex/Flex';
 
 import {useTheme} from '@theme/HDesignProvider';
 
-import {editableItemStyle} from './EditableItem.style';
+import {editableItemStyle, labelTextStyle} from './EditableItem.style';
 import EditableItemInput from './EditableItem.Input';
 import {EditableItemProps} from './EditableItem.type';
 import {EditableItemProvider} from './EditableItem.context';
@@ -12,6 +13,8 @@ import useEditableItem from './useEditableItem';
 const EditableItemBase = ({
   onInputFocus,
   onInputBlur,
+  prefixLabelText,
+  suffixLabelText,
   backgroundColor = 'white',
   children,
   ...htmlProps
@@ -21,9 +24,20 @@ const EditableItemBase = ({
   useEditableItem({onInputFocus, onInputBlur});
 
   return (
-    <div css={editableItemStyle(theme, backgroundColor)} {...htmlProps}>
-      {children}
-    </div>
+    <Flex flexDirection="column">
+      <Flex justifyContent="spaceBetween" width="100%">
+        <Text size="caption" css={labelTextStyle(theme, 'prefix')}>
+          {prefixLabelText}
+        </Text>
+        <Text size="caption" css={labelTextStyle(theme, 'suffix')}>
+          {suffixLabelText}
+        </Text>
+      </Flex>
+
+      <div css={editableItemStyle(theme, backgroundColor)} {...htmlProps}>
+        {children}
+      </div>
+    </Flex>
   );
 };
 

--- a/HDesign/src/components/EditableItem/EditableItem.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.type.ts
@@ -3,7 +3,7 @@ import {Theme} from '@theme/theme.type';
 import {ColorKeys} from '@token/colors';
 
 export interface EditableItemStyleProps {
-  backgroundColor: ColorKeys;
+  backgroundColor?: ColorKeys;
 }
 
 export interface EditableItemCustomProps {

--- a/HDesign/src/components/EditableItem/EditableItem.type.ts
+++ b/HDesign/src/components/EditableItem/EditableItem.type.ts
@@ -9,6 +9,8 @@ export interface EditableItemStyleProps {
 export interface EditableItemCustomProps {
   onInputFocus?: () => void;
   onInputBlur?: () => void;
+  prefixLabelText?: string;
+  suffixLabelText?: string;
 }
 
 export interface EditableItemStylePropsWithTheme extends EditableItemStyleProps {

--- a/HDesign/src/type/withTheme.ts
+++ b/HDesign/src/type/withTheme.ts
@@ -1,0 +1,5 @@
+import {Theme} from '@theme/theme.type';
+
+export type WithTheme<P = unknown> = P & {
+  theme: Theme;
+};

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -6,12 +6,9 @@ import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
 import Step from './Step';
 
 const StepList = () => {
-  // const {stepList} = useStepList();
-
   const {data: stepListData} = useRequestGetStepList();
   const stepList = stepListData ?? ([] as (MemberStep | BillStep)[]);
 
-  // TODO: (@weadie) if else 구문이 지저분하므로 리펙터링이 필요합니다.
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
       {stepList.map((step, index) => (


### PR DESCRIPTION
## 🎾 issue
- close #397 

<br/>
<br/>

## 🚨 여기서 구현된 `EditableItem.Input` 사용 시 유의할 점 🚨
value를 `EditableItem.Input`에 넘겨주지 않으면 가상 컴포넌트가 value 길이만큼의 width를 갖지 못하기 때문에 동적으로 width가 변하지 않습니다. 사용하실 땐 꼭 꼮 꼬꼬꼬꼮 `value` props를 넘겨주세요!!!

```js
<EditableItem.Input value={value} {...rest} />
```
(안넘겨주면 이렇게 됨)

https://github.com/user-attachments/assets/101a5cd9-aa08-48e0-8b59-221ea1c8b7a9



## 🎾 참고
- 원래 이 브랜치가 모달 구현을 위한 것이었으나, 이 동적 width작업이 선행되어야 디자인대로 만들 수 있을 것 같아서 397브랜치를 디자인 시스템 수정으로 바꿨습니다.
- input의 width가 fit-content, min-content로는 조절이 불가능했습니다.

## 🎾 구현 목적
- 시안을 보니 동적으로 input의 width를 바꿔야 했습니다.


## 🎾 구현 사항
동적으로 width를 바꾸는 컨셉은 [샌드박스](https://codesandbox.io/p/sandbox/input-box-with-dynamic-width-r7lol?file=%2Fsrc%2FinlineEditor.js%3A95%2C12-97%2C17)를 참고했습니다.

input이 동적 wdith를 가질 수 없고 고정 width는 가능하기 때문에 처음에는`글자수 * 그 글자가 차지하는 크기`px 방법을 생각했었습니다. 다만 이 방법은 모든 charactor마다의 width(px)를 알고 계산해주어야 하기 때문에 귀찮은 일이라 생각했습니다. 

그래서 참고했던 글의 방식처럼 보이진 않지만 존재하는 엘리먼트(동적 width가 가능한 div사용)를 만들고 그 엘리먼트에 값(value)를 넣어 화면에 렌더링하는 방법을 사용해보았습니다. 이 엘리먼트를 ref로 참조하고 이 엘리먼트의 style.width를 가져와 input에 할당해주는 식입니다.

```jsx
// 컴포넌트
const shadowRef = useRef<HTMLDivElement>(null);

<div ref={shadowRef} css={editingContainerStyle}>  // ⬅️ 보이진 않지만 존재하고 있는 가짜 엘리먼트
    <Text size={textSize}>{value || htmlProps.placeholder}</Text> // ⬅️ 폰트를 일치시키고 value를 렌더링해 width추출
</div>
```

<br/>
<br/>

그리고 이 엘리먼트가 화면에서 얼마만큼의 크기를 차지하는지 width를 가져와 input의 width에 넘겨주었습니다.
```jsx
// 컴포넌트
 <input
    css={inputStyle({
    theme,
    textSize,
    width: `${shadowRef.current?.offsetWidth}px`, // ⬅️1️⃣
    })} 
/>


// .style.ts
const inputBaseStyle = ({theme, width}: WithTheme<InputBaseStyleProps>) => // ⬅️2️⃣
  css({
    width, // ⬅️3️⃣
    // ...
  });
```
위 방식으로 input이 동적 width를 가질 수 있게 되었습니다.

<br/>
<br/>

## 🎾 컴포넌트의 다양한 모습
아래 모습들 모두 [스토리북](https://66a9dea5db27afc2b8f91ba7-gymdnrvega.chromatic.com/?path=/docs/components-editableitem--docs)에 있습니다.

### ✅ 동적으로 width가 변하는 모습

https://github.com/user-attachments/assets/51654247-bd7a-4d28-9e83-859d814d88b8

### ✅ readOnly인 모습

https://github.com/user-attachments/assets/e767dc06-44ae-42df-a0b6-7d128f6903b4

### ✅ 배열로 사용하는 모습

https://github.com/user-attachments/assets/7df1f5b8-d55b-4772-8307-269ff14aa280

### ✅ isFixed(변동여부)가 true인 모습

<img width="656" alt="image" src="https://github.com/user-attachments/assets/d8500f1c-631c-43a8-a186-fcec0b509e28">

## 🎾 우려되는 부분
한자리만 입력하고 포커스 풀어버리면 터치 가능한 영역이 작아집니다. 근데 시간이 모자라서 더 이상 컴포넌트 잡고 있을 순 없을 것 같아 그냥 올립니다..

