### PR TITLE
[FE] 지출 내역 추가 변경사항 적용

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.11.4",
         "@sentry/react": "^8.25.0",
         "@tanstack/react-query": "^5.51.23",
-        "haengdong-design": "^0.1.75",
+        "haengdong-design": "^0.1.76",
         "react": "^18.3.1",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
@@ -10137,9 +10137,9 @@
       }
     },
     "node_modules/haengdong-design": {
-      "version": "0.1.75",
-      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.75.tgz",
-      "integrity": "sha512-N8d34JG2lnzq1pubcH7mSO0WL1cXHgH9YmVy5EZ+kETYxLIIE18H0oSz2HJdGTz4RfE2bdsnZBCf04LueEMimw==",
+      "version": "0.1.76",
+      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.76.tgz",
+      "integrity": "sha512-wTZv/3XK9I8N5NAyCAoYyykWu76MzWQlQ+jDZDuTFuzyV2c+MoYI2Ouvyu+9rl+HDYRuBVIaQ6ysfM6hQcwVYg==",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.11.4",
         "@sentry/react": "^8.25.0",
         "@tanstack/react-query": "^5.51.23",
-        "haengdong-design": "^0.1.74",
+        "haengdong-design": "^0.1.75",
         "react": "^18.3.1",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
@@ -10137,9 +10137,9 @@
       }
     },
     "node_modules/haengdong-design": {
-      "version": "0.1.74",
-      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.74.tgz",
-      "integrity": "sha512-K75LDIR4wqR+Z8YDTMsYXm9sWQ60Qw4DLPSOSnsb5mzncX1u3/z+zLOb1gs/zS8YZznUwzu6HzavWh6Sl8guNQ==",
+      "version": "0.1.75",
+      "resolved": "https://registry.npmjs.org/haengdong-design/-/haengdong-design-0.1.75.tgz",
+      "integrity": "sha512-N8d34JG2lnzq1pubcH7mSO0WL1cXHgH9YmVy5EZ+kETYxLIIE18H0oSz2HJdGTz4RfE2bdsnZBCf04LueEMimw==",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",

--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,7 @@
     "@emotion/react": "^11.11.4",
     "@sentry/react": "^8.25.0",
     "@tanstack/react-query": "^5.51.23",
-    "haengdong-design": "^0.1.74",
+    "haengdong-design": "^0.1.75",
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,7 @@
     "@emotion/react": "^11.11.4",
     "@sentry/react": "^8.25.0",
     "@tanstack/react-query": "^5.51.23",
-    "haengdong-design": "^0.1.75",
+    "haengdong-design": "^0.1.76",
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -15,6 +15,8 @@ interface BillStepItemProps {
   setIsOpenBottomSheet: React.Dispatch<React.SetStateAction<boolean>>;
   isAddEditableItem: boolean;
   setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
+  isLastBillItem: boolean;
+  index: number;
 }
 
 const BillStepItem: React.FC<BillStepItemProps> = ({
@@ -23,6 +25,8 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   setIsOpenBottomSheet,
   isAddEditableItem,
   setIsAddEditableItem,
+  isLastBillItem,
+  index,
 }) => {
   const {isAdmin} = useOutletContext<EventPageContextProps>();
   const {handleBlurBillRequest, handleChangeBillInput, billInput} = useSetBillInput({setIsAddEditableItem});
@@ -50,6 +54,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   return (
     <>
       <DragHandleItemContainer
+        id={`${index}`}
         topLeftText={stepName}
         topRightText={`${step.members.length}명`}
         bottomLeftText="총액"
@@ -68,6 +73,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
                 backgroundColor="lightGrayContainer"
                 onClick={() => handleDragHandleItemClick(index)}
               />
+
               {isOpenBottomSheet && clickedIndex === index && isAdmin && (
                 <PutAndDeleteBillActionModal
                   billAction={action}
@@ -78,7 +84,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
             </Fragment>
           ))}
 
-        {isAddEditableItem && (
+        {isAddEditableItem && isLastBillItem && (
           <EditableItem backgroundColor="lightGrayContainer" onBlur={handleBlurBillRequest}>
             <EditableItem.Input
               placeholder="지출 내역"

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -1,9 +1,8 @@
-import type {BillStep, MemberReport} from 'types/serviceType';
-
-import {DragHandleItem, DragHandleItemContainer} from 'haengdong-design';
+import {DragHandleItem, DragHandleItemContainer, EditableItem, Flex, Text} from 'haengdong-design';
 import {Fragment, useState} from 'react';
 import {useOutletContext} from 'react-router-dom';
 
+import {BillStep, MemberReport} from 'types/serviceType';
 import {PutAndDeleteBillActionModal} from '@components/Modal/SetActionModal/PutAndDeleteBillActionModal';
 import {MemberListInBillStep} from '@components/Modal/MemberListInBillStep';
 import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
@@ -12,15 +11,23 @@ interface BillStepItemProps {
   step: BillStep;
   isOpenBottomSheet: boolean;
   setIsOpenBottomSheet: React.Dispatch<React.SetStateAction<boolean>>;
+  isAddEditableItem: boolean;
+  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, setIsOpenBottomSheet}) => {
+const BillStepItem: React.FC<BillStepItemProps> = ({
+  step,
+  isOpenBottomSheet,
+  setIsOpenBottomSheet,
+  isAddEditableItem,
+  setIsAddEditableItem,
+}) => {
   const {isAdmin} = useOutletContext<EventPageContextProps>();
   const [clickedIndex, setClickedIndex] = useState(-1);
   const [isOpenMemberListInBillStep, setIsOpenMemberListInBillStep] = useState(false);
 
   const stepName = `차`;
-  const totalPrice = step.actions.reduce((acc, cur) => acc + cur.price, 0);
+  const totalPrice = step.actions && step.type === 'BILL' ? step.actions.reduce((acc, cur) => acc + cur.price, 0) : 0;
 
   const handleDragHandleItemClick = (index: number) => {
     setClickedIndex(index);
@@ -46,24 +53,36 @@ const BillStepItem: React.FC<BillStepItemProps> = ({step, isOpenBottomSheet, set
         backgroundColor="white"
         onTopRightTextClick={handleTopRightTextClick}
       >
-        {step.actions.map((action, index) => (
-          <Fragment key={action.actionId}>
-            <DragHandleItem
-              hasDragHandler={isAdmin}
-              prefix={action.name}
-              suffix={`${action.price.toLocaleString('ko-kr')} 원`}
-              backgroundColor="lightGrayContainer"
-              onClick={() => handleDragHandleItemClick(index)}
-            />
-            {isOpenBottomSheet && clickedIndex === index && isAdmin && (
-              <PutAndDeleteBillActionModal
-                billAction={action}
-                isBottomSheetOpened={isOpenBottomSheet}
-                setIsBottomSheetOpened={setIsOpenBottomSheet}
+        {step.actions &&
+          step.type === 'BILL' &&
+          step.actions.map((action, index) => (
+            <Fragment key={action.actionId}>
+              <DragHandleItem
+                hasDragHandler={isAdmin}
+                prefix={action.name}
+                suffix={`${action.price.toLocaleString('ko-kr')} 원`}
+                backgroundColor="lightGrayContainer"
+                onClick={() => handleDragHandleItemClick(index)}
               />
-            )}
-          </Fragment>
-        ))}
+              {isOpenBottomSheet && clickedIndex === index && isAdmin && (
+                <PutAndDeleteBillActionModal
+                  billAction={action}
+                  isBottomSheetOpened={isOpenBottomSheet}
+                  setIsBottomSheetOpened={setIsOpenBottomSheet}
+                />
+              )}
+            </Fragment>
+          ))}
+
+        {isAddEditableItem && (
+          <EditableItem backgroundColor="lightGrayContainer" onBlur={() => {}}>
+            <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+            <Flex gap="0.25rem" alignItems="center">
+              <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+              <Text size="caption">원</Text>
+            </Flex>
+          </EditableItem>
+        )}
       </DragHandleItemContainer>
       {isOpenMemberListInBillStep && (
         <MemberListInBillStep

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -25,7 +25,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   setIsAddEditableItem,
 }) => {
   const {isAdmin} = useOutletContext<EventPageContextProps>();
-  const {handleBlurBillRequest, handleChangeBillInput} = useSetBillInput({setIsAddEditableItem});
+  const {handleBlurBillRequest, handleChangeBillInput, billInput} = useSetBillInput({setIsAddEditableItem});
 
   const [clickedIndex, setClickedIndex] = useState(-1);
   const [isOpenMemberListInBillStep, setIsOpenMemberListInBillStep] = useState(false);
@@ -83,12 +83,14 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
             <EditableItem.Input
               placeholder="지출 내역"
               textSize="bodyBold"
+              value={billInput.title}
               onChange={e => handleChangeBillInput('title', e)}
             ></EditableItem.Input>
             <Flex gap="0.25rem" alignItems="center">
               <EditableItem.Input
                 placeholder="0"
                 type="number"
+                value={billInput.price}
                 onChange={e => handleChangeBillInput('price', e)}
                 style={{textAlign: 'right'}}
               ></EditableItem.Input>

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -7,6 +7,8 @@ import {PutAndDeleteBillActionModal} from '@components/Modal/SetActionModal/PutA
 import {MemberListInBillStep} from '@components/Modal/MemberListInBillStep';
 import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
 
+import useSetBillInput from '@hooks/useSetBillInput';
+
 interface BillStepItemProps {
   step: BillStep;
   isOpenBottomSheet: boolean;
@@ -23,6 +25,8 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   setIsAddEditableItem,
 }) => {
   const {isAdmin} = useOutletContext<EventPageContextProps>();
+  const {handleBlurBillRequest, handleChangeBillInput} = useSetBillInput();
+
   const [clickedIndex, setClickedIndex] = useState(-1);
   const [isOpenMemberListInBillStep, setIsOpenMemberListInBillStep] = useState(false);
 
@@ -75,10 +79,22 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
           ))}
 
         {isAddEditableItem && (
-          <EditableItem backgroundColor="lightGrayContainer" onBlur={() => {}}>
-            <EditableItem.Input placeholder="지출 내역" textSize="bodyBold"></EditableItem.Input>
+          <EditableItem backgroundColor="lightGrayContainer" onBlur={handleBlurBillRequest}>
+            <EditableItem.Input
+              placeholder="지출 내역"
+              textSize="bodyBold"
+              onChange={e => handleChangeBillInput('title', e)}
+            ></EditableItem.Input>
             <Flex gap="0.25rem" alignItems="center">
-              <EditableItem.Input placeholder="0" type="number" style={{textAlign: 'right'}}></EditableItem.Input>
+              <EditableItem.Input
+                placeholder="0"
+                type="number"
+                onChange={e => {
+                  handleChangeBillInput('price', e);
+                  setIsAddEditableItem(false);
+                }}
+                style={{textAlign: 'right'}}
+              ></EditableItem.Input>
               <Text size="caption">원</Text>
             </Flex>
           </EditableItem>

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -25,7 +25,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   setIsAddEditableItem,
 }) => {
   const {isAdmin} = useOutletContext<EventPageContextProps>();
-  const {handleBlurBillRequest, handleChangeBillInput} = useSetBillInput();
+  const {handleBlurBillRequest, handleChangeBillInput} = useSetBillInput({setIsAddEditableItem});
 
   const [clickedIndex, setClickedIndex] = useState(-1);
   const [isOpenMemberListInBillStep, setIsOpenMemberListInBillStep] = useState(false);
@@ -89,10 +89,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
               <EditableItem.Input
                 placeholder="0"
                 type="number"
-                onChange={e => {
-                  handleChangeBillInput('price', e);
-                  setIsAddEditableItem(false);
-                }}
+                onChange={e => handleChangeBillInput('price', e)}
                 style={{textAlign: 'right'}}
               ></EditableItem.Input>
               <Text size="caption">원</Text>

--- a/client/src/components/StepList/Step.tsx
+++ b/client/src/components/StepList/Step.tsx
@@ -1,6 +1,6 @@
 import type {BillStep, MemberStep} from 'types/serviceType';
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import BillStepItem from './BillStepItem';
 import MemberStepItem from './MemberStepItem';
@@ -8,20 +8,32 @@ import MemberStepItem from './MemberStepItem';
 interface StepProps {
   step: BillStep | MemberStep;
   isAddEditableItem: boolean;
+  lastBillItemIndex: number;
   setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
+  index: number;
 }
 
-const Step = ({step, isAddEditableItem, setIsAddEditableItem}: StepProps) => {
+const Step = ({step, isAddEditableItem, lastBillItemIndex, setIsAddEditableItem, index}: StepProps) => {
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState<boolean>(false);
+  const [isLastBillItem, setIsLastBillItem] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (index === lastBillItemIndex) {
+      // index를 사용하여 마지막 BillStep인지 확인
+      setIsLastBillItem(true);
+    }
+  }, [index, lastBillItemIndex]);
 
   if (step.actions && step.type === 'BILL') {
     return (
       <BillStepItem
+        index={index}
         step={step as BillStep}
         isOpenBottomSheet={isOpenBottomSheet}
         setIsOpenBottomSheet={setIsOpenBottomSheet}
         isAddEditableItem={isAddEditableItem}
         setIsAddEditableItem={setIsAddEditableItem}
+        isLastBillItem={isLastBillItem}
       />
     );
   } else if (step.actions && (step.type === 'IN' || step.type === 'OUT')) {

--- a/client/src/components/StepList/Step.tsx
+++ b/client/src/components/StepList/Step.tsx
@@ -9,18 +9,21 @@ interface StepProps {
   step: BillStep | MemberStep;
   isAddEditableItem: boolean;
   lastBillItemIndex: number;
-  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
+  lastItemIndex: number;
   index: number;
+  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Step = ({step, isAddEditableItem, lastBillItemIndex, setIsAddEditableItem, index}: StepProps) => {
+const Step = ({step, isAddEditableItem, lastBillItemIndex, lastItemIndex, setIsAddEditableItem, index}: StepProps) => {
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState<boolean>(false);
   const [isLastBillItem, setIsLastBillItem] = useState<boolean>(false);
 
   useEffect(() => {
-    if (index === lastBillItemIndex) {
+    if (index === lastBillItemIndex && lastBillItemIndex === lastItemIndex) {
       // index를 사용하여 마지막 BillStep인지 확인
       setIsLastBillItem(true);
+    } else {
+      setIsLastBillItem(false);
     }
   }, [index, lastBillItemIndex]);
 

--- a/client/src/components/StepList/Step.tsx
+++ b/client/src/components/StepList/Step.tsx
@@ -7,16 +7,24 @@ import MemberStepItem from './MemberStepItem';
 
 interface StepProps {
   step: BillStep | MemberStep;
+  isAddEditableItem: boolean;
+  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Step = ({step}: StepProps) => {
+const Step = ({step, isAddEditableItem, setIsAddEditableItem}: StepProps) => {
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState<boolean>(false);
 
-  if (step.type === 'BILL') {
+  if (isAddEditableItem || (step.actions && step.type === 'BILL')) {
     return (
-      <BillStepItem step={step} isOpenBottomSheet={isOpenBottomSheet} setIsOpenBottomSheet={setIsOpenBottomSheet} />
+      <BillStepItem
+        step={step as BillStep}
+        isOpenBottomSheet={isOpenBottomSheet}
+        setIsOpenBottomSheet={setIsOpenBottomSheet}
+        isAddEditableItem={isAddEditableItem}
+        setIsAddEditableItem={setIsAddEditableItem}
+      />
     );
-  } else if (step.type === 'IN' || step.type === 'OUT') {
+  } else if (step.actions && (step.type === 'IN' || step.type === 'OUT')) {
     return (
       <MemberStepItem step={step} isOpenBottomSheet={isOpenBottomSheet} setIsOpenBottomSheet={setIsOpenBottomSheet} />
     );

--- a/client/src/components/StepList/Step.tsx
+++ b/client/src/components/StepList/Step.tsx
@@ -14,7 +14,7 @@ interface StepProps {
 const Step = ({step, isAddEditableItem, setIsAddEditableItem}: StepProps) => {
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState<boolean>(false);
 
-  if (isAddEditableItem || (step.actions && step.type === 'BILL')) {
+  if (step.actions && step.type === 'BILL') {
     return (
       <BillStepItem
         step={step as BillStep}

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -1,4 +1,5 @@
 import {Flex} from 'haengdong-design';
+import {useMemo} from 'react';
 
 import {BillStep, MemberStep} from 'types/serviceType';
 import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
@@ -14,11 +15,20 @@ const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
   const {data: stepListData} = useRequestGetStepList();
   const stepList = stepListData ?? ([] as (MemberStep | BillStep)[]);
 
+  const lastBillItemIndex = useMemo(() => {
+    const billSteps = stepList.map((step, index) => ({...step, index})).filter(step => step.type === 'BILL');
+
+    // billSteps 배열이 비어 있지 않으면 마지막 항목의 index를 반환, 그렇지 않으면 -1을 반환
+    return billSteps.length > 0 ? billSteps.slice(-1)[0].index : -1;
+  }, [stepList]);
+
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
       {stepList.map((step, index) => (
         <Step
+          index={index}
           step={step}
+          lastBillItemIndex={lastBillItemIndex}
           key={`${step.stepName}${index}`}
           isAddEditableItem={isAddEditableItem}
           setIsAddEditableItem={setIsAddEditableItem}

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -5,17 +5,24 @@ import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
 
 import Step from './Step';
 
-const StepList = () => {
-  // const {stepList} = useStepList();
+interface StepListProps {
+  isAddEditableItem: boolean;
+  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
+const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
   const {data: stepListData} = useRequestGetStepList();
   const stepList = stepListData ?? ([] as (MemberStep | BillStep)[]);
 
-  // TODO: (@weadie) if else 구문이 지저분하므로 리펙터링이 필요합니다.
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
       {stepList.map((step, index) => (
-        <Step step={step} key={`${step.stepName}${index}`} />
+        <Step
+          step={step}
+          key={`${step.stepName}${index}`}
+          isAddEditableItem={isAddEditableItem}
+          setIsAddEditableItem={setIsAddEditableItem}
+        />
       ))}
     </Flex>
   );

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -1,5 +1,5 @@
 import {Flex} from 'haengdong-design';
-import {useMemo} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 import {BillStep, MemberStep} from 'types/serviceType';
 import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
@@ -13,14 +13,41 @@ interface StepListProps {
 
 const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
   const {data: stepListData} = useRequestGetStepList();
-  const stepList = stepListData ?? ([] as (MemberStep | BillStep)[]);
+  const [stepList, setStepList] = useState<(MemberStep | BillStep)[]>([]);
+  const existIndexInStepList = stepList.map((step, index) => ({...step, index}));
+  const [hasAddedItem, setHasAddedItem] = useState(false);
+
+  useEffect(() => {
+    if (stepListData) {
+      setStepList(stepListData);
+    }
+  }, [stepListData]);
 
   const lastBillItemIndex = useMemo(() => {
-    const billSteps = stepList.map((step, index) => ({...step, index})).filter(step => step.type === 'BILL');
+    const billSteps = existIndexInStepList.filter(step => step.type === 'BILL');
 
     // billSteps 배열이 비어 있지 않으면 마지막 항목의 index를 반환, 그렇지 않으면 -1을 반환
     return billSteps.length > 0 ? billSteps.slice(-1)[0].index : -1;
   }, [stepList]);
+
+  const lastItemIndex = useMemo(() => {
+    return existIndexInStepList.length > 0 ? existIndexInStepList.slice(-1)[0].index : -1;
+  }, [existIndexInStepList]);
+
+  useEffect(() => {
+    if (isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem) {
+      setStepList(prev => [
+        ...prev,
+        {
+          type: 'BILL',
+          stepName: '',
+          members: [],
+          actions: [],
+        },
+      ]);
+      setHasAddedItem(true);
+    }
+  }, [isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem]);
 
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
@@ -29,6 +56,7 @@ const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
           index={index}
           step={step}
           lastBillItemIndex={lastBillItemIndex}
+          lastItemIndex={lastItemIndex}
           key={`${step.stepName}${index}`}
           isAddEditableItem={isAddEditableItem}
           setIsAddEditableItem={setIsAddEditableItem}

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -35,6 +35,9 @@ const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
   }, [existIndexInStepList]);
 
   useEffect(() => {
+    // 최초로 빈 stepList가 생성되고 난 후, 다시 hasAddedItem을 false로 변환하기 위한 조건문
+    if (hasAddedItem) setHasAddedItem(prev => !prev);
+
     if (isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem) {
       setStepList(prev => [
         ...prev,
@@ -45,9 +48,9 @@ const StepList = ({isAddEditableItem, setIsAddEditableItem}: StepListProps) => {
           actions: [],
         },
       ]);
-      setHasAddedItem(true);
+      setHasAddedItem(prev => !prev);
     }
-  }, [isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem]);
+  }, [isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem, existIndexInStepList, stepListData]);
 
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -1,0 +1,63 @@
+import {useState} from 'react';
+
+import validatePurchase from '@utils/validate/validatePurchase';
+import {Bill} from 'types/serviceType';
+
+import useRequestPostBillList from './queries/useRequestPostBillList';
+import {BillInputType, InputPair} from './useDynamicBillActionInput';
+
+interface UseSetBillInputReturns {
+  handleChangeBillInput: (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBlurBillRequest: () => void;
+}
+
+const useSetBillInput = (): UseSetBillInputReturns => {
+  const initialInput = {title: '', price: 0};
+  const [billInput, setBillInput] = useState<Bill>(initialInput);
+
+  const {mutate: postBillList} = useRequestPostBillList();
+
+  const handleChangeBillInput = (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target;
+    const {isValid} = validatePurchase({
+      ...billInput,
+      [field]: value,
+    });
+
+    if (isValid) {
+      console.log(billInput);
+      setBillInput(prev => ({
+        ...prev,
+        [field]: value,
+      }));
+    }
+  };
+
+  const handleBlurBillRequest = () => {
+    // 두 input의 값이 모두 채워졌을 때 api 요청
+    // api 요청을 하면 더이상 Input이 아니게 됨
+
+    const isEmptyTitle = billInput.title.trim().length;
+    const isEmptyPrice = Number(billInput.price);
+
+    if (isEmptyTitle && isEmptyPrice) {
+      console.log('조건 충족!');
+      postBillList({billList: [billInput]}),
+        {
+          onSuccess: () => {
+            console.log('post 요청 완료');
+          },
+        };
+    }
+
+    // 하나라도 공백이 존재하면 api 요청 X
+    // 여전히 input임
+  };
+
+  return {
+    handleBlurBillRequest,
+    handleChangeBillInput,
+  };
+};
+
+export default useSetBillInput;

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -6,12 +6,16 @@ import {Bill} from 'types/serviceType';
 import useRequestPostBillList from './queries/useRequestPostBillList';
 import {BillInputType, InputPair} from './useDynamicBillActionInput';
 
+interface UseSetBillInputProps {
+  setIsAddEditableItem: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 interface UseSetBillInputReturns {
   handleChangeBillInput: (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlurBillRequest: () => void;
 }
 
-const useSetBillInput = (): UseSetBillInputReturns => {
+const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBillInputReturns => {
   const initialInput = {title: '', price: 0};
   const [billInput, setBillInput] = useState<Bill>(initialInput);
 
@@ -41,13 +45,14 @@ const useSetBillInput = (): UseSetBillInputReturns => {
     const isEmptyPrice = Number(billInput.price);
 
     if (isEmptyTitle && isEmptyPrice) {
-      console.log('조건 충족!');
-      postBillList({billList: [billInput]}),
+      postBillList(
+        {billList: [billInput]},
         {
           onSuccess: () => {
-            console.log('post 요청 완료');
+            setIsAddEditableItem(false);
           },
-        };
+        },
+      );
     }
 
     // 하나라도 공백이 존재하면 api 요청 X

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -48,6 +48,7 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
         {billList: [billInput]},
         {
           onSuccess: () => {
+            setBillInput(initialInput);
             setIsAddEditableItem(false);
           },
         },

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -39,12 +39,11 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
   };
 
   const handleBlurBillRequest = () => {
-    // 두 input의 값이 모두 채워졌을 때 api 요청
-    // api 요청을 하면 더이상 Input이 아니게 됨
-
     const isEmptyTitle = billInput.title.trim().length;
     const isEmptyPrice = Number(billInput.price);
 
+    // 두 input의 값이 모두 채워졌을 때 api 요청
+    // api 요청을 하면 Input을 띄우지 않음
     if (isEmptyTitle && isEmptyPrice) {
       postBillList(
         {billList: [billInput]},
@@ -55,9 +54,6 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
         },
       );
     }
-
-    // 하나라도 공백이 존재하면 api 요청 X
-    // 여전히 input임
   };
 
   return {

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -30,7 +30,6 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
     });
 
     if (isValid) {
-      console.log(billInput);
       setBillInput(prev => ({
         ...prev,
         [field]: value,

--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -11,6 +11,7 @@ interface UseSetBillInputProps {
 }
 
 interface UseSetBillInputReturns {
+  billInput: Bill;
   handleChangeBillInput: (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlurBillRequest: () => void;
 }
@@ -60,6 +61,7 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
   };
 
   return {
+    billInput,
     handleBlurBillRequest,
     handleChangeBillInput,
   };

--- a/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
@@ -4,8 +4,7 @@ export const receiptStyle = () =>
   css({
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
-    padding: '0 8px',
+    gap: '1rem',
     paddingBottom: '8.75rem',
   });
 
@@ -19,5 +18,6 @@ export const buttonGroupStyle = () =>
   css({
     display: 'flex',
     width: '100%',
+    padding: '0 0.5rem',
     gap: '0.5rem',
   });

--- a/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
@@ -14,3 +14,10 @@ export const titleAndListButtonContainerStyle = () =>
     display: 'flex',
     flexDirection: 'column',
   });
+
+export const buttonGroupStyle = () =>
+  css({
+    display: 'flex',
+    width: '100%',
+    gap: '0.5rem',
+  });

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -59,7 +59,12 @@ const AdminPage = () => {
           <FixedButton children={'시작인원 추가하기'} onClick={() => setIsOpenFixedButtonBottomSheet(prev => !prev)} />
         ) : (
           <div css={buttonGroupStyle}>
-            <Button size="medium" variants="tertiary" style={{width: '100%'}}>
+            <Button
+              size="medium"
+              variants="tertiary"
+              style={{width: '100%'}}
+              onClick={() => setIsOpenFixedButtonBottomSheet(prev => !prev)}
+            >
               인원 변동 추가
             </Button>
             <Button size="medium" style={{width: '100%'}}>

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -16,6 +16,7 @@ import {receiptStyle, titleAndListButtonContainerStyle, buttonGroupStyle} from '
 const AdminPage = () => {
   const [isOpenFixedButtonBottomSheet, setIsOpenFixedButtonBottomSheet] = useState(false);
   const [isOpenAllMemberListButton, setIsOpenAllMemberListButton] = useState(false);
+  const [isAddEditableItem, setIsAddEditableItem] = useState(false);
 
   const {eventName} = useOutletContext<EventPageContextProps>();
   const {data: allMemberListData} = useRequestGetAllMemberList();
@@ -54,7 +55,7 @@ const AdminPage = () => {
         )}
       </div>
       <section css={receiptStyle}>
-        <StepList />
+        <StepList isAddEditableItem={isAddEditableItem} setIsAddEditableItem={setIsAddEditableItem} />
         {allMemberList.length === 0 ? (
           <FixedButton children={'시작인원 추가하기'} onClick={() => setIsOpenFixedButtonBottomSheet(prev => !prev)} />
         ) : (
@@ -67,7 +68,7 @@ const AdminPage = () => {
             >
               인원 변동 추가
             </Button>
-            <Button size="medium" style={{width: '100%'}}>
+            <Button size="medium" onClick={() => setIsAddEditableItem(true)} style={{width: '100%'}}>
               지출 내역 추가
             </Button>
           </div>

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import {Title, FixedButton, ListButton} from 'haengdong-design';
+import {Title, FixedButton, ListButton, Button} from 'haengdong-design';
 import {useOutletContext} from 'react-router-dom';
 
 import StepList from '@components/StepList/StepList';
@@ -11,7 +11,7 @@ import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import {EventPageContextProps} from '../EventPageLayout';
 
-import {receiptStyle, titleAndListButtonContainerStyle} from './AdminPage.style';
+import {receiptStyle, titleAndListButtonContainerStyle, buttonGroupStyle} from './AdminPage.style';
 
 const AdminPage = () => {
   const [isOpenFixedButtonBottomSheet, setIsOpenFixedButtonBottomSheet] = useState(false);
@@ -55,10 +55,18 @@ const AdminPage = () => {
       </div>
       <section css={receiptStyle}>
         <StepList />
-        <FixedButton
-          children={allMemberList.length === 0 ? '시작인원 추가하기' : '행동 추가하기'}
-          onClick={() => setIsOpenFixedButtonBottomSheet(prev => !prev)}
-        />
+        {allMemberList.length === 0 ? (
+          <FixedButton children={'시작인원 추가하기'} onClick={() => setIsOpenFixedButtonBottomSheet(prev => !prev)} />
+        ) : (
+          <div css={buttonGroupStyle}>
+            <Button size="medium" variants="tertiary" style={{width: '100%'}}>
+              인원 변동 추가
+            </Button>
+            <Button size="medium" style={{width: '100%'}}>
+              지출 내역 추가
+            </Button>
+          </div>
+        )}
         {isOpenFixedButtonBottomSheet && (
           <ModalBasedOnMemberCount
             allMemberList={allMemberList}


### PR DESCRIPTION
## issue
- close #399

## 구현 사항

- 인원 변동 추가 / 지출 내역 추가 Button
    
    디자인시스템 Button을 활용함. 다만, Button width가 부모만큼 커지지 않는 것을 확인.
    각 Button에 `style width: 100%`를 추가하여 부모 width 만큼 늘어나도록 함.
    
    <img width="339" alt="스크린샷 2024-08-20 14 39 00" src="https://github.com/user-attachments/assets/7d92f5ec-dbc1-43e9-a438-88724ce4e772">
    <img width="336" alt="스크린샷 2024-08-20 14 39 07" src="https://github.com/user-attachments/assets/9b1af641-dc00-4e09-a0ea-5d6ab28aa2b2">
   
- isAddEditableItem
    
    해당 상태는 지출 내역 추가를 click 했는지를 나타낸다.
    
    이 상태는 AdminPage에서 만들어져 BillStepItem까지 props drilling을 통해 전해진다.
    context나 store를 사용하여 관리할까 고민했지만, 일단은 props로 넘겨주는 것으로 했다. 추후 어떤 방식으로 하는 것이 좋을 지 논의 후 리팩토링을 꼭 진행해야 한다.
   
- useSetBillInput
    - handleChangeBillInput
        
        각 Input에 onChange가 발생할 때, valid를 실행하여 올바른 값인지 검사한다.
        isValid 하다면, 해당 field의 값을 set을 통해 BillInput 상태를 변경한다.
        
        ```tsx
        const handleChangeBillInput = (field: BillInputType, event: React.ChangeEvent<HTMLInputElement>) => {
          const {value} = event.target;
          const {isValid} = validatePurchase({
            ...billInput,
            [field]: value,
          });
        
          if (isValid) {
            setBillInput(prev => ({
              ...prev,
              [field]: value,
            }));
          }
        };
        ```
        
    - handleBlurBillRequest
        
        두 input의 값이 모두 채워져있는 상태에서 onBlur를 하면 post요청을 한다.
        이때, post 요청이 정상적으로 보내졌다면 setIsAddEditableItem (지출 내역 추가 버튼 클릭 여부)을 false로 바꾼다.
        
        ```tsx
        const handleBlurBillRequest = () => {
          const isEmptyTitle = billInput.title.trim().length;
          const isEmptyPrice = Number(billInput.price);
        
          // 두 input의 값이 모두 채워졌을 때 api 요청
          // api 요청을 하면 Input을 띄우지 않음
          if (isEmptyTitle && isEmptyPrice) {
            postBillList(
              {billList: [billInput]},
              {
                onSuccess: () => {
                  setIsAddEditableItem(false);
                },
              },
            );
          }
        };
        ```
        
- 마지막 BillStep에만 지출 내역 input 렌더링
    
    이 부분이 가장 오래 걸리고 힘들었다.. 단순하게 isAddEditableItem가 true이면 EditableItem을 렌더링 시키면, 모든 BillItem에 input이 생성된다.
    그래서 마지막 BillItem이 true (*isLastBillItem)*라는 조건도 추가했다. 하지만 여전히 모든 BillItem에서 Input이 렌더링되었다.
    
    이렇게 렌더링되는 원인은 모든 BillItem을 동일하게 보고 있기 때문이었다.
    원인을 찾는 아이디어는 이전에 만들었던 useDynamicInput에서 영감을 얻었다. 당시 useDynamicInput은 하나의 input에 값을 입력해도 모든 input에서 동일한 값으로 변경되었다. 이 원인은 각 input에 고유한 값 (key나 id)가 존재하지 않았기 때문에 모든 Input을 동일한 것으로 본 것이다. 따라서 각 input에 key를 추가해주면 해결되었다.
    
    해당 문제도 비슷하게 접근했다. 최초에 Step에서 BillStep을 Count하는 state가 존재했다. 해당 state를 id로 넣어줬더니 모든 BillItem의 id가 동일한 값인 것을 확인할 수 있었다.
    따라서 나는 모든 BillItem을 동일하게 보고 있다는 것을 파악했다. 그래서 각 BillItem마다 고유한 id를 주고자 하였다.
    
    - 각 action 마다 고유한 index 부여 및 마지막 BILL의 index 찾기
        
        ```tsx
        // StepList.tsx
        
        const lastBillItemIndex = useMemo(() => {
          const billSteps = stepList.map((step, index) => ({...step, index})).filter(step => step.type === 'BILL');
        
          // billSteps 배열이 비어 있지 않으면 마지막 항목의 index를 반환, 그렇지 않으면 -1을 반환
          return billSteps.length > 0 ? billSteps.slice(-1)[0].index : -1;
        }, [stepList]);
        ```
        
        서버로 부터 받아오는 stepList에는 각 action 마다 index가 존재하지 않는다. 따라서 stepList를 map하여 일단 각 action(step)마다 index를 부여했다. 그리고 filter를 통해 type이 BILL인 action만을 추출했다.
        
        그리고 마지막 BillItem에만 EditableItem을 렌더링하기 위해서 마지막 BillItem의 index를 찾아야 할 필요가 있었다.
        billSteps 배열의 마지막 값의 index만을 return하도록 했다. 단, 여기서 서버로부터 받은 stepList에 BILL type이 존재하지 않을 수 있다. billSteps의 길이가 0일 경우에는 -1을 return하도록 했다.
        
        > **useMemo를 사용한 이유**
        useMemo를 사용하지 않을 경우 렌더링이 발생할 때마다 해당 로직을 재실행한다. 한번만 실행해도 되기 때문에 불필요한 실행을 막고자 useMemo를 사용했다. 이때, 의존성으로는 stepList를 했다. stepList가 변경되면 다시 마지막 Bill의 index를 찾아야 하기 때문이다. 
        그리고 useMemo를 실행하지 않으면 too many render 에러가 발생한다.
        > 
    - 현재 bill action이 마지막 BillItem인지 확인하기
        
        ```tsx
        const [isLastBillItem, setIsLastBillItem] = useState<boolean>(false);
        
        useEffect(() => {
          if (index === lastBillItemIndex) {
            // index를 사용하여 마지막 BillStep인지 확인
            setIsLastBillItem(true);
          }
        }, [index, lastBillItemIndex]);
        ```
        
        isLastBillItem 상태는 마지막 Bill Item이라면 true를 아니면 false를 갖는다.
        useEffect의 의존성으로 index와 lastBillItemIndex를 넣어 렌더링 되는 action의 index가 변하거나 lastBillItemIndex이 변하면 실행되도록 했다.
        
        만약 현재 action의 index와 lastBillItemIndex가 동일하다면 set을 통해 상태를 true로 변경한다.
        
    - 마지막 BillItem에 Editable.Input 렌더링
        
        ```tsx
        // ...
        <DragHandleItemContainer
          id={`${index}`}
          topLeftText={stepName}
          topRightText={`${step.members.length}명`}
          bottomLeftText="총액"
          bottomRightText={`${totalPrice.toLocaleString('ko-kr')} 원`}
          backgroundColor="white"
          onTopRightTextClick={handleTopRightTextClick}
        >
          // ...
            {isAddEditableItem && isLastBillItem && (
              <EditableItem backgroundColor="lightGrayContainer" onBlur={handleBlurBillRequest}>
                <EditableItem.Input
                  placeholder="지출 내역"
                  textSize="bodyBold"
                  value={billInput.title}
                  onChange={e => handleChangeBillInput('title', e)}
                ></EditableItem.Input>
                <Flex gap="0.25rem" alignItems="center">
                  <EditableItem.Input
                    placeholder="0"
                    type="number"
                    value={billInput.price}
                    onChange={e => handleChangeBillInput('price', e)}
                    style={{textAlign: 'right'}}
                  ></EditableItem.Input>
                  <Text size="caption">원</Text>
                </Flex>
              </EditableItem>
            )}
         // ...
        ```
        
        DragHandleItemContainer에 id로 index를 넣어준다. 그래야 각 action들이 고유할 수 있다.
        
        그리고 조건으로 지출 생성 버튼을 클릭(isAddEditableItem)하고 해당 action이 마지막 Bill action(isLastBillItem)이라면 EditableItem을 렌더링하도록 했다.

- BillIStepItem이 존재하지 않을 때, 지출 Input이 렌더링 되지 않음
    
    BillIStepItem이 존재하지 않을 때, 지출 내역 추가 버튼을 클릭하면 에러가 발생한다.
    BillStepItem에 들어가는 Step에서의 조건문으로 인해 지출 내역 추가 버튼을 클릭해도 지출 Input이 렌더링되지 않는다.
    
    아래의 해결 방법으로 인해 해결 될 수 있다.
    
- 인원 변동 action이 추가 된 후, 지출 Input이 새로 생성되지 않음
    
    인원 변동 action이 가장 마지막에 일어난 action일 경우, 지출 내역 추가 버튼을 클릭하면 새로운 지출 action이 생성되지 않는다. 대신 바로 전 지출 action에 지출 Input이 추가된다.
    
    지출 내역 추가 버튼을 클릭했을 때, 지출 action이 step에서 가장 마지막 action인지 확인한다. 가장 마지막 action이 아니라면 새로운 지출 action을 생성하도록 한다.
    
    ```tsx
    // StepList.tsx
    
    useEffect(()=>{
    if (isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem) {
        setStepList(prev => [
          ...prev,
          {
            type: 'BILL',
            stepName: '',
            members: [],
            actions: [],
          },
        ]);
        setHasAddedItem(true);
      }
    },[isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem, existIndexInStepList, stepListData])
    ```
    
    마지막 BillItem의 index와 마지막 step의 index가 일치하지 않으면 새로운 빈 step을 생성한다.
    
    ```tsx
    // Step.tsx
    
    useEffect(() => {
      if (index === lastBillItemIndex && lastBillItemIndex === lastItemIndex) {
        // index를 사용하여 마지막 BillStep인지 확인
        setIsLastBillItem(true);
      } else {
        setIsLastBillItem(false);
      }
    }, [index, lastBillItemIndex]);
    ```
    
    그리고 Step에서 현재 action의 index와 마지막 BillItemIndex가 동일하고 마지막 BillItem의 index와 step의 마지막 index가 동일한지 확인한다. 동일하다면 islastBillItem을 true다.
    
- 인원 추가 후, 바로 지출 Input을 추가하면 새로운 step이 생성되지 않음.
    
    새로운 step이 생성되어야 하지만, 생성되지 않고 가장 마지막 bill action에 input이 생성됨
    
    StepList.tsx의 useEffect 의존성에 existIndexInStepList, stepListData 의존성 추가 → 첫번째 지출 Input 추가는 성공. 그러나 두번째 인원변동 action이 추가되면 지출 Input이 이전 BillItem에 렌더링됨.
    
    두번째 인원변동 action 후, 새로운 BillItem이 생성되지 않는 이유는 StepList의 hasAddedItem 때문이었음. 
    맨 처음에 빈 BillItem이 생성되고 난 후, hasAddedItem은 false에서 true로 바뀜. 그리고 두번째 빈 BillItem을 생성하려고 할때 hasAddedItem은 여전히 true이기 때문에 아래 조건문(`isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem`)을 통과하지 못하는 것이었음.
    
    따라서 useEffect에서 다음 조건문( `if (hasAddedItem) setHasAddedItem(prev => !prev);`)을 추가함. hasAddedItem이 true일 경우, set을 통해 다시 false로 변환해줌. hasAddedItem이 false이기 때문에 통과되지 않았던 조건문이 다시 됨.
    
    ```tsx
    useEffect(() => {
      // 최초로 빈 stepList가 생성되고 난 후, 다시 hasAddedItem을 false로 변환하기 위한 조건문
      if (hasAddedItem) setHasAddedItem(prev => !prev);
    
      if (isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem) {
        setStepList(prev => [
          ...prev,
          {
            type: 'BILL',
            stepName: '',
            members: [],
            actions: [],
          },
        ]);
        setHasAddedItem(prev => !prev);
      }
    }, [isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem, existIndexInStepList, stepListData]);
    ```

## 🫡 참고사항

### 미 반영 사항

- `시작 인원 추가` 버튼
    
    디자인 시스템에서 변경해야 하기 때문에 일단은 기존에 사용하던 FixedButton을 그대로 사용했음.
    
- 기존의 BottomSheet 미수정
    
    기존에 지출,인원(늦참,탈주) BottomSheet 디자인 및 파일명을 변경하지 않음.


