### PR TITLE
[FE] 배경색아 제발

### DIFF
--- a/HDesign/src/components/Flex/Flex.style.ts
+++ b/HDesign/src/components/Flex/Flex.style.ts
@@ -38,6 +38,8 @@ export const flexStyle = ({
           return theme?.colors.white;
         case 'gray':
           return theme?.colors.grayContainer;
+        case 'lightGray':
+          return theme?.colors.lightGrayContainer;
         default:
           return 'none';
       }

--- a/HDesign/src/components/Flex/Flex.style.ts
+++ b/HDesign/src/components/Flex/Flex.style.ts
@@ -14,6 +14,7 @@ export const flexStyle = ({
   margin = '0',
   width = 'auto',
   height = 'auto',
+  minHeight,
   backgroundColor,
   theme,
   ...rest
@@ -30,6 +31,7 @@ export const flexStyle = ({
     margin,
     width,
     height,
+    minHeight,
     ...rest,
 
     backgroundColor: (() => {

--- a/HDesign/src/components/Flex/Flex.type.ts
+++ b/HDesign/src/components/Flex/Flex.type.ts
@@ -2,7 +2,7 @@ import {Theme} from '@theme/theme.type';
 
 export type FlexDirectionType = 'row' | 'column' | 'rowReverse' | 'columnReverse';
 export type FlexDirectionStrictType = 'row' | 'column' | 'row-reverse' | 'column-reverse';
-export type FlexBackgroundColor = 'gray' | 'white';
+export type FlexBackgroundColor = 'gray' | 'white' | 'lightGray';
 
 export interface FlexProps {
   justifyContent?: 'flexStart' | 'center' | 'flexEnd' | 'spaceBetween' | 'spaceAround' | 'spaceEvenly';

--- a/HDesign/src/components/Flex/Flex.type.ts
+++ b/HDesign/src/components/Flex/Flex.type.ts
@@ -16,4 +16,5 @@ export interface FlexProps {
   height?: string;
   backgroundColor?: FlexBackgroundColor;
   theme?: Theme;
+  minHeight?: string;
 }

--- a/HDesign/src/layouts/MainLayout.tsx
+++ b/HDesign/src/layouts/MainLayout.tsx
@@ -2,7 +2,7 @@ import {PropsWithChildren} from 'react';
 
 import {Flex} from '..';
 
-type MainLayoutBackground = 'white' | 'gray';
+type MainLayoutBackground = 'white' | 'gray' | 'lightGray';
 
 interface MainLayoutProps extends PropsWithChildren {
   backgroundColor?: MainLayoutBackground;

--- a/HDesign/src/layouts/MainLayout.tsx
+++ b/HDesign/src/layouts/MainLayout.tsx
@@ -18,6 +18,7 @@ export function MainLayout({backgroundColor, children}: MainLayoutProps) {
       gap="1rem"
       width="100%"
       height="100%"
+      minHeight="100vh"
     >
       {children}
     </Flex>

--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -156,8 +156,5 @@ export const GlobalStyle = css`
   #root {
     display: flex;
     flex-direction: column;
-    height: 100%;
-
-    background-color: #f1f0f5;
   }
 `;

--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -21,7 +21,7 @@ const CompleteCreateEventPage = () => {
   const homePageUrl = getEventPageUrlByEnvironment(eventId ?? '', 'home');
 
   return (
-    <MainLayout>
+    <MainLayout backgroundColor="white">
       <TopNav />
       <Title
         title="행사 개시"

--- a/client/src/pages/CreateEventPage/SetEventNamePage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventNamePage.tsx
@@ -17,7 +17,7 @@ const SetEventNamePage = () => {
   };
 
   return (
-    <MainLayout>
+    <MainLayout backgroundColor="white">
       <TopNav>
         <Back />
       </TopNav>

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -9,7 +9,7 @@ const SetEventPasswordPage = () => {
   const {submitPassword, errorMessage, password, handleChange, canSubmit} = useSetEventPasswordPage();
 
   return (
-    <MainLayout>
+    <MainLayout backgroundColor="white">
       <TopNav>
         <Back />
       </TopNav>

--- a/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.style.ts
@@ -5,7 +5,7 @@ export const receiptStyle = () =>
     display: 'flex',
     flexDirection: 'column',
     gap: '1rem',
-    paddingBottom: '8.75rem',
+    paddingBottom: '2rem',
   });
 
 export const titleAndListButtonContainerStyle = () =>

--- a/client/src/pages/EventPage/HomePage/HomePage.tsx
+++ b/client/src/pages/EventPage/HomePage/HomePage.tsx
@@ -13,7 +13,7 @@ const HomePage = () => {
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
 
   return (
-    <div style={{height: '100%', paddingBottom: '2rem'}}>
+    <div style={{paddingBottom: '2rem'}}>
       <Title title={eventName} price={totalExpenseAmount} />
       <Tabs tabsContainerStyle={{gap: '1rem'}}>
         <Tab label="전체 지출 내역" content={<StepList />} />

--- a/client/src/pages/EventPage/HomePage/HomePage.tsx
+++ b/client/src/pages/EventPage/HomePage/HomePage.tsx
@@ -13,7 +13,7 @@ const HomePage = () => {
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
 
   return (
-    <div>
+    <div style={{height: '100%', paddingBottom: '2rem'}}>
       <Title title={eventName} price={totalExpenseAmount} />
       <Tabs tabsContainerStyle={{gap: '1rem'}}>
         <Tab label="전체 지출 내역" content={<StepList />} />


### PR DESCRIPTION
## issue
- close #464 

## 구현 사항

- 스크롤이 길어질 때 배경색이 짤리고 길어지지 않았던 버그 수정했어요
  - #root의 속성에서 height: 100%을 제거했어요.
  - 스크롤이 생기지 않을 정도로 내용이 부족할 때 메인 레이아웃의 배경색이 안 채워지는 문제가 있었습니다. 그래서 MainLayout에 min height: 100vh를 추가로 넣으니 내용이 부족할 때도 배경색이 화면을 꽉 채우고 스크롤이 생겨도 같이 배경색이 따라서 내려오게 됩니다.
  - 이도 행동 디자인이 변경됐기 때문에 `행동 디자인 재배포`가 필요합니다.

https://github.com/user-attachments/assets/e43a574e-4a1e-4717-920f-0e47fe983060

- 메인 레이아웃 배경색 변경
  - 토다리와 배경색 논의 결과 메인 레이아웃의 배경색을 gray에서 lightGray로 바꾸자는 결론이 나서 메인레이아웃 backgroundColor props로 lightGray도 추가했습니다.
  - 적용하기 위해서 `행동 디자인 재배포`가 필요하며, 배포가 된 후에 적용을 해야합니다.

- 생성 페이지 배경색 하얀색으로 설정
  - 메인 레이아웃 background color props를 white를 적용했어요

- 이벤트 레이아웃 padding bottom 조정
  - home의 경우 아래 아무 패딩도 없어서 2rem을 띄웠습니다
  - admin의 경우 fixed button 때문에 8rem이 띄워졌는데 사라졌기 때문에 home과 동일하게 2rem으로 설정했습니다.



## 🫡 참고사항
배경색 너무 힘들어요;;
