### PR TITLE
[FE] 차등 정산 적용시 신선한 데이터가 바로 반영되지 않고 시간차를 두고 반영되는 부분 수정

### DIFF
--- a/client/src/apis/request/bill.ts
+++ b/client/src/apis/request/bill.ts
@@ -43,7 +43,7 @@ export const requestPutBillAction = async ({eventId, actionId, title, price}: Wi
   });
 };
 
-type MemberReportList = {members: MemberReportInAction[]};
+export type MemberReportList = {members: MemberReportInAction[]};
 
 export const requestGetMemberReportListInAction = async ({eventId, actionId}: WithEventId<RequestBillAction>) => {
   return requestGet<MemberReportList>({

--- a/client/src/hooks/queries/useRequestDeleteAllMemberList.ts
+++ b/client/src/hooks/queries/useRequestDeleteAllMemberList.ts
@@ -19,7 +19,7 @@ const useRequestDeleteAllMemberList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMemberList]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
     },
   });

--- a/client/src/hooks/queries/useRequestPutAllMemberList.ts
+++ b/client/src/hooks/queries/useRequestPutAllMemberList.ts
@@ -19,7 +19,7 @@ const useRequestPutAllMemberList = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMemberList]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.memberReportInAction]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
     },
   });

--- a/client/src/hooks/queries/useRequestPutMemberReportListInAction.ts
+++ b/client/src/hooks/queries/useRequestPutMemberReportListInAction.ts
@@ -1,6 +1,6 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
-import {requestPutMemberReportListInAction} from '@apis/request/bill';
+import {MemberReportList, requestPutMemberReportListInAction} from '@apis/request/bill';
 import {MemberReportInAction} from 'types/serviceType';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
@@ -23,9 +23,9 @@ const useRequestPutMemberReportListInAction = (actionId: number) => {
 
       const previousMembers = queryClient.getQueryData([QUERY_KEYS.memberReportInAction, actionId]);
 
-      queryClient.setQueryData([QUERY_KEYS.memberReportInAction, actionId], (oldData: any) => ({
+      queryClient.setQueryData([QUERY_KEYS.memberReportInAction, actionId], (oldData: MemberReportList) => ({
         ...oldData,
-        members: oldData?.members?.map((member: MemberReportInAction) => {
+        members: oldData.members.map((member: MemberReportInAction) => {
           const updatedMember = newMembers.find(m => m.name === member.name);
           return updatedMember ? {...member, ...updatedMember} : member;
         }),

--- a/client/src/hooks/queries/useRequestPutMemberReportListInAction.ts
+++ b/client/src/hooks/queries/useRequestPutMemberReportListInAction.ts
@@ -16,7 +16,7 @@ const useRequestPutMemberReportListInAction = (actionId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.stepList]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReport]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.memberReportInAction, actionId]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.memberReportInAction, actionId]});
     },
     onMutate: async (newMembers: MemberReportInAction[]) => {
       await queryClient.cancelQueries({queryKey: [QUERY_KEYS.memberReportInAction, actionId]});


### PR DESCRIPTION
## issue
- close #457 

# 질문

차등 정산 적용 시 캐시를 초기화하는데 왜 늦게 반영되는 걸까요?
-> 그건 모르겠고 캐시를 무효화가 아니라 캐시를 지움으로서 해결했습니다

## 구현 사항

차등 정산 내역을 수정할 경우 반영이 늦게 되는 모습이 있어 낙관적 업데이트를 적용해 이를 해결했습니다.

https://github.com/user-attachments/assets/a2629404-58bb-4b3b-a8f4-8eacc4883f09

https://github.com/user-attachments/assets/de546b73-59ae-4b8d-901b-f44c7e45fac8

우선순위가 낮아서 안하려고 했는데, 데모데이때 사용자들이 당황할 수 있는 요소라고 생각이 들어서 수정했어요.



