### PR TITLE
[FE] 홈페이지에서 지출 내역 눌렀을 때 차등 정산 모달 뜨기

### DIFF
--- a/client/src/components/Modal/ExpenseDetailModal/ExpenseDetailModal.tsx
+++ b/client/src/components/Modal/ExpenseDetailModal/ExpenseDetailModal.tsx
@@ -1,0 +1,142 @@
+import type {BillAction} from 'types/serviceType';
+
+import {BottomSheet, EditableItem, FixedButton, Flex, Text} from 'haengdong-design';
+
+import validatePurchase from '@utils/validate/validatePurchase';
+import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
+import useMemberReportListInAction from '@hooks/useMemberReportListInAction/useMemberReportListInAction';
+import useMemberReportInput from '@hooks/useMemberReportListInAction/useMemberReportInput';
+
+import usePutAndDeleteBillAction from '@hooks/usePutAndDeleteBillAction';
+
+import {
+  bottomSheetHeaderStyle,
+  bottomSheetStyle,
+  inputContainerStyle,
+} from '../SetActionModal/PutAndDeleteBillActionModal/PutAndDeltetBillActionModal.style';
+
+type PutAndDeleteBillActionModalProps = {
+  billAction: BillAction;
+  isBottomSheetOpened: boolean;
+  setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const ExpenseDetailModal = ({
+  billAction,
+  isBottomSheetOpened,
+  setIsBottomSheetOpened,
+}: PutAndDeleteBillActionModalProps) => {
+  const {
+    inputPair,
+    handleInputChange,
+    // handleOnBlur,
+    // errorMessage,
+    // errorInfo,
+    canSubmit,
+    onDelete,
+    onSubmit: putBillAction,
+  } = usePutAndDeleteBillAction(
+    {title: billAction.name, price: String(billAction.price), index: 0},
+    validatePurchase,
+    () => setIsBottomSheetOpened(false),
+  );
+
+  const {
+    memberReportListInAction,
+    addAdjustedMember,
+    onSubmit: putMemberReportListInAction,
+    getIsSamePriceStateAndServerState,
+    getOnlyOneNotAdjustedRemainMemberIndex,
+    isExistAdjustedPrice,
+  } = useMemberReportListInAction(billAction.actionId, Number(inputPair.price), () => setIsBottomSheetOpened(false));
+  const {
+    inputList,
+    onChange,
+    canEditList,
+    canSubmit: isChangedMemberReportInput,
+  } = useMemberReportInput({
+    data: memberReportListInAction,
+    addAdjustedMember,
+    totalPrice: Number(inputPair.price),
+    getIsSamePriceStateAndServerState,
+    getOnlyOneNotAdjustedRemainMemberIndex,
+  });
+
+  const {data: stepListData = []} = useRequestGetStepList();
+
+  const actionMemberList = stepListData.filter(({actions}) =>
+    actions.find(({actionId}) => actionId === billAction.actionId),
+  )[0].members;
+
+  return (
+    <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
+      <form css={bottomSheetStyle} onSubmit={() => setIsBottomSheetOpened(false)}>
+        <h2 css={bottomSheetHeaderStyle}>
+          <Text size="bodyBold">지출 내역 상세</Text>
+        </h2>
+        <fieldset css={inputContainerStyle}>
+          <EditableItem backgroundColor="lightGrayContainer" prefixLabelText="지출 내역 / 금액">
+            <EditableItem.Input
+              placeholder="지출 내역"
+              textSize="bodyBold"
+              value={inputPair.title}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange('title', event)}
+              disabled
+            />
+            <Flex alignItems="center" gap="0.25rem">
+              <EditableItem.Input
+                placeholder="0"
+                style={{
+                  textAlign: 'right',
+                }}
+                type="number"
+                value={inputPair.price}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange('price', event)}
+                isFixed={isExistAdjustedPrice()}
+                disabled
+              />
+              <Text size="caption">원</Text>
+            </Flex>
+          </EditableItem>
+
+          <EditableItem
+            backgroundColor="lightGrayContainer"
+            prefixLabelText="참여자"
+            suffixLabelText={`총 ${actionMemberList.length}명`}
+          >
+            <Flex flexDirection="column" width="100%" gap="1rem">
+              {inputList.map(({name, price, isFixed}, index) => (
+                <Flex key={name} justifyContent="spaceBetween">
+                  <EditableItem.Input
+                    value={name}
+                    placeholder="참여자 명"
+                    textSize="smallBodyBold"
+                    disabled
+                  ></EditableItem.Input>
+                  <Flex gap="0.25rem" alignItems="center">
+                    <EditableItem.Input
+                      onChange={event => onChange(event, index)}
+                      isFixed={isFixed}
+                      textSize="smallBody"
+                      value={price}
+                      placeholder="0"
+                      type="number"
+                      disabled
+                      style={{textAlign: 'right'}}
+                    ></EditableItem.Input>
+                    <Text size="caption">원</Text>
+                  </Flex>
+                </Flex>
+              ))}
+            </Flex>
+          </EditableItem>
+        </fieldset>
+        <FixedButton type="submit" variants="tertiary">
+          닫기
+        </FixedButton>
+      </form>
+    </BottomSheet>
+  );
+};
+
+export default ExpenseDetailModal;

--- a/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
+++ b/client/src/components/Modal/SetActionModal/PutAndDeleteBillActionModal/PutAndDeleteBillActionModal.tsx
@@ -6,7 +6,6 @@ import validatePurchase from '@utils/validate/validatePurchase';
 import useRequestGetStepList from '@hooks/queries/useRequestGetStepList';
 import useMemberReportListInAction from '@hooks/useMemberReportListInAction/useMemberReportListInAction';
 import useMemberReportInput from '@hooks/useMemberReportListInAction/useMemberReportInput';
-import {useToast} from '@hooks/useToast/useToast';
 
 import usePutAndDeleteBillAction from '@hooks/usePutAndDeleteBillAction';
 
@@ -64,8 +63,6 @@ const PutAndDeleteBillActionModal = ({
   const actionMemberList = stepListData.filter(({actions}) =>
     actions.find(({actionId}) => actionId === billAction.actionId),
   )[0].members;
-
-  const {showToast} = useToast();
 
   return (
     <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>

--- a/client/src/components/StepList/BillStepItem.tsx
+++ b/client/src/components/StepList/BillStepItem.tsx
@@ -6,6 +6,7 @@ import {BillStep, MemberReport} from 'types/serviceType';
 import {PutAndDeleteBillActionModal} from '@components/Modal/SetActionModal/PutAndDeleteBillActionModal';
 import {MemberListInBillStep} from '@components/Modal/MemberListInBillStep';
 import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
+import ExpenseDetailModal from '@components/Modal/ExpenseDetailModal/ExpenseDetailModal';
 
 import useSetBillInput from '@hooks/useSetBillInput';
 
@@ -79,6 +80,13 @@ const BillStepItem: React.FC<BillStepItemProps> = ({
 
               {isOpenBottomSheet && clickedIndex === index && isAdmin && (
                 <PutAndDeleteBillActionModal
+                  billAction={action}
+                  isBottomSheetOpened={isOpenBottomSheet}
+                  setIsBottomSheetOpened={setIsOpenBottomSheet}
+                />
+              )}
+              {isOpenBottomSheet && clickedIndex === index && !isAdmin && (
+                <ExpenseDetailModal
                   billAction={action}
                   isBottomSheetOpened={isOpenBottomSheet}
                   setIsBottomSheetOpened={setIsOpenBottomSheet}


### PR DESCRIPTION
## issue
- close #504 

## 구현 목적

홈페이지에서 지출 내역 눌렀을 때 차등 정산 모달을 띄워야 합니다.

## 구현 사항
`PutAndDeleteBillActionModal`을 그대로 복사해서 `ExpenseDetailModal`을 만들었습니다. 컴포넌트명만 수정하고 스타일파일은 모두 PutAndDeleteBillActionModal에서 끌어왔습니다. 마찬가지로 타입명도 모두 그렇습니다. 시간이 없었습니다.

https://github.com/user-attachments/assets/a11830f6-bb1c-456c-9c90-1c1fed3147e3

<img width="562" alt="image" src="https://github.com/user-attachments/assets/bccf1be8-2189-4b4d-b472-8f821bf1b760">



