### PR TITLE
[FE] BottomSheet 애니메이션이 적용되지 않던 오류 수정

### DIFF
--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -117,14 +117,12 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
           </EditableItem>
         )}
       </DragHandleItemContainer>
-      {isOpenMemberListInBillStep && (
-        <MemberListInBillStep
-          stepName={step.stepName}
-          memberList={memberList}
-          isOpenBottomSheet={isOpenMemberListInBillStep}
-          setIsOpenBottomSheet={setIsOpenMemberListInBillStep}
-        />
-      )}
+      <MemberListInBillStep
+        stepName={step.stepName}
+        memberList={memberList}
+        isOpenBottomSheet={isOpenMemberListInBillStep}
+        setIsOpenBottomSheet={setIsOpenMemberListInBillStep}
+      />
     </>
   );
 };

--- a/client/src/components/StepList/MemberStepItem.tsx
+++ b/client/src/components/StepList/MemberStepItem.tsx
@@ -23,14 +23,12 @@ const MemberStepItem: React.FC<MemberStepItemProps> = ({step, isOpenBottomSheet,
         prefix={`${step.actions.map(({name}) => name).join(', ')} ${step.type === 'IN' ? '들어옴' : '나감'}`}
         onClick={() => setIsOpenBottomSheet(prev => !prev)}
       />
-      {isOpenBottomSheet && isAdmin && (
-        <DeleteMemberActionModal
-          memberActionType={step.type}
-          memberActionList={step.actions}
-          isBottomSheetOpened={isOpenBottomSheet}
-          setIsBottomSheetOpened={setIsOpenBottomSheet}
-        />
-      )}
+      <DeleteMemberActionModal
+        memberActionType={step.type}
+        memberActionList={step.actions}
+        isBottomSheetOpened={isOpenBottomSheet && isAdmin}
+        setIsBottomSheetOpened={setIsOpenBottomSheet}
+      />
     </>
   );
 };

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -3,7 +3,7 @@ import {Title, FixedButton, ListButton, Button} from 'haengdong-design';
 import {useOutletContext} from 'react-router-dom';
 
 import StepList from '@components/StepList/StepList';
-import {ModalBasedOnMemberCount} from '@components/Modal/index';
+import {ModalBasedOnMemberCount, SetAllMemberListModal} from '@components/Modal/index';
 import useRequestGetAllMemberList from '@hooks/queries/useRequestGetAllMemberList';
 import useRequestPostAuthenticate from '@hooks/queries/useRequestPostAuthentication';
 
@@ -73,15 +73,13 @@ const AdminPage = () => {
             </Button>
           </div>
         )}
-        {isOpenFixedButtonBottomSheet && (
-          <ModalBasedOnMemberCount
-            allMemberList={allMemberList}
-            setIsOpenBottomSheet={setIsOpenFixedButtonBottomSheet}
-            isOpenBottomSheet={isOpenFixedButtonBottomSheet}
-            isOpenAllMemberListButton={isOpenAllMemberListButton}
-            setIsOpenAllMemberListButton={setIsOpenAllMemberListButton}
-          />
-        )}
+        <ModalBasedOnMemberCount
+          allMemberList={allMemberList}
+          setIsOpenBottomSheet={setIsOpenFixedButtonBottomSheet}
+          isOpenBottomSheet={isOpenFixedButtonBottomSheet}
+          isOpenAllMemberListButton={isOpenAllMemberListButton}
+          setIsOpenAllMemberListButton={setIsOpenAllMemberListButton}
+        />
       </section>
     </>
   );


### PR DESCRIPTION
## issue
- close #492

## 구현 목적
BottomSheet의 애니메이션이 적용되지 않던 버그가 있어 이를 수정합니다.

## 구현 사항
BottomSheet 구조상, 조건부 렌더링이 아닌, `isOpen` 상태의 변화를 통해 애니메이션을 적용해 주는 것이기 때문에, 조건부 렌더링을 진행하면 애니메이션이 적용되지 않습니다.

조건부 렌더링을 상태를 이용하도록 변경해 주었습니다.

## 🫡 참고사항
런칭페스티벌을 앞두고, 급하게 변경사항을 적용했습니다.
간단한 인원 변동 추가 바텀시트와 인원 수정 바텀시트는 잘 작동하지만,
여러 상태가 엮여있는 전체 참여자 바텀시트와 금액 수정 바텀시트는 여전히 작동하지 않습니다.

바텀시트 관련한 부분들도 수정을 직접 해보니 굉장히 결합도가 높고 불필요한 코드가 많아보여요
레벨 4에서 할일이 정말 고봉밥이네요...