### PR TITLE
[FE] React-Query devtools 환경 설정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
         "@jest/types": "^29.6.3",
         "@sentry/webpack-plugin": "^2.22.0",
         "@svgr/webpack": "^8.1.0",
+        "@tanstack/react-query-devtools": "^5.52.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -4335,6 +4336,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.51.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.51.16.tgz",
+      "integrity": "sha512-ajwuq4WnkNCMj/Hy3KR8d3RtZ6PSKc1dD2vs2T408MdjgKzQ3klVoL6zDgVO7X+5jlb5zfgcO3thh4ojPhfIaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.51.23",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.23.tgz",
@@ -4348,6 +4359,23 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.52.0.tgz",
+      "integrity": "sha512-oq8bDxMQ95edOlcWFaGsnSFzH11s06M1uiNiLtgsm+UG6Y5w+K6BJp0GeXN8q7sBNVBw/WPyeFdUH8rj9RT2Aw==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.51.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.52.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@jest/types": "^29.6.3",
     "@sentry/webpack-plugin": "^2.22.0",
     "@svgr/webpack": "^8.1.0",
+    "@tanstack/react-query-devtools": "^5.52.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import {Outlet} from 'react-router-dom';
 import {HDesignProvider} from 'haengdong-design';
 import {Global} from '@emotion/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 
 import {ToastProvider} from '@hooks/useToast/ToastProvider';
 import {ErrorProvider} from '@hooks/useError/ErrorProvider';
@@ -9,12 +10,20 @@ import {ErrorProvider} from '@hooks/useError/ErrorProvider';
 import {GlobalStyle} from './GlobalStyle';
 import UnhandledErrorBoundary from './UnhandledErrorBoundary';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1 minute
+      gcTime: 1000 * 60, // 1 minute
+    },
+  },
+});
 
 const App: React.FC = () => {
   return (
     <HDesignProvider>
       <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
         <UnhandledErrorBoundary>
           <Global styles={GlobalStyle} />
           <ErrorProvider>


### PR DESCRIPTION
## issue
- close #459 

## 구현 사항
react-query devtools 초기 설정을 했습니다.
도입한 목적은 귀여운 야자수를 확인할 수 있기 때문입니다.
사실 devtool을 설치하면 캐싱 데이터의 상태를 눈으로 확인할 수 있어서 셋팅해뒀습니다.
![image](https://github.com/user-attachments/assets/c2fcdc4a-b7ac-4daf-a84c-6c5f61d3726d)


## 논의하고 싶은 부분(선택)
stale time, gc time을 임시로 1분씩 설정했습니다.
추후에 같이 논의해서 수정해봐요

## 🫡 참고사항
