### PR TITLE
[FE] 관리자 로그인 페이지에서 스위치가 관리로 활성화되지 않는 버그

### DIFF
--- a/client/src/hooks/useEventLogin.ts
+++ b/client/src/hooks/useEventLogin.ts
@@ -1,0 +1,42 @@
+import {useState} from 'react';
+
+import validateEventPassword from '@utils/validate/validateEventPassword';
+
+import RULE from '@constants/rule';
+
+import useRequestPostLogin from './queries/useRequestPostLogin';
+
+const useEventLogin = () => {
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [canSubmit, setCanSubmit] = useState(false);
+  const {mutate: postLogin} = useRequestPostLogin();
+
+  const submitPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    postLogin({password}, {onError: () => setErrorMessage('비밀번호가 틀렸어요')});
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    const validation = validateEventPassword(newValue);
+    setErrorMessage(validation.errorMessage);
+
+    if (validation.isValid) {
+      setPassword(newValue);
+    }
+
+    setCanSubmit(newValue.length === RULE.maxEventPasswordLength);
+  };
+
+  return {
+    password,
+    errorMessage,
+    handleChange,
+    canSubmit,
+    submitPassword,
+  };
+};
+
+export default useEventLogin;

--- a/client/src/hooks/useNavSwitch.tsx
+++ b/client/src/hooks/useNavSwitch.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 
 const PATH_TABLE: Record<string, string> = {
@@ -21,6 +21,11 @@ const useNavSwitch = () => {
   const lastPath = pathArray[pathArray.length - 1];
 
   const [nav, setNav] = useState(PATH_DISPLAY_TABLE[lastPath]);
+
+  useEffect(() => {
+    const isLogin = lastPath === 'login';
+    setNav(isLogin ? '관리' : PATH_DISPLAY_TABLE[lastPath]);
+  }, [location]);
 
   const onChange = (displayName: string) => {
     setNav(displayName);

--- a/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
@@ -1,17 +1,14 @@
 import {useState} from 'react';
-import {FixedButton, MainLayout, LabelInput, Title, TopNav, Switch} from 'haengdong-design';
+import {FixedButton, MainLayout, LabelInput, Title} from 'haengdong-design';
 
 import validateEventPassword from '@utils/validate/validateEventPassword';
 import useRequestPostLogin from '@hooks/queries/useRequestPostLogin';
-
-import useNavSwitch from '@hooks/useNavSwitch';
 
 import RULE from '@constants/rule';
 import {PASSWORD_LENGTH} from '@constants/password';
 
 const EventLoginPage = () => {
   const [password, setPassword] = useState('');
-  const {nav, paths, onChange} = useNavSwitch();
   const [errorMessage, setErrorMessage] = useState('');
   const [canSubmit, setCanSubmit] = useState(false);
   const {mutate: postLogin} = useRequestPostLogin();
@@ -38,11 +35,7 @@ const EventLoginPage = () => {
   };
 
   return (
-    <MainLayout>
-      <TopNav>
-        <Switch value={nav} values={paths} onChange={onChange} />
-        {/* <Back /> */}
-      </TopNav>
+    <>
       <Title
         title="행사 비밀번호 입력"
         description={`관리를 위해선 비밀번호가 필요해요. 행사 생성 시 설정한 ${PASSWORD_LENGTH} 자리의 숫자 비밀번호를 입력해 주세요.`}
@@ -61,7 +54,7 @@ const EventLoginPage = () => {
         ></LabelInput>
         <FixedButton disabled={!canSubmit}>관리 페이지로</FixedButton>
       </form>
-    </MainLayout>
+    </>
   );
 };
 

--- a/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
@@ -1,38 +1,12 @@
-import {useState} from 'react';
-import {FixedButton, MainLayout, LabelInput, Title} from 'haengdong-design';
+import {FixedButton, LabelInput, Title} from 'haengdong-design';
 
-import validateEventPassword from '@utils/validate/validateEventPassword';
-import useRequestPostLogin from '@hooks/queries/useRequestPostLogin';
+import useEventLogin from '@hooks/useEventLogin';
 
 import RULE from '@constants/rule';
 import {PASSWORD_LENGTH} from '@constants/password';
 
 const EventLoginPage = () => {
-  const [password, setPassword] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [canSubmit, setCanSubmit] = useState(false);
-  const {mutate: postLogin} = useRequestPostLogin();
-
-  const submitPassword = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    postLogin({password}, {onError: () => setErrorMessage('비밀번호가 틀렸어요')});
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    const validation = validateEventPassword(newValue);
-
-    setCanSubmit(newValue.length === RULE.maxEventPasswordLength);
-
-    if (validation.isValid) {
-      setPassword(newValue);
-      setErrorMessage('');
-    } else {
-      event.target.value = password;
-      setErrorMessage(validation.errorMessage ?? '');
-    }
-  };
+  const {password, errorMessage, handleChange, canSubmit, submitPassword} = useEventLogin();
 
   return (
     <>

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -24,6 +24,7 @@ const EventPageLayout = () => {
   const eventId = getEventIdByUrl();
 
   const isAdmin = useMatch(ROUTER_URLS.eventManage) !== null;
+  const isLoginPage = useMatch(ROUTER_URLS.eventLogin) !== null;
 
   const outletContext: EventPageContextProps = {
     isAdmin,
@@ -37,22 +38,24 @@ const EventPageLayout = () => {
     <MainLayout backgroundColor="gray">
       <TopNav>
         <Switch value={nav} values={paths} onChange={onChange} />
-        <CopyToClipboard
-          text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\n${url}`}
-          onCopy={() =>
-            showToast({
-              showingTime: 3000,
-              message: '링크가 복사되었어요 :) \n참여자들에게 링크를 공유해 주세요!',
-              type: 'confirm',
-              position: 'bottom',
-              bottom: '8rem',
-            })
-          }
-        >
-          <Button size="small" variants="secondary">
-            정산 초대하기
-          </Button>
-        </CopyToClipboard>
+        {!isLoginPage && (
+          <CopyToClipboard
+            text={`[행동대장]\n"${eventName}"에 대한 정산을 시작할게요:)\n아래 링크에 접속해서 정산 내역을 확인해 주세요!\n${url}`}
+            onCopy={() =>
+              showToast({
+                showingTime: 3000,
+                message: '링크가 복사되었어요 :) \n참여자들에게 링크를 공유해 주세요!',
+                type: 'confirm',
+                position: 'bottom',
+                bottom: '8rem',
+              })
+            }
+          >
+            <Button size="small" variants="secondary">
+              정산 초대하기
+            </Button>
+          </CopyToClipboard>
+        )}
       </TopNav>
       <Outlet context={outletContext} />
     </MainLayout>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -36,15 +36,15 @@ const router = createBrowserRouter([
         element: <CompleteCreateEventPage />,
       },
       {
-        path: ROUTER_URLS.eventLogin,
-        element: <EventLoginPage />,
-      },
-      {
         path: ROUTER_URLS.event,
         element: <EventPage />,
         children: [
           {path: ROUTER_URLS.eventManage, element: <AdminPage />},
           {path: ROUTER_URLS.home, element: <HomePage />},
+          {
+            path: ROUTER_URLS.eventLogin,
+            element: <EventLoginPage />,
+          },
         ],
       },
       {


### PR DESCRIPTION
## issue
- close #467 

## 구현 사항
관리자 로그인 페이지에서 스위치가 관리로 활성화되지 않는 버그를 해결했습니다.

관리자로 접속해서 들어간 페이지인데 관리가 활성화되지 않아서 유저가 나는 지금 어디있는거지라고 생각할 것 같아서, 너는 지금 관리페이지에 들어왔어 하지만 너는 "쿠키 is me"가 없기 때문에 관리할 수 없어 비밀번호 입력해! 라는 것을 더 잘 표시하기 위해 로그인 페이지에도 관리 탭이 활성화됐음을 강조했어요.

자세한 것은 영상으로

https://github.com/user-attachments/assets/4d4ec8ff-08f6-4c01-a341-82c004aacbf2

추가로 useEventLogin 훅을 만들어서 EventLogin 관련 로직을 훅으로 분리했어요.

## 🫡 참고사항
