### PR TITLE
[FE] api 순서보장 await없어서 안됨

### DIFF
--- a/client/src/hooks/usePutAndDeleteBillAction.ts
+++ b/client/src/hooks/usePutAndDeleteBillAction.ts
@@ -83,12 +83,12 @@ const usePutAndDeleteBillAction = (
     setErrorInfo(errorInfo ?? {title: false, price: false});
   };
 
-  const onSubmit = (event: React.FormEvent<HTMLFormElement>, inputPair: InputPair, actionId: number) => {
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>, inputPair: InputPair, actionId: number) => {
     event.preventDefault();
 
     const {title, price} = inputPair;
 
-    putBillAction({actionId, title, price: Number(price)});
+    await putBillAction({actionId, title, price: Number(price)});
 
     onClose();
   };


### PR DESCRIPTION
## issue
- close #461 

## 구현 사항
mutateAsync를 사용함에도 불구하고 async/await 키워드가 없어서 순서 보장이 안됐던 문제를 해결했습니다.