### PR TITLE
[FE] 지출 내역 추가 시 금액에 숫자 외 다른 문자 입력 가능한 버그 수정

### DIFF
--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -108,7 +108,7 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
               <EditableItem.Input
                 placeholder="0"
                 type="number"
-                value={billInput.price || ''}
+                value={billInput.price ?? null}
                 onChange={e => handleChangeBillInput('price', e)}
                 style={{textAlign: 'right'}}
               ></EditableItem.Input>

--- a/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
+++ b/client/src/pages/CreateEventPage/SetEventPasswordPage.tsx
@@ -22,7 +22,7 @@ const SetEventPasswordPage = () => {
           labelText="비밀번호"
           errorText={errorMessage}
           value={password}
-          type="secret"
+          type="number"
           maxLength={RULE.maxEventPasswordLength}
           placeholder="비밀번호"
           onChange={handleChange}


### PR DESCRIPTION
## issue
- close #490 

## 구현 목적
- 기존에 지출내역의 금액 부분에 문자가 입력되는 버그 발생

https://github.com/user-attachments/assets/c2b91e71-a791-4e06-a7e9-fe3958545cdf

## 구현 사항
- `type=number`로 제한되어 있는 input에 초기값으로 `''`가 주어지다 보니 이 부분에서 문자열을 받으면서 버그가 발생함
- value 초기값을 `''`이 아닌 `null`을 줌으로써 해결함