### PR TITLE
[BE] 로깅 적용 후 예외 응답 불가 버그 수정

### DIFF
--- a/server/src/main/java/server/haengdong/config/RequestServletFilter.java
+++ b/server/src/main/java/server/haengdong/config/RequestServletFilter.java
@@ -1,0 +1,23 @@
+package server.haengdong.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class RequestServletFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) request);
+
+        chain.doFilter(wrappedRequest, response);
+    }
+}


### PR DESCRIPTION
## issue
- close #412 

## 구현 사항

http request 로깅 적용 후 예외 응답을 반환하지 않는 버그를 수정했습니다.
http request의 경우 Spring에서 한번 read하면 읽지 못해 로깅을 위해 다시 읽을 수 없습니다.
ContentCachingRequestWrapper 를 사용하여 여러번 읽을 수 있도록  filter에서 request를 바꿔주었습니다.

## 논의하고 싶은 부분(선택)

그런데 AuthenticationException의 경우는 왜 request를 읽을 수 있었는지 모르겠습니다.