### PR TITLE
[FE] 입금 상태를 관리하는 컴포넌트 DepositToggle 기능 구현

### DIFF
--- a/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
@@ -1,4 +1,7 @@
+/** @jsxImportSource @emotion/react */
 import type {Meta, StoryObj} from '@storybook/react';
+
+import {useEffect, useState} from 'react';
 
 import {DepositToggle} from './DepositToggle';
 
@@ -20,14 +23,29 @@ const meta = {
       options: [undefined, () => alert('change toggle')],
     },
   },
-  args: {
-    isDeposit: false,
-    onToggle: () => alert('change toggle'),
-  },
 } satisfies Meta<typeof DepositToggle>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {};
+export const Playground: Story = {
+  args: {
+    isDeposit: false,
+    onToggle: () => {},
+  },
+  render: ({isDeposit, onToggle, ...args}) => {
+    const [isDepositState, setIsDepositState] = useState(isDeposit);
+
+    useEffect(() => {
+      setIsDepositState(isDeposit);
+    }, [isDeposit]);
+
+    const handleToggle = () => {
+      setIsDepositState(!isDepositState);
+      onToggle();
+    };
+
+    return <DepositToggle {...args} isDeposit={isDepositState} onToggle={handleToggle} />;
+  },
+};

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
   },
   args: {
     isDeposit: false,
-    onToggle: () => {},
+    onToggle: () => alert('change toggle'),
   },
 } satisfies Meta<typeof DepositToggle>;
 

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
@@ -1,0 +1,20 @@
+import type {Meta, StoryObj} from '@storybook/react';
+
+import {DepositToggle} from './DepositToggle';
+
+const meta = {
+  title: 'Components/DepositToggle',
+  component: DepositToggle,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof DepositToggle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.stories.tsx
@@ -9,8 +9,21 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  argTypes: {},
-  args: {},
+  argTypes: {
+    isDeposit: {
+      description: '',
+      control: {type: 'boolean'},
+    },
+    onToggle: {
+      description: '',
+      control: {type: 'select'},
+      options: [undefined, () => alert('change toggle')],
+    },
+  },
+  args: {
+    isDeposit: false,
+    onToggle: () => {},
+  },
 } satisfies Meta<typeof DepositToggle>;
 
 export default meta;

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -2,7 +2,12 @@ import {css} from '@emotion/react';
 
 import {Theme} from '@theme/theme.type';
 
-export const depositToggleStyle = (theme: Theme) =>
+interface Props {
+  theme: Theme;
+  isDeposit: boolean;
+}
+
+export const depositToggleStyle = ({theme, isDeposit}: Props) =>
   css({
     display: `flex`,
     flexDirection: 'column',
@@ -13,14 +18,27 @@ export const depositToggleStyle = (theme: Theme) =>
     width: '4rem',
 
     div: {
+      // zIndex: '5',
+    },
+
+    p: {
       display: 'flex',
       justifyContent: 'center',
       borderRadius: '0.5rem',
       padding: ' 0.125rem 0 0 0',
+      zIndex: '10',
     },
 
-    '& .on-toggle': {
+    '.toggle-background': {
+      position: 'fixed',
+      width: '56px',
+      height: '20px',
+      borderRadius: '0.5rem',
       backgroundColor: theme.colors.white,
-      transition: '0.5s',
+
+      transition: '0.2s',
+      transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
+
+      transform: !isDeposit ? 'translateY(1.25rem)' : '',
     },
   });

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -1,13 +1,8 @@
 import {css} from '@emotion/react';
 
-import {Theme} from '@theme/theme.type';
+import {DepositToggleStylePropsWithTheme} from './DepositToggle.type';
 
-interface Props {
-  theme: Theme;
-  isDeposit: boolean;
-}
-
-export const depositToggleStyle = ({theme, isDeposit}: Props) =>
+export const depositToggleStyle = ({theme, isDeposit}: DepositToggleStylePropsWithTheme) =>
   css({
     display: `flex`,
     flexDirection: 'column',
@@ -16,10 +11,6 @@ export const depositToggleStyle = ({theme, isDeposit}: Props) =>
     backgroundColor: theme.colors.tertiary,
     cursor: 'pointer',
     width: '4rem',
-
-    div: {
-      // zIndex: '5',
-    },
 
     p: {
       display: 'flex',

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -7,25 +7,19 @@ export const depositToggleStyle = (theme: Theme) =>
     display: `flex`,
     flexDirection: 'column',
     padding: '0.25rem',
-    borderRadius: '12px',
+    borderRadius: '0.75rem',
     backgroundColor: theme.colors.tertiary,
+    cursor: 'pointer',
+    width: '4rem',
 
-    p: {
-      padding: '1px 4px',
-      borderRadius: '8px',
-      width: '100%',
-      textAlign: 'center',
-      color: theme.colors.gray,
+    div: {
+      display: 'flex',
+      justifyContent: 'center',
+      borderRadius: '0.5rem',
+      padding: ' 0.125rem 0 0 0',
     },
 
     '& .on-toggle': {
       backgroundColor: theme.colors.white,
-      '&.completed': {
-        color: theme.colors.onTertiary,
-      },
-
-      '&.not-completed': {
-        color: theme.colors.error,
-      },
     },
   });

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -1,8 +1,10 @@
 import {css} from '@emotion/react';
 
-import {DepositToggleStylePropsWithTheme} from './DepositToggle.type';
+import {WithTheme} from '@components/Design/type/withTheme';
 
-export const depositToggleStyle = ({theme, isDeposit}: DepositToggleStylePropsWithTheme) =>
+import {DepositToggleStyleProps} from './DepositToggle.type';
+
+export const depositToggleStyle = ({theme, isDeposit}: WithTheme<DepositToggleStyleProps>) =>
   css({
     display: `flex`,
     flexDirection: 'column',

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -12,7 +12,7 @@ export const depositToggleStyle = ({theme, isDeposit}: DepositToggleStylePropsWi
     cursor: 'pointer',
     width: '4rem',
 
-    p: {
+    '.deposit-text': {
       display: 'flex',
       justifyContent: 'center',
       borderRadius: '0.5rem',

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -1,0 +1,31 @@
+import {css} from '@emotion/react';
+
+import {Theme} from '@theme/theme.type';
+
+export const depositToggleStyle = (theme: Theme) =>
+  css({
+    display: `flex`,
+    flexDirection: 'column',
+    padding: '0.25rem',
+    borderRadius: '12px',
+    backgroundColor: theme.colors.tertiary,
+
+    p: {
+      padding: '1px 4px',
+      borderRadius: '8px',
+      width: '100%',
+      textAlign: 'center',
+      color: theme.colors.gray,
+    },
+
+    '& .on-focus': {
+      backgroundColor: theme.colors.white,
+      '&.completed': {
+        color: theme.colors.onTertiary,
+      },
+
+      '&.not-completed': {
+        color: theme.colors.error,
+      },
+    },
+  });

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -18,7 +18,7 @@ export const depositToggleStyle = (theme: Theme) =>
       color: theme.colors.gray,
     },
 
-    '& .on-focus': {
+    '& .on-toggle': {
       backgroundColor: theme.colors.white,
       '&.completed': {
         color: theme.colors.onTertiary,

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.style.ts
@@ -21,5 +21,6 @@ export const depositToggleStyle = (theme: Theme) =>
 
     '& .on-toggle': {
       backgroundColor: theme.colors.white,
+      transition: '0.5s',
     },
   });

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
@@ -7,14 +7,15 @@ import Text from '../Text/Text';
 import {DepositToggleProps} from './DepositToggle.type';
 import {depositToggleStyle} from './DepositToggle.style';
 
-export const DepositToggle: React.FC<DepositToggleProps> = () => {
+export const DepositToggle: React.FC<DepositToggleProps> = ({isDeposit = false, onToggle}: DepositToggleProps) => {
   const {theme} = useTheme();
+
   return (
-    <div css={depositToggleStyle(theme)} role="button">
-      <Text size="caption" className="on-focus completed">
+    <div css={depositToggleStyle(theme)} onClick={onToggle} role="button">
+      <Text size="caption" className={`${isDeposit && 'on-toggle'} completed`}>
         입금 완료
       </Text>
-      <Text size="caption" className="not-completed">
+      <Text size="caption" className={`${isDeposit || 'on-toggle'} not-completed`}>
         미입금
       </Text>
     </div>

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
@@ -12,12 +12,16 @@ export const DepositToggle: React.FC<DepositToggleProps> = ({isDeposit = false, 
 
   return (
     <div css={depositToggleStyle(theme)} onClick={onToggle} role="button">
-      <Text size="caption" className={`${isDeposit && 'on-toggle'} completed`}>
-        입금 완료
-      </Text>
-      <Text size="caption" className={`${isDeposit || 'on-toggle'} not-completed`}>
-        미입금
-      </Text>
+      <div className={`${isDeposit && 'on-toggle'}`}>
+        <Text size="caption" textColor={isDeposit ? `onTertiary` : 'gray'} className="completed">
+          입금 완료
+        </Text>
+      </div>
+      <div className={`${isDeposit || 'on-toggle'}`}>
+        <Text size="caption" textColor={isDeposit ? `gray` : 'error'} className="not-completed">
+          미입금
+        </Text>
+      </div>
     </div>
   );
 };

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
@@ -11,17 +11,14 @@ export const DepositToggle: React.FC<DepositToggleProps> = ({isDeposit = false, 
   const {theme} = useTheme();
 
   return (
-    <div css={depositToggleStyle(theme)} onClick={onToggle} role="button">
-      <div className={`${isDeposit && 'on-toggle'}`}>
-        <Text size="caption" textColor={isDeposit ? `onTertiary` : 'gray'} className="completed">
-          입금 완료
-        </Text>
-      </div>
-      <div className={`${isDeposit || 'on-toggle'}`}>
-        <Text size="caption" textColor={isDeposit ? `gray` : 'error'} className="not-completed">
-          미입금
-        </Text>
-      </div>
+    <div css={depositToggleStyle({theme, isDeposit})} onClick={onToggle} role="button">
+      <div className={'toggle-background'} content="" />
+      <Text size="caption" textColor={isDeposit ? `onTertiary` : 'gray'} className="completed">
+        입금 완료
+      </Text>
+      <Text size="caption" textColor={isDeposit ? `gray` : 'error'} className="not-completed">
+        미입금
+      </Text>
     </div>
   );
 };

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
@@ -1,0 +1,22 @@
+/** @jsxImportSource @emotion/react */
+
+import {useTheme} from '@theme/HDesignProvider';
+
+import Text from '../Text/Text';
+
+import {DepositToggleProps} from './DepositToggle.type';
+import {depositToggleStyle} from './DepositToggle.style';
+
+export const DepositToggle: React.FC<DepositToggleProps> = () => {
+  const {theme} = useTheme();
+  return (
+    <div css={depositToggleStyle(theme)} role="button">
+      <Text size="caption" className="on-focus completed">
+        입금 완료
+      </Text>
+      <Text size="caption" className="not-completed">
+        미입금
+      </Text>
+    </div>
+  );
+};

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.tsx
@@ -13,10 +13,10 @@ export const DepositToggle: React.FC<DepositToggleProps> = ({isDeposit = false, 
   return (
     <div css={depositToggleStyle({theme, isDeposit})} onClick={onToggle} role="button">
       <div className={'toggle-background'} content="" />
-      <Text size="caption" textColor={isDeposit ? `onTertiary` : 'gray'} className="completed">
+      <Text size="caption" textColor={isDeposit ? `onTertiary` : 'gray'} className="deposit-text">
         입금 완료
       </Text>
-      <Text size="caption" textColor={isDeposit ? `gray` : 'error'} className="not-completed">
+      <Text size="caption" textColor={isDeposit ? `gray` : 'error'} className="deposit-text">
         미입금
       </Text>
     </div>

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
@@ -1,5 +1,3 @@
-import {Theme} from '@components/Design/theme/theme.type';
-
 export interface DepositToggleStyleProps {
   isDeposit: boolean;
 }
@@ -7,10 +5,6 @@ export interface DepositToggleStyleProps {
 export interface DepositToggleCustomProps {
   isDeposit: boolean;
   onToggle: () => void;
-}
-
-export interface DepositToggleStylePropsWithTheme extends DepositToggleStyleProps {
-  theme: Theme;
 }
 
 export type DepositToggleOptionProps = DepositToggleStyleProps & DepositToggleCustomProps;

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
@@ -1,6 +1,9 @@
 export interface DepositToggleStyleProps {}
 
-export interface DepositToggleCustomProps {}
+export interface DepositToggleCustomProps {
+  isDeposit: boolean;
+  onToggle: () => void;
+}
 
 export type DepositToggleOptionProps = DepositToggleStyleProps & DepositToggleCustomProps;
 

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
@@ -1,0 +1,7 @@
+export interface DepositToggleStyleProps {}
+
+export interface DepositToggleCustomProps {}
+
+export type DepositToggleOptionProps = DepositToggleStyleProps & DepositToggleCustomProps;
+
+export type DepositToggleProps = React.ComponentProps<'div'> & DepositToggleOptionProps;

--- a/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
+++ b/client/src/components/Design/components/DepositToggle/DepositToggle.type.ts
@@ -1,8 +1,16 @@
-export interface DepositToggleStyleProps {}
+import {Theme} from '@components/Design/theme/theme.type';
+
+export interface DepositToggleStyleProps {
+  isDeposit: boolean;
+}
 
 export interface DepositToggleCustomProps {
   isDeposit: boolean;
   onToggle: () => void;
+}
+
+export interface DepositToggleStylePropsWithTheme extends DepositToggleStyleProps {
+  theme: Theme;
 }
 
 export type DepositToggleOptionProps = DepositToggleStyleProps & DepositToggleCustomProps;

--- a/client/src/components/Design/components/Text/Text.style.ts
+++ b/client/src/components/Design/components/Text/Text.style.ts
@@ -23,6 +23,8 @@ export const getSizeStyling = ({size, textColor, theme}: Required<TextStyleProps
 
   const baseStyle = css({
     whiteSpace: 'pre-line',
+    transition: '0.2s',
+    transitionTimingFunction: 'cubic-bezier(0.7, 0.62, 0.62, 1.16)',
   });
 
   return [style[size], colorStyle, baseStyle];


### PR DESCRIPTION
## issue
- close #554 

## 구현 사항

DepositToggle의 디자인 컴포넌트를 구현했습니다.

<img width="134" alt="스크린샷 2024-09-12 17 40 04" src="https://github.com/user-attachments/assets/fdbe5a2b-effd-4de4-aa16-93d7f30086e9">

<img width="125" alt="스크린샷 2024-09-12 17 40 16" src="https://github.com/user-attachments/assets/ed332928-175c-44f3-8872-288a84f8d0e5">

- 디자인 수정
    
    issue에 올린 Toggle의 디자인은 Button 컴포넌트를 활용하여 디자인한 것입니다.
    
    그러나, 해당 Toggle은 Button 컴포넌트를 활용해서는 만들 수 없습니다. 따라서, 이전에 Button 컴포넌트로 font 사이즈가 맞춰져 있던 것을 일반 Text 컴포넌트의 font 사이즈로 변경했습니다.
    
    font 사이즈는 12px로 동일하나 line-height, padding을 변경해줬습니다.
    
- div 태그에 `role=”button”`
    
    button 태그를 활용하려고 했으나, 퍼블리싱이 원하는 대로 동작하지 않는 이슈가 발생했습니다. 이는 아마도 모든 태그의 스타일을 초기화하기 때문이 아닐까.. 싶은...
    
    따라서 div 태그를 활용하여 Toggle을 만들어줬습니다. 그러나 스크린 리더기에서는 해당 div가 버튼인지를 모를 것입니다. 그렇기에 div 태그에 role 속성을 추가해줬습니다. 
    
    role 속성을 button으로 지정해주면, 스크린 리더기에서 해당 div가 button임을 인지할 수 있습니다.

- onToggle시 배경색 이동 애니메이션
    
    onToggle된 값(입금 확인/미입금)에는 흰색 배경색이 들어갑니다. 이때, DepositToggle을 클릭하면 그 반대의 값 (true면 false, false면 true)으로 변경됩니다. 그러면서 흰 배경색도 해당 값으로 이동하게 됩니다. 이때, 이동하는 배경색에 애니메이션을 줬습니다. (대-토다리)

    toggle-background라는 클래스 이름을 가진 div 태그는 흰색 배경색을 가집니다. 그리고 Text 컴포넌트는 zIndex 5를 가집니다. 이 흰색 배경은 isDeposit 값에 따라 위치가 변경됩니다.

    https://github.com/user-attachments/assets/9fa9e285-8225-4c57-b067-6c263667e34b

## 🫡 참고사항
페이지까지 만들려고 했는데, 애니메이션에서 죽쒀서 못 만들어쒀여 ㅎ... 
