### PR TITLE
[FE] 차등 적용 적용 중 지원되지 않는 기능 수정

### DIFF
--- a/client/src/hooks/useMemberReportListInAction/useMemberReportInput.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportInput.tsx
@@ -11,12 +11,21 @@ type MemberReportInput = MemberReportInAction & {
 type UseMemberReportProps = {
   data: MemberReportInAction[];
   addAdjustedMember: (memberReport: MemberReportInAction) => void;
+  getOnlyOneNotAdjustedRemainMemberIndex: () => number | null;
+  isSameStateAndServerState: boolean;
   totalPrice: number;
 };
 
-const useMemberReportInput = ({data, addAdjustedMember, totalPrice}: UseMemberReportProps) => {
+const useMemberReportInput = ({
+  data,
+  addAdjustedMember,
+  totalPrice,
+  getOnlyOneNotAdjustedRemainMemberIndex,
+}: UseMemberReportProps) => {
   const [inputList, setInputList] = useState<MemberReportInput[]>(data.map((item, index) => ({...item, index})));
   const [canSubmit, setCanSubmit] = useState<boolean>(false);
+
+  const [canEditList, setCanEditList] = useState<boolean[]>(new Array(data.length).fill(true));
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>, index: number) => {
     const {value} = event.target;
@@ -25,8 +34,8 @@ const useMemberReportInput = ({data, addAdjustedMember, totalPrice}: UseMemberRe
   };
 
   const validateAndAddAdjustedMember = (price: string, index: number) => {
-    const {isValid, errorMessage} = validateMemberReportInAction(price, totalPrice);
-    setCanSubmit(errorMessage === null);
+    const {isValid} = validateMemberReportInAction(price, totalPrice);
+    setCanSubmit(isValid);
 
     if (isValid) {
       const newInputList = [...inputList];
@@ -45,11 +54,20 @@ const useMemberReportInput = ({data, addAdjustedMember, totalPrice}: UseMemberRe
   // addAdjustedMember로 인해 data가 변했을 때 input list의 값을 맞춰주기 위함
   useEffect(() => {
     setInputList(data.map((item, index) => ({...item, index})));
+
+    // 남은 인원이 1명일 때 수정을 불가능하도록 설정
+    const onlyOneIndex = getOnlyOneNotAdjustedRemainMemberIndex();
+    if (onlyOneIndex !== null) {
+      const newCanEditList = new Array(data.length).fill(true);
+      newCanEditList[onlyOneIndex] = false;
+      setCanEditList(newCanEditList);
+    }
   }, [data]);
 
   return {
     inputList,
     onChange,
+    canEditList,
     canSubmit,
   };
 };

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportInput.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportInput.tsx
@@ -12,7 +12,7 @@ type UseMemberReportProps = {
   data: MemberReportInAction[];
   addAdjustedMember: (memberReport: MemberReportInAction) => void;
   getOnlyOneNotAdjustedRemainMemberIndex: () => number | null;
-  isSameStateAndServerState: boolean;
+  getIsSamePriceStateAndServerState: () => boolean;
   totalPrice: number;
 };
 
@@ -21,6 +21,7 @@ const useMemberReportInput = ({
   addAdjustedMember,
   totalPrice,
   getOnlyOneNotAdjustedRemainMemberIndex,
+  getIsSamePriceStateAndServerState,
 }: UseMemberReportProps) => {
   const [inputList, setInputList] = useState<MemberReportInput[]>(data.map((item, index) => ({...item, index})));
   const [canSubmit, setCanSubmit] = useState<boolean>(false);
@@ -53,6 +54,7 @@ const useMemberReportInput = ({
 
   // addAdjustedMember로 인해 data가 변했을 때 input list의 값을 맞춰주기 위함
   useEffect(() => {
+    setCanSubmit(!getIsSamePriceStateAndServerState());
     setInputList(data.map((item, index) => ({...item, index})));
 
     // 남은 인원이 1명일 때 수정을 불가능하도록 설정

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
@@ -275,6 +275,27 @@ describe('useMemberReportListInActionTest', () => {
       const targetMemberReset = result.current.memberReportListInAction.find(member => member.name === '망쵸');
       expect(targetMemberReset?.isFixed).toBe(false);
     });
+
+    it('아무도 조정된 값이 없다면 조정값이 있는지 확인 결과 false다.', async () => {
+      const {result} = initializeProvider(actionId, totalPrice);
+
+      await waitFor(() => expect(result.current.queryResult.isSuccess).toBe(true));
+
+      expect(result.current.isExistAdjustedPrice()).toBe(false);
+    });
+
+    it('망쵸의 가격을 100원으로 바꾼 후 리스트 중 조정값이 있는지 확인 결과 true다.', async () => {
+      const {result} = initializeProvider(actionId, totalPrice);
+      const adjustedMemberMangcho: MemberReportInAction = {name: '망쵸', price: 100, isFixed: false};
+
+      await waitFor(() => expect(result.current.queryResult.isSuccess).toBe(true));
+
+      act(() => {
+        result.current.addAdjustedMember(adjustedMemberMangcho);
+      });
+
+      expect(result.current.isExistAdjustedPrice()).toBe(true);
+    });
   });
 
   // last

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -37,13 +37,17 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
     if (totalPriceFromServer !== totalPrice) {
       reCalculatePriceByTotalPriceChange();
     }
-  }, [totalPrice, memberReportListInActionFromServer]);
+  }, [totalPrice]);
 
   useEffect(() => {
     if (queryResult.isSuccess) {
       setMemberReportListInAction(memberReportListInActionFromServer);
     }
   }, [memberReportListInActionFromServer, queryResult.isSuccess]);
+
+  const isExistAdjustedPrice = () => {
+    return memberReportListInAction.some(member => member.isFixed === true);
+  };
 
   // 조정값 멤버의 수를 구하는 함수
   const getAdjustedMemberCount = (memberReportListInAction: MemberReportInAction[]) => {
@@ -118,6 +122,7 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
   return {
     memberReportListInAction,
     addAdjustedMember,
+    isExistAdjustedPrice,
     onSubmit,
     queryResult,
   };

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -13,6 +13,32 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
     memberReportListInActionFromServer,
   );
 
+  // isFixed를 모두 풀고 계산값으로 모두 처리하는 기능
+  const reCalculatePriceByTotalPriceChange = () => {
+    const {divided, remainder} = calculateDividedPrice(memberReportListInAction.length, 0);
+
+    const resetMemberReportList = [...memberReportListInAction];
+    resetMemberReportList.forEach((member, index) => {
+      if (index !== resetMemberReportList.length - 1) {
+        member.price = divided;
+      } else {
+        member.price = divided + remainder;
+      }
+      member.isFixed = false;
+    });
+
+    setMemberReportListInAction(resetMemberReportList);
+  };
+
+  // 총 금액이 변동됐을 때 (서버에서 온 값과 다를 때) 재계산 실행
+  useEffect(() => {
+    const totalPriceFromServer = memberReportListInActionFromServer.reduce((acc, cur) => acc + cur.price, 0);
+
+    if (totalPriceFromServer !== totalPrice) {
+      reCalculatePriceByTotalPriceChange();
+    }
+  }, [totalPrice, memberReportListInActionFromServer]);
+
   useEffect(() => {
     if (queryResult.isSuccess) {
       setMemberReportListInAction(memberReportListInActionFromServer);

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -49,6 +49,15 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
     return memberReportListInAction.some(member => member.isFixed === true);
   };
 
+  // 조정되지 않은 인원이 단 1명인 경우의 index
+  const getOnlyOneNotAdjustedRemainMemberIndex = (): number | null => {
+    const adjustedPriceCount = getAdjustedMemberCount(memberReportListInAction);
+
+    if (adjustedPriceCount < memberReportListInAction.length - 1) return null;
+
+    return memberReportListInAction.findIndex(member => member.isFixed === false);
+  };
+
   // 조정값 멤버의 수를 구하는 함수
   const getAdjustedMemberCount = (memberReportListInAction: MemberReportInAction[]) => {
     return memberReportListInAction.filter(member => member.isFixed === true).length;
@@ -124,6 +133,7 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
     addAdjustedMember,
     isExistAdjustedPrice,
     onSubmit,
+    getOnlyOneNotAdjustedRemainMemberIndex,
     queryResult,
   };
 };

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -128,12 +128,29 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
     putMemberReportListInAction(memberReportListInAction);
   };
 
+  const getIsSamePriceStateAndServerState = () => {
+    const serverStatePriceList = memberReportListInActionFromServer.map(({price}) => price);
+    const clientStatePriceList = memberReportListInAction.map(({price}) => price);
+
+    let isSame = true;
+
+    // isArrayEqual을 사용하지 않은 이유는 정렬이 영향을 받으면 안 되기 때문입니다
+    for (let i = 0; i < serverStatePriceList.length; i++) {
+      if (serverStatePriceList[i] !== clientStatePriceList[i]) {
+        isSame = false;
+      }
+    }
+
+    return isSame;
+  };
+
   return {
     memberReportListInAction,
     addAdjustedMember,
     isExistAdjustedPrice,
     onSubmit,
     getOnlyOneNotAdjustedRemainMemberIndex,
+    getIsSamePriceStateAndServerState,
     queryResult,
   };
 };

--- a/client/src/utils/validate/validateMemberReportInAction.ts
+++ b/client/src/utils/validate/validateMemberReportInAction.ts
@@ -17,21 +17,13 @@ const validateMemberReportInAction = (price: string, totalPrice: number): Valida
     return true;
   };
 
-  const validateEmpty = () => {
-    if (!price.trim().length) {
-      errorMessage = ERROR_MESSAGE.preventEmpty;
-      return false;
-    }
-    return true;
-  };
-
   const validateUnderTotalPrice = () => {
     if (numberTypePrice > totalPrice) return false;
 
     return true;
   };
 
-  if (validateOnlyNaturalNumber() && validatePrice() && validateEmpty() && validateUnderTotalPrice()) {
+  if (validateOnlyNaturalNumber() && validatePrice() && validateUnderTotalPrice()) {
     return {isValid: true, errorMessage: null};
   }
 


### PR DESCRIPTION
## issue
- close #422 

## 구현 사항
차등 적용 적용 중 지원되지 않는 기능을 수정했습니다.

1. 해당하는 지출 금액이 변경되어도 반영해주는 것
서버에서 온 지출 금액과 현재 상태의 지출 금액이 다를 때 재계산하는 기능을 추가했습니다.
이 때 isFixed는 전부 false로 조정하고 여기서 발생하는 나머지 금액은 마지막 사람에게 부과됩니다.

```tsx
  useEffect(() => {
    const totalPriceFromServer = memberReportListInActionFromServer.reduce((acc, cur) => acc + cur.price, 0);

    if (totalPriceFromServer !== totalPrice) {
      reCalculatePriceByTotalPriceChange();
    }
  }, [totalPrice]);
```

2. 하나라도 isFixed flag가 있는지 파악
isExistAdjustedPrice 함수를 사용하면 됩니다.
리스트에 isFixed가 하나라도 있으면 true, 아니면 false를 줍니다.

```tsx
const isExistAdjustedPrice = () => {
    return memberReportListInAction.some(member => member.isFixed === true);
  };
```

3. input이 0이 되지 않는 버그
validateMemberReportInAction에서 빈 값을 허용하지 않는 validation 조건을 삭제했습니다.

4. 3명 중 2명이 isFixed일 때 마지막 input 입력이 되는 현상 (계산은 되지 않음)
getOnlyOneNotAdjustedRemainMemberIndex함수를 추가했습니다.
이는 3명 중 2명 미만으로 수정시에는 null이 나오게 되며, 2명이 fixed를 가질 때 해당 index를 return합니다.
useMemberReportInput에서 이 함수를 사용하며, 해당 index의 canEditList의 값을 false로 바꾸게됩니다.

컴포넌트에서 canEditList를 readOnly에 !canEditList를 주면 될 것 같아요.


5. submit을 판단할 수 있는 로직
이미 되어있어서 적용하면 될 것 같습니다😊
-> 추가로 서버상태와 클라이언트 상태 둘의 가격을 비교해서 같을 경우 can submit을 false 하도록 설정해뒀습니다.
getIsSamePriceStateAndServerState을 Action 훅에서 가져와서 Input훅에 전달해주면 됩니다.

나중에 이 두 훅의 의존도가 강해서 리팩토링 해야 할 듯;;;;

## 🫡 참고사항
