### PR TITLE
[FE] html height 100%

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -134,6 +134,10 @@ export const GlobalStyle = css`
     box-sizing: border-box;
   }
 
+  html {
+    height: 100%;
+  }
+
   body {
     max-width: 768px;
     height: 100%;


### PR DESCRIPTION
## issue
- close #421

## 구현 사항
body 태그에 heigth가 100%임에도 배경색상이 잘리는 문제가 발생.
body 태그의 부모에 높이가 존재하지 않아서 발생한 문제이다.
따라서 body 태그의 부모인 html 태그에 height를 100% 추가해주었다.

## 🫡 참고사항
