### PR TITLE
[FE] 배경색상 height 버그

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -136,6 +136,7 @@ export const GlobalStyle = css`
 
   html {
     height: 100%;
+    background-color: #f1f0f5;
   }
 
   body {

--- a/client/src/pages/MainPage/Nav/Nav.style.ts
+++ b/client/src/pages/MainPage/Nav/Nav.style.ts
@@ -1,7 +1,4 @@
 import {css} from '@emotion/react';
-import {useTheme} from 'haengdong-design/dist/theme/HDesignProvider';
-
-interface NavStyleProps {}
 
 export const navStyle = css({
   position: 'fixed',


### PR DESCRIPTION
## issue
- close #440 

## 구현 사항
몇번째인지 모르겠는... heigth 잘림 수정..

간단하게 일단 문제를 해결하고자 html 태그에 background-color를 넣어줬어요.
color를 넣어줌으로 배경색이 더이상 잘리지 않습니다! 왜냐면 기본 틀의 색상을 그냥 저걸로 박어버렸기에..

<img width="243" alt="스크린샷 2024-08-21 16 46 32" src="https://github.com/user-attachments/assets/ed961c3d-d65c-47dc-bea5-88f46aee32fd">
<img width="233" alt="스크린샷 2024-08-21 16 46 23" src="https://github.com/user-attachments/assets/33492c33-ceb5-4457-ad52-3f2d9d1107fa">

**하지만 문제는 랜딩페이지입니다.**
html의 배경색이 더이상 화이트가 아니기 때문에.. 다음과 같이 배경색이 들어가게 됩니다.
근데 일단은 랜딩페이지에 배경색이 들어가는 것 보다는 관리/홈 페이지에서 배경색이 잘리는 것이 더 크리티컬하다고 판단하여 일단 해당 방식으로 해결했습니다.

<img width="235" alt="스크린샷 2024-08-21 16 46 43" src="https://github.com/user-attachments/assets/3c4d0b4f-6d12-49da-8aee-2053ad965a79">

사실 더 괜찮게 해결할 수 있는 방법이 존재합니다.
id가 root인 태그의 바로 아래 태그에는 height가 100% 존재합니다. 이 height를 삭제해줍니다.
그러면 홈/관리 Nav 탭이 사라지게 됩니다. 이유는 해당 Nav 탭에는 height가 존재하지 않기 때문입니다.
따라서 홈/관리 Nav 탭에 heigth를 지정해주면 됩니다. (개발자도구에서만 확인했던 사항이라 정확하진 않을 것입니다.)

하지만 해당 방법은 수정을 하려면 디자인시스템도 수정해야 합니다. 그리고 공수도 더 들어가구요. 일단 당장 금요일이 시연이기 때문에 더 간단한 방식으로 해결했습니다.


## 🫡 참고사항
