### PR TITLE
[FE] 초기 인원 설정 시 placeholder 없던 오류 수정

### DIFF
--- a/client/src/components/Modal/SetInitialMemberListModal/SetInitialMemberListModal.tsx
+++ b/client/src/components/Modal/SetInitialMemberListModal/SetInitialMemberListModal.tsx
@@ -44,6 +44,7 @@ const SetInitialMemberListModal = ({isOpenBottomSheet, setIsOpenBottomSheet}: Se
               <LabelGroupInput.Element
                 key={`${index}`}
                 elementKey={`${index}`}
+                placeholder="이름"
                 type="text"
                 value={value}
                 isError={errorIndexList.includes(index)}


### PR DESCRIPTION
## issue
- close #479 

## 구현 목적
- 유저 테스트 결과, 초기 시작인원 설정 바텀시트에서 이름이 아닌 명수(숫자)를 입력하는 경우가 많았습니다.
- placeholder로 무엇을 입력해야 하는지 명시하지 않아서 생기는 오류라고 판단했습니다.

![image](https://github.com/user-attachments/assets/40f3eb2f-7710-4da0-9a1a-bb4c0daca172)

## 구현 사항
- 시작 인원 추가 flow에서 placeholder를 생성해 주었습니다.

![image](https://github.com/user-attachments/assets/4eaf6419-94b2-4d1e-b10f-e27c70b25b5a)


## 참고사항
label이 눈에 잘 안띄나 보네요.... 흐으으음 ㅜㅜㅠ
디자인 정말 어렵다...