### PR TITLE
[FE] Step에 stepName 반영하기

### DIFF
--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -34,7 +34,6 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
   const [clickedIndex, setClickedIndex] = useState(-1);
   const [isOpenMemberListInBillStep, setIsOpenMemberListInBillStep] = useState(false);
 
-  const stepName = `차`;
   const totalPrice = step.actions && step.type === 'BILL' ? step.actions.reduce((acc, cur) => acc + cur.price, 0) : 0;
 
   const handleDragHandleItemClick = (index: number) => {
@@ -55,7 +54,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
     <>
       <DragHandleItemContainer
         id={`${index}`}
-        topLeftText={stepName}
+        topLeftText={step.stepName}
         topRightText={`${step.members.length}명`}
         bottomLeftText="총액"
         bottomRightText={`${totalPrice.toLocaleString('ko-kr')} 원`}
@@ -107,7 +106,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
       </DragHandleItemContainer>
       {isOpenMemberListInBillStep && (
         <MemberListInBillStep
-          stepName={stepName}
+          stepName={step.stepName}
           memberList={memberList}
           isOpenBottomSheet={isOpenMemberListInBillStep}
           setIsOpenBottomSheet={setIsOpenMemberListInBillStep}

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -59,7 +59,8 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
         bottomLeftText="총액"
         bottomRightText={`${totalPrice.toLocaleString('ko-kr')} 원`}
         backgroundColor="white"
-        onTopRightTextClick={handleTopRightTextClick}
+        // TODO: (@soha) 백엔드의 요청으로 인해 인원수 click시 BottomSheet가 띄워지지 않도록 주석처리
+        // onTopRightTextClick={handleTopRightTextClick}
       >
         {step.actions &&
           step.type === 'BILL' &&

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -16,6 +16,7 @@ const StepList = ({isAddEditableItem = false, setIsAddEditableItem = () => {}}: 
   const [stepList, setStepList] = useState<(MemberStep | BillStep)[]>([]);
   const existIndexInStepList = stepList.map((step, index) => ({...step, index}));
   const [hasAddedItem, setHasAddedItem] = useState(false);
+  const nextStepName = stepList.length > 0 ? String(stepList[stepList.length - 1].stepName).match(/.*(?=차)/) : '';
 
   useEffect(() => {
     if (stepListData) {
@@ -43,7 +44,7 @@ const StepList = ({isAddEditableItem = false, setIsAddEditableItem = () => {}}: 
         ...prev,
         {
           type: 'BILL',
-          stepName: '',
+          stepName: `${Number(nextStepName) + 1}차`,
           members: [],
           actions: [],
         },


### PR DESCRIPTION
## issue
- close #445 

## 구현 사항
- 서버로 부터 받은 stepName을 뿌립니다.
- 마지막 action이 Bill이 아닐 때, 지출 내역을 추가하면 client에서 만든 임의의 데이터를 출력합니다.
  이때, stepName을 넣어주기 위해서 서버로 부터 받은 stepList의 마지막 action의 stepName에서 1을 더한 값을 사용합니다.

## 🫡 참고사항
백엔드의 요청으로 인해 인원수 click시 BottomSheet가 띄워지지 않도록 주석처리한 커밋이 존재합니다.
