### PR TITLE
[FE] 지출 내역이 없을 때 홈페이지에서 없다고 띄우기

### DIFF
--- a/client/src/components/MemberReportList/MemberReportList.tsx
+++ b/client/src/components/MemberReportList/MemberReportList.tsx
@@ -1,11 +1,11 @@
-import {ExpenseList, Flex, Input} from 'haengdong-design';
-import React, {useState} from 'react';
+import {ExpenseList, Flex, Input, Text} from 'haengdong-design';
+import React, {useEffect, useState} from 'react';
 
 import useSearchMemberReportList from '@hooks/useSearchMemberReportList/useSearchMemberReportList';
 
 const MemberReportList = () => {
   const [name, setName] = useState('');
-  const {memberReportSearchList} = useSearchMemberReportList({name});
+  const {memberReportSearchList, memberReportList} = useSearchMemberReportList({name});
 
   const changeName = ({target}: React.ChangeEvent<HTMLInputElement>) => {
     setName(target.value);
@@ -13,8 +13,18 @@ const MemberReportList = () => {
 
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
-      <Input inputType="search" value={name} onChange={changeName} placeholder="참여자 이름" />
-      <ExpenseList expenseList={memberReportSearchList} />
+      {memberReportList.length > 0 ? (
+        <>
+          <Input inputType="search" value={name} onChange={changeName} placeholder="참여자 이름" />
+          {memberReportSearchList.length !== 0 && <ExpenseList expenseList={memberReportSearchList} />}
+        </>
+      ) : (
+        <Flex width="100%" justifyContent="center">
+          <Text size="body" textColor="gray" style={{paddingTop: '1rem'}}>
+            지금은 참여자가 한 명도 없어요. :(
+          </Text>
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/client/src/components/StepList/StepList.tsx
+++ b/client/src/components/StepList/StepList.tsx
@@ -1,4 +1,4 @@
-import {Flex} from 'haengdong-design';
+import {Flex, Text} from 'haengdong-design';
 import {useEffect, useMemo, useState} from 'react';
 
 import {BillStep, MemberStep} from 'types/serviceType';
@@ -58,17 +58,25 @@ const StepList = ({isAddEditableItem = false, setIsAddEditableItem = () => {}}: 
 
   return (
     <Flex flexDirection="column" gap="0.5rem" paddingInline="0.5rem">
-      {stepList.map((step, index) => (
-        <Step
-          index={index}
-          step={step}
-          lastBillItemIndex={lastBillItemIndex}
-          lastItemIndex={lastItemIndex}
-          key={`${step.stepName}${index}`}
-          isAddEditableItem={isAddEditableItem}
-          setIsAddEditableItem={setIsAddEditableItem}
-        />
-      ))}
+      {stepList.length > 0 ? (
+        stepList.map((step, index) => (
+          <Step
+            index={index}
+            step={step}
+            lastBillItemIndex={lastBillItemIndex}
+            lastItemIndex={lastItemIndex}
+            key={`${step.stepName}${index}`}
+            isAddEditableItem={isAddEditableItem}
+            setIsAddEditableItem={setIsAddEditableItem}
+          />
+        ))
+      ) : (
+        <Flex width="100%" justifyContent="center">
+          <Text size="body" textColor="gray" style={{paddingTop: '1rem'}}>
+            지금은 지출 내역이 없어요. :(
+          </Text>
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/client/src/hooks/useSearchMemberReportList/useSearchMemberReportList.tsx
+++ b/client/src/hooks/useSearchMemberReportList/useSearchMemberReportList.tsx
@@ -10,6 +10,7 @@ const useSearchMemberReportList = ({name}: UseSearchMemberReportListParams) => {
 
   return {
     memberReportSearchList: memberReportList.filter(memberReport => memberReport.name.includes(name)),
+    memberReportList,
   };
 };
 


### PR DESCRIPTION
## issue
- close #519 

## 구현 사항
지출 내역이 없을 때 참여자가 보는 홈 페이지에서 없다고 띄웁니다.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/545b029a-96e0-415c-8560-327bcd3dee18">

<img width="391" alt="image" src="https://github.com/user-attachments/assets/349a0131-d942-4b2e-980b-e348e8bf9e6b">


