### PR TITLE
[FE] 지출 Input 금액 default 변경 및 autoFocus

### DIFF
--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -85,7 +85,15 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
           ))}
 
         {isAddEditableItem && isLastBillItem && (
-          <EditableItem backgroundColor="lightGrayContainer" onBlur={handleBlurBillRequest}>
+          <EditableItem
+            backgroundColor="lightGrayContainer"
+            onBlur={handleBlurBillRequest}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                handleBlurBillRequest();
+              }
+            }}
+          >
             <EditableItem.Input
               placeholder="지출 내역"
               textSize="bodyBold"

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -96,7 +96,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
               <EditableItem.Input
                 placeholder="0"
                 type="number"
-                value={billInput.price}
+                value={billInput.price || ''}
                 onChange={e => handleChangeBillInput('price', e)}
                 style={{textAlign: 'right'}}
               ></EditableItem.Input>

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -91,6 +91,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
               textSize="bodyBold"
               value={billInput.title}
               onChange={e => handleChangeBillInput('title', e)}
+              autoFocus
             ></EditableItem.Input>
             <Flex gap="0.25rem" alignItems="center">
               <EditableItem.Input


### PR DESCRIPTION
## issue
- close #468 

## 구현 사항

```tsx
 <EditableItem.Input
  placeholder="지출 내역"
  textSize="bodyBold"
  value={billInput.title}
  onChange={e => handleChangeBillInput('title', e)}
  autoFocus
></EditableItem.Input>
<Flex gap="0.25rem" alignItems="center">
  <EditableItem.Input
    placeholder="0"
    type="number"
    value={billInput.price || ''}
    onChange={e => handleChangeBillInput('price', e)}
    style={{textAlign: 'right'}}
  ></EditableItem.Input>
```
- 지출 내역 금액 default가 0이 아닌 `‘’`로 변경

   지출 내역 금액의 value를 `value={billInput.price || ''}`로 변경했다.
만약 value의 값이 falsy(0)하다면 ''를 truthy하다면 price를 출력하도록 했다.
useSetBillInput에서 price 값을 0에서 `''`로 변경하려고 했으나, validate 검사나 Type이 price는 number였다. 이로 인해 발생하는 다른 수정이 많기 때문에 해당 방법으로 `''`을 value로 갖도록 했다.

- 지출 내역을 추가하면 title에 autoFocus

   지출 내역 title input에 autoFocus 속성을 추가했다.

- enter 키를 누르면 handleBlurBillRequest가 실행되도록 기능 추가

   EditableItem에는 onBlur시에만 handleBlurBillRequest가 실행되고 있다.
   enter 키를 눌렀을 때도 handleBlurBillRequest가 실행되게 하고 싶었다.
   따라서 onKeyDown 이벤트를 추가하여 Enter를 눌렀을 경우 handleBlurBillRequest가 실행되도록 했다.
   ```tsx
  onKeyDown={e => {
      if (e.key === 'Enter') {
        handleBlurBillRequest();
      }
    }}
   ```

## 🫡 참고사항
