### PR TITLE
[BE] MemberAction 제거로 인한 Bill 도메인의 테스트 변경사항 반영 to feature/#546

### DIFF
--- a/server/src/main/java/server/haengdong/domain/action/Bill.java
+++ b/server/src/main/java/server/haengdong/domain/action/Bill.java
@@ -72,9 +72,7 @@ public class Bill {
         }
     }
 
-    public static Bill create(
-            Event event, String title, Long price, List<Member> members
-    ) {
+    public static Bill create(Event event, String title, Long price, List<Member> members) {
         Bill bill = new Bill(event, title, price);
         bill.resetBillDetails(members);
         return bill;
@@ -165,6 +163,7 @@ public class Bill {
                 .findFirst()
                 .orElseGet(() -> DEFAULT_PRICE);
     }
+
     public List<Member> getMembers() {
         return billDetails.stream()
                 .map(BillDetail::getMember)

--- a/server/src/main/java/server/haengdong/domain/action/Bill.java
+++ b/server/src/main/java/server/haengdong/domain/action/Bill.java
@@ -129,7 +129,7 @@ public class Bill {
         resetBillDetails();
     }
 
-    private void addDetail(BillDetail billDetail) {
+    public void addDetail(BillDetail billDetail) {
         this.billDetails.add(billDetail);
         billDetail.setBill(this);
     }

--- a/server/src/main/java/server/haengdong/domain/action/BillDetailRepository.java
+++ b/server/src/main/java/server/haengdong/domain/action/BillDetailRepository.java
@@ -2,10 +2,18 @@ package server.haengdong.domain.action;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BillDetailRepository extends JpaRepository<BillDetail, Long> {
 
     List<BillDetail> findAllByBill(Bill bill);
+
+    @Query("""
+            select bd from BillDetail bd
+            join fetch bd.member
+            where bd.bill.id = :billId
+            """)
+    List<BillDetail> findAllByBillId(Long billId);
 }

--- a/server/src/main/java/server/haengdong/presentation/BillController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillController.java
@@ -37,9 +37,9 @@ public class BillController {
     @GetMapping("/api/events/{eventId}/bills/{billId}/fixed")
     public ResponseEntity<BillDetailsResponse> findBillDetails(
             @PathVariable("eventId") String token,
-            @PathVariable("actionId") Long actionId
+            @PathVariable("billId") Long billId
     ) {
-        BillDetailsAppResponse appResponse = billService.findBillDetails(token, actionId);
+        BillDetailsAppResponse appResponse = billService.findBillDetails(token, billId);
 
         return ResponseEntity.ok(BillDetailsResponse.of(appResponse));
     }

--- a/server/src/main/java/server/haengdong/presentation/BillController.java
+++ b/server/src/main/java/server/haengdong/presentation/BillController.java
@@ -20,7 +20,7 @@ public class BillController {
     private final BillService billService;
 
     @GetMapping("/api/events/{eventId}/bills")
-    public ResponseEntity<StepsResponse> findActions(@PathVariable("eventId") String token) {
+    public ResponseEntity<StepsResponse> findBills(@PathVariable("eventId") String token) {
         StepsResponse stepsResponse = StepsResponse.of(billService.findSteps(token));
 
         return ResponseEntity.ok(stepsResponse);

--- a/server/src/test/java/server/haengdong/application/BillServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillServiceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import server.haengdong.application.request.BillAppRequest;
 import server.haengdong.application.request.BillDetailUpdateAppRequest;
 import server.haengdong.application.request.BillDetailsUpdateAppRequest;
 import server.haengdong.application.response.BillAppResponse;
@@ -68,34 +69,29 @@ class BillServiceTest extends ServiceTestSupport {
                         tuple(member.getId(), member.getName())
                 );
     }
-//
-//    @DisplayName("지출 내역을 생성한다.")
-//    @Test
-//    void saveBillAction() {
-//        Event event = Fixture.EVENT1;
-//        Event savedEvent = eventRepository.save(event);
-//        Sequence sequence1 = Sequence.createFirst();
-//        Sequence sequence2 = sequence1.next();
-//        MemberAction memberAction1 = new MemberAction(event, sequence1, "백호", MemberActionStatus.IN);
-//        MemberAction memberAction2 = new MemberAction(event, sequence2, "망쵸", MemberActionStatus.IN);
-//        memberActionRepository.saveAll(List.of(memberAction1, memberAction2));
-//
-//        List<BillAppRequest> requests = List.of(
-//                new BillAppRequest("뽕족", 10_000L),
-//                new BillAppRequest("인생맥주", 15_000L)
-//        );
-//
-//        billService.saveAllBillAction(event.getToken(), requests);
-//
-//        List<Bill> actions = billActionRepository.findByEvent(savedEvent);
-//
-//        assertThat(actions).extracting(Bill::getTitle, Bill::getPrice, Bill::getSequence)
-//                .containsExactlyInAnyOrder(
-//                        tuple("뽕족", 10_000L, new Sequence(3L)),
-//                        tuple("인생맥주", 15_000L, new Sequence(4L))
-//                );
-//    }
-//
+
+    @DisplayName("지출 내역을 생성한다.")
+    @Test
+    void saveBillAction() {
+        Event event = Fixture.EVENT1;
+        Event savedEvent = eventRepository.save(event);
+
+        Member member1 = Fixture.MEMBER1;
+        Member member2 = Fixture.MEMBER2;
+        memberRepository.saveAll(List.of(member1, member2));
+        List<Long> memberIds = List.of(member1.getId(), member2.getId());
+        BillAppRequest billAppRequest = new BillAppRequest("뽕족", 10_000L, memberIds);
+
+        billService.saveBill(event.getToken(), billAppRequest);
+
+        List<Bill> actions = billRepository.findByEvent(savedEvent);
+
+        assertThat(actions).extracting(Bill::getTitle, Bill::getPrice)
+                .containsExactlyInAnyOrder(
+                        tuple("뽕족", 10_000L)
+                );
+    }
+
 //    @DisplayName("지출 내역을 생성하면 지출 상세 내역이 생성된다.")
 //    @Test
 //    void saveBillActionTest1() {

--- a/server/src/test/java/server/haengdong/application/BillServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillServiceTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import server.haengdong.application.request.BillDetailUpdateAppRequest;
 import server.haengdong.application.request.BillDetailsUpdateAppRequest;
 import server.haengdong.application.response.BillAppResponse;
+import server.haengdong.application.response.BillDetailAppResponse;
+import server.haengdong.application.response.BillDetailsAppResponse;
 import server.haengdong.application.response.MemberAppResponse;
 import server.haengdong.application.response.StepAppResponse;
 import server.haengdong.domain.action.Bill;
@@ -290,27 +292,28 @@ class BillServiceTest extends ServiceTestSupport {
                         tuple(billDetails.get(1).getId(), 7000L)
                 );
     }
-//
-//    @DisplayName("참여자별 지출 금액을 조회한다.")
-//    @Test
-//    void findBillDetailsTest() {
-//        Event event1 = Fixture.EVENT1;
-//        eventRepository.save(event1);
-//        Sequence sequence = Sequence.createFirst();
-//        Bill billAction = new Bill(event1, sequence, "뽕족", 10000L);
-//        billActionRepository.save(billAction);
-//        BillDetail billActionDetail1 = new BillDetail(billAction, "토다리", 6000L, true);
-//        BillDetail billActionDetail2 = new BillDetail(billAction, "쿠키", 4000L, true);
-//        billActionDetailRepository.saveAll(List.of(billActionDetail1, billActionDetail2));
-//
-//        BillDetailsAppResponse response = billDetailService.findBillDetails(
-//                event1.getToken(), billAction.getId());
-//
-//        assertThat(response.billDetails()).hasSize(2)
-//                .extracting(BillDetailAppResponse::memberName, BillDetailAppResponse::price)
-//                .containsExactly(
-//                        tuple("토다리", 6000L),
-//                        tuple("쿠키", 4000L)
-//                );
-//    }
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillDetailsTest() {
+        Event event1 = Fixture.EVENT1;
+        eventRepository.save(event1);
+
+        Member member1 = Fixture.MEMBER1;
+        Member member2 = Fixture.MEMBER2;
+        List<Member> members = List.of(member1, member2);
+        memberRepository.saveAll(members);
+
+        Bill bill = Bill.create(event1, "뽕족", 10000L, members);
+        billRepository.save(bill);
+
+        BillDetailsAppResponse response = billService.findBillDetails(event1.getToken(), bill.getId());
+
+        assertThat(response.billDetails()).hasSize(2)
+                .extracting(BillDetailAppResponse::memberName, BillDetailAppResponse::price)
+                .containsExactly(
+                        tuple("토다리", 5000L),
+                        tuple("쿠키", 5000L)
+                );
+    }
 }

--- a/server/src/test/java/server/haengdong/application/BillServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/BillServiceTest.java
@@ -137,7 +137,7 @@ class BillServiceTest extends ServiceTestSupport {
                 .isInstanceOf(HaengdongException.class);
     }
 
-    @DisplayName("지출 액션을 수정한다.")
+    @DisplayName("지출을 수정한다.")
     @Test
     void updateBillAction() {
         Event event = Fixture.EVENT1;
@@ -159,7 +159,7 @@ class BillServiceTest extends ServiceTestSupport {
         );
     }
 
-    @DisplayName("행사에 속하지 않은 지출 액션은 수정할 수 없다.")
+    @DisplayName("행사에 속하지 않은 지출은 수정할 수 없다.")
     @Test
     void updateBillAction1() {
         Event event1 = Fixture.EVENT1;

--- a/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
@@ -28,6 +28,7 @@ import server.haengdong.presentation.admin.AdminBillController;
 import server.haengdong.presentation.request.BillDetailUpdateRequest;
 import server.haengdong.presentation.request.BillDetailsUpdateRequest;
 import server.haengdong.presentation.request.BillSaveRequest;
+import server.haengdong.presentation.request.BillUpdateRequest;
 import server.haengdong.support.fixture.Fixture;
 
 class AdminBillControllerDocsTest extends RestDocsSupport {
@@ -71,36 +72,36 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
                 ));
     }
 
-//    @DisplayName("지출 액션을 수정한다.")
-//    @Test
-//    void updateBillAction() throws Exception {
-//        BillActionUpdateRequest request = new BillActionUpdateRequest("뽕족", 10_000L);
-//
-//        String requestBody = objectMapper.writeValueAsString(request);
-//        String eventId = "웨디토큰";
-//
-//        mockMvc.perform(put("/api/admin/events/{eventId}/bill-actions/{actionId}", eventId, 1L)
-//                        .cookie(EVENT_COOKIE)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(requestBody))
-//                .andDo(print())
-//                .andExpect(status().isOk())
-//                .andDo(document("updateBillAction",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("eventId").description("행사 ID"),
-//                                parameterWithName("actionId").description("지출 액션 ID")
-//                        ),
-//                        requestCookies(
-//                                cookieWithName("eventToken").description("행사 관리자 토큰")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("title").description("수정할 지출 액션의 제목"),
-//                                fieldWithPath("price").description("수정할 지출 액션의 금액")
-//                        )
-//                ));
-//    }
+    @DisplayName("지출 액션을 수정한다.")
+    @Test
+    void updateBillAction() throws Exception {
+        BillUpdateRequest request = new BillUpdateRequest("뽕족", 10_000L);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "웨디토큰";
+
+        mockMvc.perform(put("/api/admin/events/{eventId}/bills/{billId}", eventId, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("updateBillAction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("eventId").description("행사 ID"),
+                                parameterWithName("billId").description("지출 액션 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName("eventToken").description("행사 관리자 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("수정할 지출 액션의 제목"),
+                                fieldWithPath("price").description("수정할 지출 액션의 금액")
+                        )
+                ));
+    }
 
     @DisplayName("참여자별 지출 금액을 수정한다.")
     @Test

--- a/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
@@ -42,7 +42,7 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
 
     @DisplayName("지출 내역을 생성한다.")
     @Test
-    void saveAllBillAction() throws Exception {
+    void saveAllBill() throws Exception {
         List<Long> members = List.of(1L, 2L);
         BillSaveRequest request = new BillSaveRequest("뽕족", 10_000L, members);
 
@@ -72,9 +72,9 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
                 ));
     }
 
-    @DisplayName("지출 액션을 수정한다.")
+    @DisplayName("지출을 수정한다.")
     @Test
-    void updateBillAction() throws Exception {
+    void updateBill() throws Exception {
         BillUpdateRequest request = new BillUpdateRequest("뽕족", 10_000L);
 
         String requestBody = objectMapper.writeValueAsString(request);
@@ -86,32 +86,32 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
                         .cookie(EVENT_COOKIE))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andDo(document("updateBillAction",
+                .andDo(document("updateBill",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("eventId").description("행사 ID"),
-                                parameterWithName("billId").description("지출 액션 ID")
+                                parameterWithName("billId").description("지출 ID")
                         ),
                         requestCookies(
                                 cookieWithName("eventToken").description("행사 관리자 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("title").description("수정할 지출 액션의 제목"),
-                                fieldWithPath("price").description("수정할 지출 액션의 금액")
+                                fieldWithPath("title").description("수정할 지출 제목"),
+                                fieldWithPath("price").description("수정할 지출 금액")
                         )
                 ));
     }
 
     @DisplayName("참여자별 지출 금액을 수정한다.")
     @Test
-    void updateBillActionDetailsTest() throws Exception {
-        List<BillDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
+    void updateBillDetailsTest() throws Exception {
+        List<BillDetailUpdateRequest> billDetailUpdateRequests = List.of(
                 new BillDetailUpdateRequest(1L, 10000L, true),
                 new BillDetailUpdateRequest(2L, 20000L, true)
         );
         BillDetailsUpdateRequest request = new BillDetailsUpdateRequest(
-                billActionDetailUpdateRequests);
+                billDetailUpdateRequests);
 
         String json = objectMapper.writeValueAsString(request);
 
@@ -148,7 +148,7 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
 
     @DisplayName("지출 내역을 삭제한다.")
     @Test
-    void deleteBillAction() throws Exception {
+    void deleteBill() throws Exception {
         String eventId = "토다리토큰";
 
         mockMvc.perform(delete("/api/admin/events/{eventId}/bills/{billId}", eventId, 1)

--- a/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/AdminBillControllerDocsTest.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWit
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -26,6 +27,8 @@ import server.haengdong.application.BillService;
 import server.haengdong.presentation.admin.AdminBillController;
 import server.haengdong.presentation.request.BillDetailUpdateRequest;
 import server.haengdong.presentation.request.BillDetailsUpdateRequest;
+import server.haengdong.presentation.request.BillSaveRequest;
+import server.haengdong.support.fixture.Fixture;
 
 class AdminBillControllerDocsTest extends RestDocsSupport {
 
@@ -36,41 +39,38 @@ class AdminBillControllerDocsTest extends RestDocsSupport {
         return new AdminBillController(billService);
     }
 
-//    @DisplayName("지출 내역을 생성한다.")
-//    @Test
-//    void saveAllBillAction() throws Exception {
-//        BillActionsSaveRequest request = new BillActionsSaveRequest(
-//                List.of(
-//                        new BillActionSaveRequest("뽕족", 10_000L),
-//                        new BillActionSaveRequest("인생맥주", 10_000L)
-//                )
-//        );
-//        String requestBody = objectMapper.writeValueAsString(request);
-//        String eventId = "쿠키토큰";
-//
-//        mockMvc.perform(post("/api/admin/events/{eventId}/bill-actions", eventId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .cookie(EVENT_COOKIE)
-//                        .content(requestBody))
-//                .andDo(print())
-//                .andExpect(status().isOk())
-//                .andDo(document("createBillActions",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("eventId").description("행사 ID")
-//                        ),
-//                        requestCookies(
-//                                cookieWithName("eventToken").description("행사 관리자 토큰")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("actions").description("생성할 지출 액션 목록"),
-//                                fieldWithPath("actions[0].title").description("생성할 지출 액션의 제목"),
-//                                fieldWithPath("actions[0].price").description("생성할 지출 액션의 금액")
-//                        )
-//                ));
-//    }
-//
+    @DisplayName("지출 내역을 생성한다.")
+    @Test
+    void saveAllBillAction() throws Exception {
+        List<Long> members = List.of(1L, 2L);
+        BillSaveRequest request = new BillSaveRequest("뽕족", 10_000L, members);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "쿠키토큰";
+
+        mockMvc.perform(post("/api/admin/events/{eventId}/bills", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .cookie(Fixture.EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("createBillActions",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("eventId").description("행사 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName("eventToken").description("행사 관리자 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("생성할 지출 제목"),
+                                fieldWithPath("price").description("생성할 지출 금액"),
+                                fieldWithPath("members").description("생성할 지출의 참여인원")
+                        )
+                ));
+    }
+
 //    @DisplayName("지출 액션을 수정한다.")
 //    @Test
 //    void updateBillAction() throws Exception {

--- a/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
@@ -69,10 +69,22 @@ public class BillControllerDocsTest extends RestDocsSupport {
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("steps").description("지출 차수 목록"),
+                                        fieldWithPath("steps[].bills").description("해당 차수의 지출 내역"),
+                                        fieldWithPath("steps[].bills[].id").description("지출 ID"),
+                                        fieldWithPath("steps[].bills[].title").description("지출 이름"),
+                                        fieldWithPath("steps[].bills[].price").description("지출 금액"),
+                                        fieldWithPath("steps[].bills[].isFixed").description("지출 수정 여부"),
+                                        fieldWithPath("steps[].members").description("해당 차수의 참여자 목록"),
+                                        fieldWithPath("steps[].members[].id").description("참여자 ID"),
+                                        fieldWithPath("steps[].members[].name").description("참여자 이름")
                                 )
                         )
                 );
     }
+
 
     @DisplayName("참여자별 지출 금액을 조회한다.")
     @Test

--- a/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
@@ -1,0 +1,71 @@
+package server.haengdong.docs;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.haengdong.application.BillService;
+import server.haengdong.application.response.BillAppResponse;
+import server.haengdong.application.response.MemberAppResponse;
+import server.haengdong.application.response.StepAppResponse;
+import server.haengdong.domain.action.Bill;
+import server.haengdong.domain.action.Member;
+import server.haengdong.presentation.BillController;
+import server.haengdong.support.fixture.Fixture;
+
+public class BillControllerDocsTest extends RestDocsSupport {
+
+    private final BillService billService = mock(BillService.class);
+
+    @Override
+    protected Object initController() {
+        return new BillController(billService);
+    }
+
+    @DisplayName("전체 지출 내역을 조회한다.")
+    @Test
+    void findBills() throws Exception {
+        Bill bill = Fixture.BILL1;
+        List<BillAppResponse> bills = List.of(BillAppResponse.of(bill));
+
+        Member member = Fixture.MEMBER1;
+        List<MemberAppResponse> members = List.of(MemberAppResponse.of(member));
+
+        StepAppResponse stepAppResponse = new StepAppResponse(bills, members);
+        given(billService.findSteps(anyString())).willReturn(List.of(stepAppResponse));
+
+        mockMvc.perform(get("/api/events/{eventId}/bills", "token"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps").isArray())
+                .andExpect(jsonPath("$.steps[0].bills").isArray())
+                .andExpect(jsonPath("$.steps[0].bills[0].id").value(bill.getId()))
+                .andExpect(jsonPath("$.steps[0].bills[0].title").value(bill.getTitle()))
+                .andExpect(jsonPath("$.steps[0].bills[0].price").value(bill.getPrice()))
+                .andExpect(jsonPath("$.steps[0].bills[0].isFixed").value(bill.isFixed()))
+                .andExpect(jsonPath("$.steps[0].members").isArray())
+                .andExpect(jsonPath("$.steps[0].members[0].id").value(member.getId()))
+                .andExpect(jsonPath("$.steps[0].members[0].name").value(member.getName()))
+                .andDo(document("findBills",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID")
+                                )
+                        )
+                );
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
@@ -1,5 +1,6 @@
 package server.haengdong.docs;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import server.haengdong.application.BillService;
 import server.haengdong.application.response.BillAppResponse;
+import server.haengdong.application.response.BillDetailAppResponse;
+import server.haengdong.application.response.BillDetailsAppResponse;
 import server.haengdong.application.response.MemberAppResponse;
 import server.haengdong.application.response.StepAppResponse;
 import server.haengdong.domain.action.Bill;
@@ -64,6 +67,31 @@ public class BillControllerDocsTest extends RestDocsSupport {
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillActionDetails() throws Exception {
+        BillDetailsAppResponse appResponse = new BillDetailsAppResponse(
+                List.of(new BillDetailAppResponse(1L, "토다리", 1000L, false)));
+        given(billService.findBillDetails(anyString(), anyLong())).willReturn(appResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/bills/{billId}/fixed", "TOKEN", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members[0].id").value(1L))
+                .andExpect(jsonPath("$.members[0].memberName").value("토다리"))
+                .andExpect(jsonPath("$.members[0].price").value(1000L))
+                .andExpect(jsonPath("$.members[0].isFixed").value(false))
+                .andDo(document("findBillActionDetails",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("eventId").description("행사 ID"),
+                                        parameterWithName("billId").description("지출 ID")
                                 )
                         )
                 );

--- a/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
@@ -9,6 +9,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -92,6 +94,12 @@ public class BillControllerDocsTest extends RestDocsSupport {
                                 pathParameters(
                                         parameterWithName("eventId").description("행사 ID"),
                                         parameterWithName("billId").description("지출 ID")
+                                ), responseFields(
+                                        fieldWithPath("members").description("참여자 목록"),
+                                        fieldWithPath("members[].id").description("참여자 ID"),
+                                        fieldWithPath("members[].memberName").description("참여자 이름"),
+                                        fieldWithPath("members[].price").description("참여자별 지출 금액"),
+                                        fieldWithPath("members[].isFixed").description("지출 수정 여부")
                                 )
                         )
                 );

--- a/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
@@ -1,0 +1,47 @@
+package server.haengdong.presentation;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.haengdong.application.response.BillAppResponse;
+import server.haengdong.application.response.MemberAppResponse;
+import server.haengdong.application.response.StepAppResponse;
+import server.haengdong.domain.action.Bill;
+import server.haengdong.domain.action.Member;
+import server.haengdong.support.fixture.Fixture;
+
+public class BillControllerTest extends ControllerTestSupport {
+
+    @DisplayName("전체 지출 내역을 조회한다.")
+    @Test
+    void findBills() throws Exception {
+        Bill bill = Fixture.BILL1;
+        List<BillAppResponse> bills = List.of(BillAppResponse.of(bill));
+
+        Member member = Fixture.MEMBER1;
+        List<MemberAppResponse> members = List.of(MemberAppResponse.of(member));
+
+        StepAppResponse stepAppResponse = new StepAppResponse(bills, members);
+        given(billService.findSteps(anyString())).willReturn(List.of(stepAppResponse));
+
+        mockMvc.perform(get("/api/events/{eventId}/bills", "token"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps").isArray())
+                .andExpect(jsonPath("$.steps[0].bills").isArray())
+                .andExpect(jsonPath("$.steps[0].bills[0].id").value(bill.getId()))
+                .andExpect(jsonPath("$.steps[0].bills[0].title").value(bill.getTitle()))
+                .andExpect(jsonPath("$.steps[0].bills[0].price").value(bill.getPrice()))
+                .andExpect(jsonPath("$.steps[0].bills[0].isFixed").value(bill.isFixed()))
+                .andExpect(jsonPath("$.steps[0].members").isArray())
+                .andExpect(jsonPath("$.steps[0].members[0].id").value(member.getId()))
+                .andExpect(jsonPath("$.steps[0].members[0].name").value(member.getName()));
+    }
+}

--- a/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
@@ -1,5 +1,6 @@
 package server.haengdong.presentation;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -11,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import server.haengdong.application.response.BillAppResponse;
+import server.haengdong.application.response.BillDetailAppResponse;
+import server.haengdong.application.response.BillDetailsAppResponse;
 import server.haengdong.application.response.MemberAppResponse;
 import server.haengdong.application.response.StepAppResponse;
 import server.haengdong.domain.action.Bill;
@@ -43,5 +46,21 @@ public class BillControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.steps[0].members").isArray())
                 .andExpect(jsonPath("$.steps[0].members[0].id").value(member.getId()))
                 .andExpect(jsonPath("$.steps[0].members[0].name").value(member.getName()));
+    }
+
+    @DisplayName("참여자별 지출 금액을 조회한다.")
+    @Test
+    void findBillActionDetails() throws Exception {
+        BillDetailsAppResponse appResponse = new BillDetailsAppResponse(
+                List.of(new BillDetailAppResponse(1L, "토다리", 1000L, false)));
+        given(billService.findBillDetails(anyString(), anyLong())).willReturn(appResponse);
+
+        mockMvc.perform(get("/api/events/{eventId}/bills/{billId}/fixed", "TOKEN", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members[0].id").value(1L))
+                .andExpect(jsonPath("$.members[0].memberName").value("토다리"))
+                .andExpect(jsonPath("$.members[0].price").value(1000L))
+                .andExpect(jsonPath("$.members[0].isFixed").value(false));
     }
 }

--- a/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static server.haengdong.support.fixture.Fixture.EVENT_COOKIE;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,7 @@ import server.haengdong.presentation.ControllerTestSupport;
 import server.haengdong.presentation.request.BillDetailUpdateRequest;
 import server.haengdong.presentation.request.BillDetailsUpdateRequest;
 import server.haengdong.presentation.request.BillSaveRequest;
-import server.haengdong.support.fixture.Fixture;
+import server.haengdong.presentation.request.BillUpdateRequest;
 
 class AdminBillControllerTest extends ControllerTestSupport {
 
@@ -35,44 +36,42 @@ class AdminBillControllerTest extends ControllerTestSupport {
         mockMvc.perform(post("/api/admin/events/{eventId}/bills", eventId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody)
-                        .cookie(Fixture.EVENT_COOKIE))
+                        .cookie(EVENT_COOKIE))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
 
-//    @DisplayName("title이 비어 있는 경우 지출 내역을 생성할 수 없다.")
-//    @Test
-//    void saveAllBillAction1() throws Exception {
-//        BillActionsSaveRequest request = new BillActionsSaveRequest(
-//                List.of(
-//                        new BillActionSaveRequest("", 10_000L),
-//                        new BillActionSaveRequest("인생맥주", 10_000L)
-//                )
-//        );
-//        String requestBody = objectMapper.writeValueAsString(request);
-//        String eventId = "소하토큰";
-//
-//        mockMvc.perform(post("/api/admin/events/{eventId}/bill-actions", eventId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(requestBody))
-//                .andDo(print())
-//                .andExpect(status().isBadRequest());
-//    }
-//
-//    @DisplayName("지출 액션을 수정한다.")
-//    @Test
-//    void updateBillAction() throws Exception {
-//        BillActionUpdateRequest request = new BillActionUpdateRequest("뽕족", 10_000L);
-//
-//        String requestBody = objectMapper.writeValueAsString(request);
-//        String eventId = "웨디토큰";
-//
-//        mockMvc.perform(put("/api/admin/events/{eventId}/bill-actions/{actionId}", eventId, 1L)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(requestBody))
-//                .andDo(print())
-//                .andExpect(status().isOk());
-//    }
+    @DisplayName("title이 비어 있는 경우 지출 내역을 생성할 수 없다.")
+    @Test
+    void saveAllBillAction1() throws Exception {
+        List<Long> members = List.of(1L, 2L);
+        BillSaveRequest request = new BillSaveRequest("", 10_000L, members);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "소하토큰";
+
+        mockMvc.perform(post("/api/admin/events/{eventId}/bill-actions", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("지출 액션을 수정한다.")
+    @Test
+    void updateBillAction() throws Exception {
+        BillUpdateRequest request = new BillUpdateRequest("뽕족", 10_000L);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "웨디토큰";
+
+        mockMvc.perform(put("/api/admin/events/{eventId}/bills/{billId}", eventId, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .cookie(EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
 
     @DisplayName("지출 내역을 삭제한다.")
     @Test

--- a/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
@@ -50,7 +50,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
         String requestBody = objectMapper.writeValueAsString(request);
         String eventId = "소하토큰";
 
-        mockMvc.perform(post("/api/admin/events/{eventId}/bill-actions", eventId)
+        mockMvc.perform(post("/api/admin/events/{eventId}/bills", eventId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andDo(print())

--- a/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,28 +18,28 @@ import server.haengdong.exception.HaengdongException;
 import server.haengdong.presentation.ControllerTestSupport;
 import server.haengdong.presentation.request.BillDetailUpdateRequest;
 import server.haengdong.presentation.request.BillDetailsUpdateRequest;
+import server.haengdong.presentation.request.BillSaveRequest;
+import server.haengdong.support.fixture.Fixture;
 
 class AdminBillControllerTest extends ControllerTestSupport {
 
-//    @DisplayName("지출 내역을 생성한다.")
-//    @Test
-//    void saveAllBillAction() throws Exception {
-//        BillActionsSaveRequest request = new BillActionsSaveRequest(
-//                List.of(
-//                        new BillActionSaveRequest("뽕족", 10_000L),
-//                        new BillActionSaveRequest("인생맥주", 10_000L)
-//                )
-//        );
-//        String requestBody = objectMapper.writeValueAsString(request);
-//        String eventId = "쿠키토큰";
-//
-//        mockMvc.perform(post("/api/admin/events/{eventId}/bill-actions", eventId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(requestBody))
-//                .andDo(print())
-//                .andExpect(status().isOk());
-//    }
-//
+    @DisplayName("지출 내역을 생성한다.")
+    @Test
+    void saveAllBillAction() throws Exception {
+        List<Long> members = List.of(1L, 2L);
+        BillSaveRequest request = new BillSaveRequest("뽕족", 10_000L, members);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+        String eventId = "쿠키토큰";
+
+        mockMvc.perform(post("/api/admin/events/{eventId}/bills", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .cookie(Fixture.EVENT_COOKIE))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
 //    @DisplayName("title이 비어 있는 경우 지출 내역을 생성할 수 없다.")
 //    @Test
 //    void saveAllBillAction1() throws Exception {

--- a/server/src/test/java/server/haengdong/support/fixture/Fixture.java
+++ b/server/src/test/java/server/haengdong/support/fixture/Fixture.java
@@ -11,7 +11,7 @@ public class Fixture {
     public static final Event EVENT2 = new Event("웨디", "1234", "TOKEN2");
     public static final Cookie EVENT_COOKIE = new Cookie("eventToken", "토큰토큰");
     public static final Member MEMBER1 = new Member(EVENT1, "토다리");
-    public static final Member MEMBER2 = new Member(EVENT2, "쿠키");
+    public static final Member MEMBER2 = new Member(EVENT1, "쿠키");
     public static final Bill BILL1 = new Bill(EVENT1, "행동대장 회식", 10000L);
     public static final Bill BILL2 = new Bill(EVENT2, "행동대장 회식2", 20000L);
 //    public static final Bill BILL_ACTION = new Bill(EVENT1, new Sequence(1L), "뽕족", 30_000L);

--- a/server/src/test/java/server/haengdong/support/fixture/Fixture.java
+++ b/server/src/test/java/server/haengdong/support/fixture/Fixture.java
@@ -1,13 +1,19 @@
 package server.haengdong.support.fixture;
 
 import jakarta.servlet.http.Cookie;
+import server.haengdong.domain.action.Bill;
+import server.haengdong.domain.action.Member;
 import server.haengdong.domain.event.Event;
 
 public class Fixture {
-//
+
     public static final Event EVENT1 = new Event("쿠키", "1234", "TOKEN1");
     public static final Event EVENT2 = new Event("웨디", "1234", "TOKEN2");
     public static final Cookie EVENT_COOKIE = new Cookie("eventToken", "토큰토큰");
+    public static final Member MEMBER1 = new Member(EVENT1, "토다리");
+    public static final Member MEMBER2 = new Member(EVENT2, "쿠키");
+    public static final Bill BILL1 = new Bill(EVENT1, "행동대장 회식", 10000L);
+    public static final Bill BILL2 = new Bill(EVENT2, "행동대장 회식2", 20000L);
 //    public static final Bill BILL_ACTION = new Bill(EVENT1, new Sequence(1L), "뽕족", 30_000L);
 //
 //    public static Bill createBillAction(Event event, Long sequence, String title, Long price) {


### PR DESCRIPTION
feature/#546-part1 브랜치에서 작업 후, feature/#546 브랜치에 push pr 올립니다.

## 구현 사항
1. 지출 전체 조회
2. 지출 고정 금액 조회
3. 지출 내역 추가
4. 지출 수정

RestDocs, 컨트롤러, 서비스 테스트코드를 수정했습니다.