### PR TITLE
[FE] 인원을 삭제했을 때 지출 상세 캐시 데이터 지우지 않는 문제

### DIFF
--- a/client/src/hooks/queries/useRequestDeleteAllMemberList.ts
+++ b/client/src/hooks/queries/useRequestDeleteAllMemberList.ts
@@ -19,6 +19,7 @@ const useRequestDeleteAllMemberList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMemberList]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
     },
   });

--- a/client/src/hooks/queries/useRequestDeleteMemberAction.ts
+++ b/client/src/hooks/queries/useRequestDeleteMemberAction.ts
@@ -19,6 +19,7 @@ const useRequestDeleteMemberAction = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMemberList]});
     },
   });

--- a/client/src/hooks/queries/useRequestPutAllMemberList.ts
+++ b/client/src/hooks/queries/useRequestPutAllMemberList.ts
@@ -19,6 +19,7 @@ const useRequestPutAllMemberList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMemberList]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
     },
   });


### PR DESCRIPTION
## issue
- close #444 

## 구현 사항
멤버가 변동됐을 때 지출 상세 정보 데이터가 날라가지 않는 버그 수정했습니다.
인원이 변동됐을 때 (추가 제외) 지출 상세 캐시를 무효화 시켜서 영향이 없도록 수정했습니다

## 🫡 참고사항
