### PR TITLE
[FE] 차등 적용 인원이 2명일 때 계산되지 않는 버그

### DIFF
--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
@@ -1,4 +1,4 @@
-import type {MemberReport, MemberReportInAction} from 'types/serviceType';
+import type {MemberReportInAction} from 'types/serviceType';
 
 import {renderHook, waitFor, act} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
@@ -295,6 +295,47 @@ describe('useMemberReportListInActionTest', () => {
       });
 
       expect(result.current.isExistAdjustedPrice()).toBe(true);
+    });
+  });
+
+  describe('지출 인원이 2명인 상황', () => {
+    const actionId = 1;
+    const totalPrice = 50000;
+
+    // 망쵸 이상
+    it('망쵸의 가격을 100원으로 수정한 경우, 이상의 가격이 49900원으로 수정된다.', async () => {
+      const {result} = initializeProvider(actionId, totalPrice);
+      const adjustedMemberMangcho: MemberReportInAction = {name: '망쵸', price: 100, isFixed: false};
+
+      await waitFor(() => expect(result.current.queryResult.isSuccess).toBe(true));
+
+      act(() => {
+        result.current.addAdjustedMember(adjustedMemberMangcho);
+      });
+
+      const targetMember = result.current.memberReportListInAction.find(member => member.name === '이상');
+
+      expect(targetMember?.price).toBe(49900);
+    });
+
+    it('망쵸의 가격을 100원으로 수정하고 다시 200원으로 수정한 경우, 이상의 가격이 49800원으로 수정된다.', async () => {
+      const {result} = initializeProvider(actionId, totalPrice);
+      const adjustedMemberMangcho: MemberReportInAction = {name: '망쵸', price: 100, isFixed: false};
+      const adjustedMemberMangchoOther: MemberReportInAction = {name: '망쵸', price: 200, isFixed: true};
+
+      await waitFor(() => expect(result.current.queryResult.isSuccess).toBe(true));
+
+      act(() => {
+        result.current.addAdjustedMember(adjustedMemberMangcho);
+      });
+
+      act(() => {
+        result.current.addAdjustedMember(adjustedMemberMangchoOther);
+      });
+
+      const targetMember = result.current.memberReportListInAction.find(member => member.name === '이상');
+
+      expect(targetMember?.price).toBe(49800);
     });
   });
 

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
@@ -165,38 +165,6 @@ describe('useMemberReportListInActionTest', () => {
       expect(anotherMemberList[0].price).toBe(33300);
     });
 
-    it('참여인원의 가격을 모두 바꾸려고 하면, 마지막 사람의 조정치는 반영되지 않는다.', async () => {
-      const {result} = initializeProvider(actionId, totalPrice);
-      const adjustedMemberMangcho: MemberReportInAction = {name: '망쵸', price: 100, isFixed: false};
-      const adjustedMemberCookie: MemberReportInAction = {name: '쿠키', price: 100, isFixed: false};
-      const adjustedMemberSoha: MemberReportInAction = {name: '소하', price: 100, isFixed: false};
-
-      // 마지막 사람
-      const adjustedMemberLeeSang: MemberReportInAction = {name: '이상', price: 100, isFixed: false};
-
-      await waitFor(() => expect(result.current.queryResult.isSuccess).toBe(true));
-
-      act(() => {
-        result.current.addAdjustedMember(adjustedMemberMangcho);
-      });
-
-      act(() => {
-        result.current.addAdjustedMember(adjustedMemberCookie);
-      });
-
-      act(() => {
-        result.current.addAdjustedMember(adjustedMemberSoha);
-      });
-
-      act(() => {
-        result.current.addAdjustedMember(adjustedMemberLeeSang);
-      });
-
-      const targetMember = result.current.memberReportListInAction.find(member => member.name === '이상');
-
-      expect(targetMember?.price).not.toBe(100);
-    });
-
     it('망쵸에게 300원을 주면 나머지 사람들은 33233원이고 마지막 사람은 33234원이 된다.', async () => {
       const {result} = initializeProvider(actionId, totalPrice);
       const adjustedMemberMangcho: MemberReportInAction = {name: '망쵸', price: 300, isFixed: false};

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -64,19 +64,11 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
   };
 
   const addAdjustedMember = (memberReport: MemberReportInAction) => {
-    if (getAdjustedMemberCount(memberReportListInAction) + 1 >= memberReportListInAction.length) {
-      const newMemberReportListInAction = memberReportListInAction.map(member =>
-        member.name === memberReport.name ? {...member, price: memberReport.price} : member,
-      );
+    const newMemberReportListInAction = memberReportListInAction.map(member =>
+      member.name === memberReport.name ? {...member, price: memberReport.price, isFixed: true} : member,
+    );
 
-      calculateAnotherMemberPrice(newMemberReportListInAction);
-    } else {
-      const newMemberReportListInAction = memberReportListInAction.map(member =>
-        member.name === memberReport.name ? {...member, price: memberReport.price, isFixed: true} : member,
-      );
-
-      calculateAnotherMemberPrice(newMemberReportListInAction);
-    }
+    calculateAnotherMemberPrice(newMemberReportListInAction);
   };
 
   const calculateDividedPrice = (remainMemberCount: number, totalAdjustedPrice: number) => {

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.ts
@@ -65,14 +65,18 @@ const useMemberReportListInAction = (actionId: number, totalPrice: number) => {
 
   const addAdjustedMember = (memberReport: MemberReportInAction) => {
     if (getAdjustedMemberCount(memberReportListInAction) + 1 >= memberReportListInAction.length) {
-      return;
+      const newMemberReportListInAction = memberReportListInAction.map(member =>
+        member.name === memberReport.name ? {...member, price: memberReport.price} : member,
+      );
+
+      calculateAnotherMemberPrice(newMemberReportListInAction);
+    } else {
+      const newMemberReportListInAction = memberReportListInAction.map(member =>
+        member.name === memberReport.name ? {...member, price: memberReport.price, isFixed: true} : member,
+      );
+
+      calculateAnotherMemberPrice(newMemberReportListInAction);
     }
-
-    const newMemberReportListInAction = memberReportListInAction.map(member =>
-      member.name === memberReport.name ? {...member, price: memberReport.price, isFixed: true} : member,
-    );
-
-    calculateAnotherMemberPrice(newMemberReportListInAction);
   };
 
   const calculateDividedPrice = (remainMemberCount: number, totalAdjustedPrice: number) => {

--- a/client/src/mocks/handlers/memberReportInActionHandlers.ts
+++ b/client/src/mocks/handlers/memberReportInActionHandlers.ts
@@ -8,17 +8,31 @@ import memberReportInActionJson from '../memberReportListInAction.json';
 
 let memberReportInActionMockData = memberReportInActionJson as MemberReport[];
 
+type MemberReportListRequestParams = {
+  eventId: string;
+  actionId: string;
+};
 type MemberReportListBody = {members: MemberReport[]};
 
 export const memberReportInActionHandler = [
-  http.get<any, MemberReportListBody, any, `${typeof TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`>(
-    `${TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`,
-    () => {
+  http.get<
+    MemberReportListRequestParams,
+    MemberReportListBody,
+    any,
+    `${typeof TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`
+  >(`${TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`, ({params}) => {
+    const {actionId} = params;
+
+    if (Number(actionId) === 123) {
       return HttpResponse.json({
         members: memberReportInActionMockData,
       });
-    },
-  ),
+    }
+
+    return HttpResponse.json({
+      members: memberReportInActionMockData.slice(0, 2),
+    });
+  }),
 
   http.put<any, MemberReportListBody, any, `${typeof TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`>(
     `${TEMP_PREFIX}/:eventId/bill-actions/:actionId/fixed`,


### PR DESCRIPTION
## issue
- close #432

## 구현 사항
차등 적용 인원이 2명일 때 계산되지 않는 버그가 있었어요.
조정이 되지 않은 인원이 1명 남았을 때, 아에 계산 로직이 돌아가지 않았기 때문이에요.
그래서 1명 남았을 때도 계산을 하도록 수정했어요.

-> 한 명이 남았을 때 마지막 input은 아에 disabled 처리가 되므로 관련로직을 훅에서 제거했어요.


## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
