### PR TITLE
[FE] title과 price에 값이 존재하지 않을 경우 지출 input 닫기

### DIFF
--- a/client/src/hooks/useSetBillInput.ts
+++ b/client/src/hooks/useSetBillInput.ts
@@ -52,6 +52,8 @@ const useSetBillInput = ({setIsAddEditableItem}: UseSetBillInputProps): UseSetBi
           },
         },
       );
+    } else if (!isEmptyTitle && !isEmptyPrice) {
+      setIsAddEditableItem(false);
     }
   };
 


### PR DESCRIPTION
## issue
- close #471 

## 구현 사항

### title과 price에 값이 존재하지 않으면 지출 input 닫기
useSetBillInput의 handleBlurBillRequest에 조건문을 추가했습니다.
title과 price의 값이 존재하지 않다면 지출 Input은 set을 통해 false가 되면서 닫히게 됩니다.

```tsx
const handleBlurBillRequest = () => {
    const isEmptyTitle = billInput.title.trim().length;
    const isEmptyPrice = Number(billInput.price);

    // 두 input의 값이 모두 채워졌을 때 api 요청
    // api 요청을 하면 Input을 띄우지 않음
    if (isEmptyTitle && isEmptyPrice) {
      postBillList(
        {billList: [billInput]},
        {
          onSuccess: () => {
            setBillInput(initialInput);
            setIsAddEditableItem(false);
          },
        },
      );
    } else if (!isEmptyTitle && !isEmptyPrice) {
      setIsAddEditableItem(false);
    }
  };

```

### 문제

단, 해당 코드를 추가하면서 발생한 문제가 존재합니다.
price를 먼저 입력하는 것이 불가능합니다. 현재 input이 생성되면 title에 autoFocus가 됩니다. 이 상태에서 price를 먼저 입력하고 싶어 price input을 클릭하면 onBlur가 실행됩니다. 그리고 title과 price의 값이 비워져있기 때문에 지출 input이 닫힙니다.
해당 문제를 해결하기 위해서는 title의 autoFocus를 제거해야 합니다. 하지만 autoFocus가 존재하지 않는 것이 더 불편할 것으로 판단됩니다. 그래서 일단은 price를 먼저 입력할 수 없도록 하는 방향으로 정했습니다.

https://github.com/user-attachments/assets/ee2cc3d0-1556-4566-8152-6b87b1d10be1

## 🫡 참고사항
