### PR TITLE
[BE] Domain 패키지와 Exception 패키지간의 순환 참조 해결

### DIFF
--- a/server/src/docs/asciidoc/bill.adoc
+++ b/server/src/docs/asciidoc/bill.adoc
@@ -75,7 +75,7 @@ operation::updateBill[snippets="path-parameters,http-request,request-body,reques
    },
    {
       "code":"BILL_NOT_FOUND",
-      "message":"존재하지 않는 지출 액션입니다."
+      "message":"존재하지 않는 지출입니다."
    },
    {
       "code":"TOKEN_NOT_FOUND",

--- a/server/src/docs/asciidoc/billDetail.adoc
+++ b/server/src/docs/asciidoc/billDetail.adoc
@@ -15,7 +15,7 @@ operation::findBillDetails[snippets="path-parameters,http-request,http-response,
   },
   {
     "code": "BILL_NOT_FOUND",
-    "message": "존재하지 않는 지출 액션입니다."
+    "message": "존재하지 않는 지출입니다."
   },
   {
     "code": "BILL_DETAIL_NOT_FOUND",
@@ -63,7 +63,7 @@ operation::updateBillDetails[snippets="path-parameters,http-request,request-body
   },
   {
     "code": "BILL_NOT_FOUND",
-    "message": "존재하지 않는 지출 액션입니다."
+    "message": "존재하지 않는 지출 입니다."
   },
   {
     "code": "BILL_DETAIL_NOT_FOUND",

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -14,7 +14,7 @@ import server.haengdong.application.response.MemberBillReportAppResponse;
 import server.haengdong.domain.bill.Bill;
 import server.haengdong.domain.bill.BillRepository;
 import server.haengdong.domain.member.Member;
-import server.haengdong.domain.member.MemberBillReport;
+import server.haengdong.domain.bill.MemberBillReport;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.domain.event.EventTokenProvider;

--- a/server/src/main/java/server/haengdong/application/MemberService.java
+++ b/server/src/main/java/server/haengdong/application/MemberService.java
@@ -63,8 +63,7 @@ public class MemberService {
 
     private void validateMemberSave(List<String> memberNames, Event event) {
         if (memberNamesDuplicated(memberNames)) {
-            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE,
-                    "중복된 이름이 존재합니다. 입력된 이름: " + memberNames);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE, memberNames);
         }
         if (memberRepository.findAllByEvent(event).stream()
                 .anyMatch(member -> memberNames.contains(member.getName()))) {

--- a/server/src/main/java/server/haengdong/domain/bill/Bill.java
+++ b/server/src/main/java/server/haengdong/domain/bill/Bill.java
@@ -29,10 +29,10 @@ import server.haengdong.exception.HaengdongException;
 @Entity
 public class Bill {
 
-    public static final int MIN_TITLE_LENGTH = 1;
-    public static final int MAX_TITLE_LENGTH = 30;
-    public static final long MIN_PRICE = 1L;
-    public static final long MAX_PRICE = 10_000_000L;
+    private static final int MIN_TITLE_LENGTH = 1;
+    private static final int MAX_TITLE_LENGTH = 30;
+    private static final long MIN_PRICE = 1L;
+    private static final long MAX_PRICE = 10_000_000L;
     private static final long DEFAULT_PRICE = 0L;
 
     @Id

--- a/server/src/main/java/server/haengdong/domain/bill/Bill.java
+++ b/server/src/main/java/server/haengdong/domain/bill/Bill.java
@@ -63,13 +63,13 @@ public class Bill {
     private void validateTitle(String title) {
         int titleLength = title.trim().length();
         if (titleLength < MIN_TITLE_LENGTH || titleLength > MAX_TITLE_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.BILL_TITLE_INVALID);
+            throw new HaengdongException(HaengdongErrorCode.BILL_TITLE_INVALID, MIN_TITLE_LENGTH, MAX_TITLE_LENGTH);
         }
     }
 
     private void validatePrice(Long price) {
         if (price < MIN_PRICE || price > MAX_PRICE) {
-            throw new HaengdongException(HaengdongErrorCode.BILL_PRICE_INVALID);
+            throw new HaengdongException(HaengdongErrorCode.BILL_PRICE_INVALID, MAX_PRICE);
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/bill/MemberBillReport.java
+++ b/server/src/main/java/server/haengdong/domain/bill/MemberBillReport.java
@@ -1,12 +1,11 @@
-package server.haengdong.domain.member;
+package server.haengdong.domain.bill;
 
 import static java.util.stream.Collectors.toMap;
 
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
-import server.haengdong.domain.bill.Bill;
-import server.haengdong.domain.bill.BillDetail;
+import server.haengdong.domain.member.Member;
 
 @Getter
 public class MemberBillReport {

--- a/server/src/main/java/server/haengdong/domain/event/Bank.java
+++ b/server/src/main/java/server/haengdong/domain/event/Bank.java
@@ -40,10 +40,10 @@ public enum Bank {
         Arrays.stream(Bank.values())
                 .filter(bank -> bank.name.equals(bankName))
                 .findFirst()
-                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BANK_NAME_INVALID));
+                .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.BANK_NAME_INVALID, getSupportedBanks()));
     }
 
-    public static String getSupportedBanks() {
+    private static String getSupportedBanks() {
         return Arrays.stream(Bank.values())
                 .map(Bank::getName)
                 .reduce((bank1, bank2) -> bank1 + ", " + bank2)

--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -53,7 +53,8 @@ public class Event {
     private void validateName(String name) {
         int nameLength = name.trim().length();
         if (nameLength < MIN_NAME_LENGTH || MAX_NAME_LENGTH < nameLength) {
-            throw new HaengdongException(HaengdongErrorCode.EVENT_NAME_LENGTH_INVALID);
+            throw new HaengdongException(
+                    HaengdongErrorCode.EVENT_NAME_LENGTH_INVALID, MIN_NAME_LENGTH, MAX_NAME_LENGTH);
         }
         if (isBlankContinuous(name)) {
             throw new HaengdongException(HaengdongErrorCode.EVENT_NAME_CONSECUTIVE_SPACES);
@@ -90,7 +91,8 @@ public class Event {
     private void validateAccountNumber(String accountNumber) {
         int accountLength = accountNumber.trim().length();
         if (accountLength < MIN_ACCOUNT_NUMBER_LENGTH || MAX_ACCOUNT_NUMBER_LENGTH < accountLength) {
-            throw new HaengdongException(HaengdongErrorCode.ACCOUNT_LENGTH_INVALID);
+            throw new HaengdongException(
+                    HaengdongErrorCode.ACCOUNT_LENGTH_INVALID, MIN_ACCOUNT_NUMBER_LENGTH, MAX_ACCOUNT_NUMBER_LENGTH);
         }
     }
 }

--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -18,10 +18,10 @@ import server.haengdong.exception.HaengdongException;
 @Entity
 public class Event {
 
-    public static final int MIN_NAME_LENGTH = 1;
-    public static final int MAX_NAME_LENGTH = 20;
-    public static final int MIN_ACCOUNT_NUMBER_LENGTH = 8;
-    public static final int MAX_ACCOUNT_NUMBER_LENGTH = 30;
+    private static final int MIN_NAME_LENGTH = 1;
+    private static final int MAX_NAME_LENGTH = 20;
+    private static final int MIN_ACCOUNT_NUMBER_LENGTH = 8;
+    private static final int MAX_ACCOUNT_NUMBER_LENGTH = 30;
     private static final String SPACES = "  ";
 
     @Id

--- a/server/src/main/java/server/haengdong/domain/event/Password.java
+++ b/server/src/main/java/server/haengdong/domain/event/Password.java
@@ -31,7 +31,7 @@ public class Password {
     private void validatePassword(String password) {
         Matcher matcher = PASSWORD_PATTERN.matcher(password);
         if (!matcher.matches()) {
-            throw new HaengdongException(HaengdongErrorCode.EVENT_PASSWORD_FORMAT_INVALID);
+            throw new HaengdongException(HaengdongErrorCode.EVENT_PASSWORD_FORMAT_INVALID, PASSWORD_LENGTH);
         }
     }
 

--- a/server/src/main/java/server/haengdong/domain/event/Password.java
+++ b/server/src/main/java/server/haengdong/domain/event/Password.java
@@ -17,7 +17,7 @@ import server.haengdong.exception.HaengdongException;
 @Embeddable
 public class Password {
 
-    public static final int PASSWORD_LENGTH = 4;
+    private static final int PASSWORD_LENGTH = 4;
     private static final Pattern PASSWORD_PATTERN = Pattern.compile(String.format("^\\d{%d}$", PASSWORD_LENGTH));
     private static final String HASH_ALGORITHM = "SHA-256";
 

--- a/server/src/main/java/server/haengdong/domain/member/Member.java
+++ b/server/src/main/java/server/haengdong/domain/member/Member.java
@@ -24,8 +24,8 @@ import server.haengdong.exception.HaengdongException;
 @Entity
 public class Member {
 
-    public static final int MIN_NAME_LENGTH = 1;
-    public static final int MAX_NAME_LENGTH = 8;
+    private static final int MIN_NAME_LENGTH = 1;
+    private static final int MAX_NAME_LENGTH = 8;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/server/haengdong/domain/member/Member.java
+++ b/server/src/main/java/server/haengdong/domain/member/Member.java
@@ -56,7 +56,7 @@ public class Member {
     private void validateName(String name) {
         int nameLength = name.length();
         if (nameLength < MIN_NAME_LENGTH || nameLength > MAX_NAME_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID, MIN_NAME_LENGTH, MAX_NAME_LENGTH);
         }
     }
 

--- a/server/src/main/java/server/haengdong/exception/ErrorResponse.java
+++ b/server/src/main/java/server/haengdong/exception/ErrorResponse.java
@@ -1,15 +1,15 @@
 package server.haengdong.exception;
 
 public record ErrorResponse(
-        HaengdongErrorCode errorCode,
+        String errorCode,
         String message
 ) {
 
     public static ErrorResponse of(HaengdongErrorCode errorCode) {
-        return new ErrorResponse(errorCode, errorCode.getMessage());
+        return new ErrorResponse(errorCode.name(), errorCode.getMessage());
     }
 
     public static ErrorResponse of(HaengdongErrorCode errorCode, String message) {
-        return new ErrorResponse(errorCode, message);
+        return new ErrorResponse(errorCode.name(), message);
     }
 }

--- a/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/server/haengdong/exception/GlobalExceptionHandler.java
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> haengdongException(HttpServletRequest req, HaengdongException e) {
         log.warn(LOG_FORMAT, req.getMethod(), req.getRequestURI(), getRequestBody(req), e.getMessage(), e);
         return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(e.getErrorCode()));
+                .body(ErrorResponse.of(e.getErrorCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -1,11 +1,6 @@
 package server.haengdong.exception;
 
 import lombok.Getter;
-import server.haengdong.domain.bill.Bill;
-import server.haengdong.domain.member.Member;
-import server.haengdong.domain.event.Bank;
-import server.haengdong.domain.event.Event;
-import server.haengdong.domain.event.Password;
 
 @Getter
 public enum HaengdongErrorCode {
@@ -13,30 +8,21 @@ public enum HaengdongErrorCode {
     /* Domain */
 
     EVENT_NOT_FOUND("존재하지 않는 행사입니다."),
-    EVENT_NAME_LENGTH_INVALID(String.format("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다.",
-            Event.MIN_NAME_LENGTH,
-            Event.MAX_NAME_LENGTH)),
+    EVENT_NAME_LENGTH_INVALID("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다."),
     EVENT_NAME_CONSECUTIVE_SPACES("행사 이름에는 공백 문자가 연속될 수 없습니다."),
-    EVENT_PASSWORD_FORMAT_INVALID(String.format("비밀번호는 %d자리 숫자만 가능합니다.", Password.PASSWORD_LENGTH)),
-    BANK_NAME_INVALID(String.format("지원하지 않는 은행입니다. 지원하는 은행 목록: %s",
-            Bank.getSupportedBanks())),
-    ACCOUNT_LENGTH_INVALID(String.format("계좌번호는 %d자 이상 %d자 이하만 입력 가능합니다.",
-            Event.MIN_ACCOUNT_NUMBER_LENGTH,
-            Event.MAX_ACCOUNT_NUMBER_LENGTH)),
+    EVENT_PASSWORD_FORMAT_INVALID("비밀번호는 %d자리 숫자만 가능합니다."),
+    BANK_NAME_INVALID("지원하지 않는 은행입니다. 지원하는 은행 목록: %s"),
+    ACCOUNT_LENGTH_INVALID("계좌번호는 %d자 이상 %d자 이하만 입력 가능합니다."),
 
-    MEMBER_NAME_LENGTH_INVALID(String.format("멤버 이름은 %d자 이상 %d자 이하만 입력 가능합니다.",
-            Member.MIN_NAME_LENGTH,
-            Member.MAX_NAME_LENGTH)),
+    MEMBER_NAME_LENGTH_INVALID("멤버 이름은 %d자 이상 %d자 이하만 입력 가능합니다."),
     MEMBER_NAME_DUPLICATE("중복된 행사 참여 인원 이름이 존재합니다."),
     MEMBER_NOT_FOUND("존재하지 않는 참여자입니다."),
     MEMBER_ALREADY_EXIST("현재 참여하고 있는 인원이 존재합니다."),
     MEMBER_NAME_CHANGE_DUPLICATE("중복된 참여 인원 이름 변경 요청이 존재합니다."),
 
     BILL_NOT_FOUND("존재하지 않는 지출입니다."),
-    BILL_TITLE_INVALID(String.format("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다.",
-            Bill.MIN_TITLE_LENGTH,
-            Bill.MAX_TITLE_LENGTH)),
-    BILL_PRICE_INVALID(String.format("지출 금액은 %,d 이하의 자연수여야 합니다.", Bill.MAX_PRICE)),
+    BILL_TITLE_INVALID("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다."),
+    BILL_PRICE_INVALID("지출 금액은 %,d 이하의 자연수여야 합니다."),
     BILL_DETAIL_NOT_FOUND("존재하지 않는 참여자 지출입니다."),
     BILL_PRICE_NOT_MATCHED("지출 총액이 일치하지 않습니다."),
 

--- a/server/src/main/java/server/haengdong/exception/HaengdongException.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongException.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 public class HaengdongException extends RuntimeException {
 
     private final HaengdongErrorCode errorCode;
-    private final String message;
 
     public HaengdongException(HaengdongErrorCode errorCode) {
-        this(errorCode, errorCode.getMessage());
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 
-    public HaengdongException(HaengdongErrorCode errorCode, String message) {
+    public HaengdongException(HaengdongErrorCode errorCode, Object... args) {
+        super(String.format(errorCode.getMessage(), args));
         this.errorCode = errorCode;
-        this.message = message;
     }
 }

--- a/server/src/test/java/server/haengdong/application/MemberServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberServiceTest.java
@@ -119,7 +119,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.saveMembers(event.getToken(), request))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessageContaining("중복된 이름이 존재합니다. 입력된 이름: [토다리, 토다리]");
+                .hasMessageContaining("중복된 행사 참여 인원 이름이 존재합니다.");
     }
 
     @DisplayName("행사 참여 인원을 삭제한다.")

--- a/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/BillControllerDocsTest.java
@@ -88,7 +88,7 @@ class BillControllerDocsTest extends RestDocsSupport {
 
     @DisplayName("참여자별 지출 금액을 조회한다.")
     @Test
-    void findBillActionDetails() throws Exception {
+    void findBillDetails() throws Exception {
         BillDetailsAppResponse appResponse = new BillDetailsAppResponse(
                 List.of(new BillDetailAppResponse(1L, "토다리", 1000L, false)));
         given(billService.findBillDetails(anyString(), anyLong())).willReturn(appResponse);

--- a/server/src/test/java/server/haengdong/domain/member/MemberBillReportTest.java
+++ b/server/src/test/java/server/haengdong/domain/member/MemberBillReportTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import server.haengdong.domain.bill.Bill;
 import server.haengdong.domain.event.Event;
+import server.haengdong.domain.bill.MemberBillReport;
 import server.haengdong.support.fixture.Fixture;
 
 class MemberBillReportTest {

--- a/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/BillControllerTest.java
@@ -50,7 +50,7 @@ class BillControllerTest extends ControllerTestSupport {
 
     @DisplayName("참여자별 지출 금액을 조회한다.")
     @Test
-    void findBillActionDetails() throws Exception {
+    void findBillDetails() throws Exception {
         BillDetailsAppResponse appResponse = new BillDetailsAppResponse(
                 List.of(new BillDetailAppResponse(1L, "토다리", 1000L, false)));
         given(billService.findBillDetails(anyString(), anyLong())).willReturn(appResponse);

--- a/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/admin/AdminBillControllerTest.java
@@ -26,7 +26,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("지출 내역을 생성한다.")
     @Test
-    void saveAllBillAction() throws Exception {
+    void saveAllBill() throws Exception {
         List<Long> members = List.of(1L, 2L);
         BillSaveRequest request = new BillSaveRequest("뽕족", 10_000L, members);
 
@@ -43,7 +43,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("title이 비어 있는 경우 지출 내역을 생성할 수 없다.")
     @Test
-    void saveAllBillAction1() throws Exception {
+    void saveAllBill1() throws Exception {
         List<Long> members = List.of(1L, 2L);
         BillSaveRequest request = new BillSaveRequest("", 10_000L, members);
 
@@ -59,7 +59,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("지출 액션을 수정한다.")
     @Test
-    void updateBillAction() throws Exception {
+    void updateBill() throws Exception {
         BillUpdateRequest request = new BillUpdateRequest("뽕족", 10_000L);
 
         String requestBody = objectMapper.writeValueAsString(request);
@@ -75,7 +75,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("지출 내역을 삭제한다.")
     @Test
-    void deleteBillAction() throws Exception {
+    void deleteBill() throws Exception {
         String eventId = "토다리토큰";
 
         mockMvc.perform(delete("/api/admin/events/{eventId}/bills/{billId}", eventId, 1))
@@ -85,7 +85,7 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("존재하지 않는 행사에 대한 지출 내역을 삭제할 수 없다.")
     @Test
-    void deleteBillAction1() throws Exception {
+    void deleteBill1() throws Exception {
         String eventId = "이상해토큰";
         doThrow(new HaengdongException(HaengdongErrorCode.EVENT_NOT_FOUND))
                 .when(billService).deleteBill(any(String.class), any(Long.class));
@@ -97,13 +97,13 @@ class AdminBillControllerTest extends ControllerTestSupport {
 
     @DisplayName("참여자별 지출 금액을 수정한다.")
     @Test
-    void updateBillActionDetailsTest() throws Exception {
-        List<BillDetailUpdateRequest> billActionDetailUpdateRequests = List.of(
+    void updateBillDetailsTest() throws Exception {
+        List<BillDetailUpdateRequest> billDetailUpdateRequests = List.of(
                 new BillDetailUpdateRequest(1L, 10000L, true),
                 new BillDetailUpdateRequest(2L, 20000L, true)
         );
         BillDetailsUpdateRequest request = new BillDetailsUpdateRequest(
-                billActionDetailUpdateRequests);
+                billDetailUpdateRequests);
 
         String json = objectMapper.writeValueAsString(request);
 


### PR DESCRIPTION
## issue
- close #580

## 구현 사항

HaengdongErrorCode에서 구체적인 예외 메시지 전달을 위해 Domain을 참조하고
Domain에서 예외를 던지기 위해 HaengdongErrorCode를 사용하여 순환참조 문제가 있었습니다.

해결 방법
- HaengdongErrorCode는 예외 메시지의 포멧만 지정한다.
- HaengdongException은 HaengdongErrorCode와 예외메시지 포멧에 필요한 인자를 받아 예외 메시지로 변환한다.
- 도메인은 예외를 던질 때 HaengdongErrorCode와 예외 메시지 포멧에 필요한 인자를 전달한다.

```java
public enum HaengdongErrorCode {

    /* Domain */

    EVENT_NOT_FOUND("존재하지 않는 행사입니다."),
    EVENT_NAME_LENGTH_INVALID("행사 이름은 %d자 이상 %d자 이하만 입력 가능합니다."),
    EVENT_NAME_CONSECUTIVE_SPACES("행사 이름에는 공백 문자가 연속될 수 없습니다."),
    EVENT_PASSWORD_FORMAT_INVALID("비밀번호는 %d자리 숫자만 가능합니다."),
    BANK_NAME_INVALID("지원하지 않는 은행입니다. 지원하는 은행 목록: %s"),
    ACCOUNT_LENGTH_INVALID("계좌번호는 %d자 이상 %d자 이하만 입력 가능합니다."),
...
}

public class HaengdongException extends RuntimeException {

    private final HaengdongErrorCode errorCode;

    public HaengdongException(HaengdongErrorCode errorCode) {
        super(errorCode.getMessage());
        this.errorCode = errorCode;
    }

    public HaengdongException(HaengdongErrorCode errorCode, Object... args) {
        super(String.format(errorCode.getMessage(), args));
        this.errorCode = errorCode;
    }
}

public class Password {
    private static final int PASSWORD_LENGTH = 4;
...
    private void validatePassword(String password) {
        Matcher matcher = PASSWORD_PATTERN.matcher(password);
        if (!matcher.matches()) {
            throw new HaengdongException(HaengdongErrorCode.EVENT_PASSWORD_FORMAT_INVALID, PASSWORD_LENGTH);
        }
    }
```

