### PR TITLE
[FE] 전체 금액 수정 시 계산이 마이너스가 되는 문제

### DIFF
--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -53,7 +53,7 @@ const PutAndDeleteBillActionModal = ({
   } = useMemberReportInput({
     data: memberReportListInAction,
     addAdjustedMember,
-    totalPrice: billAction.price,
+    totalPrice: Number(inputPair.price),
     getIsSamePriceStateAndServerState,
     getOnlyOneNotAdjustedRemainMemberIndex,
   });


### PR DESCRIPTION
## issue
- close #439 

## 구현 사항
전체 금액 수정 시 계산이 마이너스가 되는 문제를 해결했어요.
훅에 현재 입력 값이 아니라 서버에서 온 값으로 넣어줘서 변경 값으로 인식을 하지 않았던 문제입니다.


## 🫡 참고사항
