### PR TITLE
[FE] 행사 완료 페이지 간소화

### DIFF
--- a/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
+++ b/client/src/pages/CreateEventPage/CompleteCreateEventPage.tsx
@@ -1,11 +1,5 @@
 import {useLocation, useNavigate} from 'react-router-dom';
-import {Button, FixedButton, Flex, Input, MainLayout, Text, Title, TopNav} from 'haengdong-design';
-import {CopyToClipboard} from 'react-copy-to-clipboard';
-import {css} from '@emotion/react';
-
-import {useToast} from '@hooks/useToast/useToast';
-
-import getEventPageUrlByEnvironment from '@utils/getEventPageUrlByEnvironment';
+import {FixedButton, MainLayout, Title, TopNav} from 'haengdong-design';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
 
@@ -16,41 +10,14 @@ const CompleteCreateEventPage = () => {
   const params = new URLSearchParams(location.search);
   const eventId = params.get('eventId');
 
-  const {showToast} = useToast();
-
-  const homePageUrl = getEventPageUrlByEnvironment(eventId ?? '', 'home');
-
   return (
     <MainLayout>
       <TopNav />
       <Title
         title="행사 개시"
-        description="행사가 성공적으로 개시됐어요 :) 행사 링크를 통해서 지출 내역 공유와 참여자 관리가 가능해요."
+        description={`행사가 성공적으로 개시됐어요 :)
+        관리 페이지로 이동해서 정산을 시작할 수 있어요`}
       />
-      <div css={css({display: 'flex', flexDirection: 'column', gap: '1rem', margin: '0 1rem'})}>
-        <Flex flexDirection="column">
-          <Text textColor="gray">링크가 없으면 페이지에 접근할 수 없어요.</Text>
-          <Text textColor="primary">관리를 위해서 행사 링크를 복사 후 보관해 주세요.</Text>
-        </Flex>
-        <Input value={homePageUrl} disabled />
-
-        <CopyToClipboard
-          text={homePageUrl}
-          onCopy={() =>
-            showToast({
-              showingTime: 3000,
-              message: '링크가 복사되었어요 :) \n링크를 절대 분실하지 마세요!',
-              type: 'confirm',
-              position: 'bottom',
-              bottom: '8rem',
-            })
-          }
-        >
-          <Button size="large" variants="tertiary">
-            행사 링크 복사하기
-          </Button>
-        </CopyToClipboard>
-      </div>
 
       <FixedButton onClick={() => navigate(`${ROUTER_URLS.event}/${eventId}/admin`)}>관리 페이지로 이동</FixedButton>
     </MainLayout>


### PR DESCRIPTION
## issue
- close #477 

## 구현 목적
- #271 에서 작업했던 행사 완료 페이지가 유저테스트 결과 유저 친화적이지 않다는 결론을 내렸습니다.
- 기존엔 링크를 복사할 방법이 없어 이 페이지를 제작해 주었지만, 한번에 주어지는 정보가 너무 많고 복잡해 실제로 사용하는 유저들이 해당 페이지에서 정체되는 상황을 경험했습니다.
- 이에 다시 행사 생성 완료 페이지를 간소화합니다.

## 구현 사항
### before
![image](https://github.com/user-attachments/assets/3a87e440-b5cc-4760-93c8-b49fd7a64de0)

### after
![image](https://github.com/user-attachments/assets/9a184881-b361-4b16-9518-737d91bfd1ce)
