### PR TITLE
[FE] 지출 내역 및 전체 참여자 버그

### DIFF
--- a/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/AddMemberActionListModalContent.tsx
+++ b/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/AddMemberActionListModalContent.tsx
@@ -27,8 +27,6 @@ const AddMemberActionListModalContent = ({inOutAction, setIsOpenBottomSheet}: Ad
     setIsOpenBottomSheet(false);
   };
 
-  console.log(inputList);
-
   return (
     <div css={style.container}>
       <div css={style.inputGroup}>

--- a/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/AddMemberActionListModalContent.tsx
+++ b/client/src/components/Modal/SetActionModal/AddMemberActionListModalContent/AddMemberActionListModalContent.tsx
@@ -18,7 +18,7 @@ interface AddMemberActionListModalContentProps {
 
 const AddMemberActionListModalContent = ({inOutAction, setIsOpenBottomSheet}: AddMemberActionListModalContentProps) => {
   const dynamicProps = useDynamicInput(validateMemberName);
-  const {inputList, getFilledInputList, errorMessage, canSubmit} = dynamicProps;
+  const {inputList, getFilledInputList, errorMessage, canSubmit, resetInputValue} = dynamicProps;
 
   const {mutate: postMemberList} = useRequestPostMemberList();
 
@@ -26,6 +26,8 @@ const AddMemberActionListModalContent = ({inOutAction, setIsOpenBottomSheet}: Ad
     postMemberList({memberNameList: getFilledInputList().map(({value}) => value), type: inOutAction});
     setIsOpenBottomSheet(false);
   };
+
+  console.log(inputList);
 
   return (
     <div css={style.container}>
@@ -38,7 +40,10 @@ const AddMemberActionListModalContent = ({inOutAction, setIsOpenBottomSheet}: Ad
         disabled={!canSubmit}
         variants={'primary'}
         children={`${inputList.length - 1}명 ${inOutAction === 'OUT' ? '탈주' : '늦참'}`}
-        onClick={handleUpdateMemberListSubmit}
+        onClick={() => {
+          handleUpdateMemberListSubmit();
+          resetInputValue();
+        }}
       />
     </div>
   );

--- a/client/src/components/StepList/MemberStepItem.tsx
+++ b/client/src/components/StepList/MemberStepItem.tsx
@@ -18,7 +18,7 @@ const MemberStepItem: React.FC<MemberStepItemProps> = ({step, isOpenBottomSheet,
   return (
     <>
       <DragHandleItem
-        hasDragHandler={isAdmin}
+        hasDragHandler={false}
         backgroundColor="white"
         prefix={`${step.actions.map(({name}) => name).join(', ')} ${step.type === 'IN' ? '들어옴' : '나감'}`}
         onClick={() => setIsOpenBottomSheet(prev => !prev)}

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -36,8 +36,11 @@ const StepList = ({isAddEditableItem = false, setIsAddEditableItem = () => {}}: 
   }, [existIndexInStepList]);
 
   useEffect(() => {
-    // 최초로 빈 stepList가 생성되고 난 후, 다시 hasAddedItem을 false로 변환하기 위한 조건문
-    if (hasAddedItem) setHasAddedItem(prev => !prev);
+    if (hasAddedItem) {
+      setHasAddedItem(false);
+
+      setStepList(prev => [...prev.filter(({actions}) => actions.length !== 0)]);
+    }
 
     if (isAddEditableItem && lastBillItemIndex !== lastItemIndex && !hasAddedItem) {
       setStepList(prev => [
@@ -51,7 +54,7 @@ const StepList = ({isAddEditableItem = false, setIsAddEditableItem = () => {}}: 
       ]);
       setHasAddedItem(prev => !prev);
     }
-  }, [isAddEditableItem, lastBillItemIndex, lastItemIndex, hasAddedItem, existIndexInStepList, stepListData]);
+  }, [isAddEditableItem]);
 
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">

--- a/client/src/hooks/useDynamicInput.tsx
+++ b/client/src/hooks/useDynamicInput.tsx
@@ -21,6 +21,7 @@ export type ReturnUseDynamicInput = {
   getFilledInputList: (list?: InputValue[]) => InputValue[];
   focusNextInputOnEnter: (e: React.KeyboardEvent<HTMLInputElement>, index: number) => void;
   setInputValueTargetIndex: (index: number, value: string) => void;
+  resetInputValue: () => void;
 };
 
 const useDynamicInput = (validateFunc: (name: string) => ValidateResult): ReturnUseDynamicInput => {
@@ -96,6 +97,10 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     });
   };
 
+  const resetInputValue = () => {
+    setInputList(initialInputList);
+  };
+
   const focusNextInputOnEnter = (e: React.KeyboardEvent<HTMLInputElement>, index: number) => {
     if (e.nativeEvent.isComposing) return;
 
@@ -130,6 +135,7 @@ const useDynamicInput = (validateFunc: (name: string) => ValidateResult): Return
     getFilledInputList,
     focusNextInputOnEnter,
     setInputValueTargetIndex,
+    resetInputValue,
   };
 };
 

--- a/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
+++ b/client/src/hooks/useMemberReportListInAction/useMemberReportListInAction.test.tsx
@@ -172,8 +172,6 @@ describe('useMemberReportListInActionTest', () => {
         result.current.addAdjustedMember(adjustedMemberMangcho);
       });
 
-      console.log(result.current.memberReportListInAction);
-
       const targetMember = result.current.memberReportListInAction.find(member => member.name === '망쵸');
       expect(targetMember?.price).toBe(300);
 

--- a/client/src/hooks/useSetAllMemberList.tsx
+++ b/client/src/hooks/useSetAllMemberList.tsx
@@ -83,7 +83,7 @@ const useSetAllMemberList = ({
         return null; // 조건에 맞지 않으면 null을 반환
       })
       .filter(item => item !== null); // null인 항목을 필터링하여 제거
-    putAllMemberList({members: editedMemberName});
+    if (!isArraysEqual(editedAllMemberList, deleteInOriginal)) putAllMemberList({members: editedMemberName});
     handleCloseAllMemberListModal();
   };
 

--- a/client/src/hooks/useSetAllMemberList.tsx
+++ b/client/src/hooks/useSetAllMemberList.tsx
@@ -44,7 +44,7 @@ const useSetAllMemberList = ({
   const [deleteInOriginal, setDeleteInOriginal] = useState<string[]>(allMemberList);
   const [deleteMemberList, setDeleteMemberList] = useState<string[]>([]);
 
-  const {mutate: deleteAllMemberList} = useDeleteAllMemberList();
+  const {mutateAsync: deleteAllMemberList} = useDeleteAllMemberList();
   const {mutate: putAllMemberList} = usePutAllMemberList();
 
   const editedAllMemberList = inputList.map(input => input.value);
@@ -71,7 +71,7 @@ const useSetAllMemberList = ({
     // deleteMemberList가 비어있지 않은 경우에만 반복문 실행 (삭제 api 요청)
     if (deleteMemberList.length > 0) {
       for (const deleteMember of deleteMemberList) {
-        deleteAllMemberList({memberName: deleteMember});
+        await deleteAllMemberList({memberName: deleteMember});
       }
     }
 


### PR DESCRIPTION
## issue
- close #495

## 구현 사항
- 지출 내역: 상단 Bill action이 존재하지 않을 경우에 Input만 닫히고 Bill Container는 닫히지 않음
    
    ```tsx
    useEffect(() => {
      if (hasAddedItem) {
        setHasAddedItem(false);
    
        setStepList(prev => [...prev.filter(({actions}) => actions.length !== 0)]);
      }
     // ...
     }, [isAddEditableItem]);
    ```
    
    `setStepList(prev => [...prev.filter(({actions}) => actions.length !== 0)]);` 추가
    
    지출 내역 추가 버튼을 클릭하면 isAddEditableItem은 false에서 true가 된다. 직전에 Bill action이 존재하지 않을 경우 새로운 bill action을 임의로 생성한다. 이때 새로운 bill이 생성되면 hasAddedItem은 true가 된다. 
    
    그리고 사용자가 input에 아무런 값도 입력하지 않을 경우 isAddEditableItem의 값은 false로 변환된다. 이때 useEffect의 의존성으로 isAddEditableItem가 존재하기 때문에 useEffect가 실행된다.
    
    useEffect 내부의 코드를 살펴보자.
    만약 hasAddedItem이 true라면, 즉 새로운 Bill action이 생성되었다면 isAddEditableItem을 false로 반환한다.
    그리고 stepList에서 actions 배열을 도는데 actions의 값이 존재하지 않는 것은 삭제한다. 이를 통해 아무런 bill action도 추가되지 않은 Bill Container는 사라지게 된다.
    
- 전체 참여자 수정
    - 이름 변경 수정이 존재하지 않는 상황에서도 nameChange api 요청이 전송되지 않도록 수정
        
        인원 삭제를 하고 수정완료 버튼을 클릭하면 삭제 요청 → 이름 변경 요청 순서로 된다.
        근데 이름 변경 요청이 존재하지 않을 때에도 수정 완료버튼을 클릭하면 무조건 요청이 된다.
        
        ```jsx
          if (!isArraysEqual(editedAllMemberList, deleteInOriginal)) putAllMemberList({members: editedMemberName});
        ```
        
        put 요청을 위한 조건문을 추가했다. 이름 수정이 존재할 때만 put 요청을 보낸다.
        
    - 전체 참여자 삭제 및 이름 수정 api 요청 순서 보장
        
        mutationAsync와 await를 사용하여 삭제 요청 후 수정 요청 순서가 보장되도록 수정했다.
        
        ```jsx
        const {mutateAsync: deleteAllMemberList} = useDeleteAllMemberList();
        
        // ...
        
        const handlePutAllMemberList = async () => {
          // deleteMemberList가 비어있지 않은 경우에만 반복문 실행 (삭제 api 요청)
          if (deleteMemberList.length > 0) {
            for (const deleteMember of deleteMemberList) {
              await deleteAllMemberList({memberName: deleteMember});
            }
          }
        ```
        
- 인원 변동 Input 버그
    
    직전에 인원 변동 요청을 전송했다. 그리고 바로 인원 변동을 추가하게 되면 직전에 입력했던 value가 그대로 들어온다.
    
    해당 방법을 해결하기 위해서 useDynamicInput에 resetInputValue 함수를 만들었다.
    
    ```tsx
    const resetInputValue = () => {
      setInputList(initialInputList);
    };
    ```
    
    ```tsx
    <FixedButton
      disabled={!canSubmit}
      variants={'primary'}
      children={`${inputList.length - 1}명 ${inOutAction === 'OUT' ? '탈주' : '늦참'}`}
      onClick={() => {
        handleUpdateMemberListSubmit();
        resetInputValue();
      }}
    />
    ```
    
    인원변동 요청 FixedButton의 onClick 이벤트가 발생할 때, api 요청 후 resetInputValue 함수를 실행하도록 했다.
    
    **추가 논의 사항**
    현재 DynamicInput을 사용하는 BottomSheet에서는 input에 값을 입력한 후, api 요청을 전송하지 않고 BottomSheet를 닫으면 input에 value가 그대로 존재한다.
    이런 상황이 사용자에게더 좋을지? BottomSheet를 닫아도 초기화 해주는 것이 더 좋은 방향일지 논의가 필요하다.

