### PR TITLE
[FE] 계좌번호 입력 확인 버튼 활성화가 되지 않는 버그, 빈 값일 때 새로운 값이 반영되지 않는 버그

### DIFF
--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -46,11 +46,11 @@ const useAccount = () => {
   };
 
   useEffect(() => {
-    const existEmptyField = bankName.trim() === '' && accountNumber.trim() === '';
+    const existEmptyField = bankNameState.trim() === '' || accountNumberState.trim() === '';
     const isChanged = bankName !== bankNameState || accountNumber !== accountNumberState;
 
     setCanSubmit(!existEmptyField && isChanged);
-  }, [bankName, accountNumber, bankNameState, accountNumberState]);
+  }, [bankNameState, accountNumberState]);
 
   return {
     bankName: bankNameState,

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -30,11 +30,11 @@ const useAccount = () => {
   const getChangedField = () => {
     const changedField: Partial<Event> = {};
 
-    if (bankName.trim() !== '' && bankName !== bankNameState) {
+    if (bankNameState.trim() !== '' && bankName !== bankNameState) {
       changedField.bankName = bankNameState;
     }
 
-    if (accountNumber.trim() !== '' && accountNumber !== accountNumberState) {
+    if (accountNumberState.trim() !== '' && accountNumber !== accountNumberState) {
       changedField.accountNumber = accountNumberState;
     }
 


### PR DESCRIPTION
## issue
- close #599 

## 구현 사항
조건문을 변경했습니다.
서버 상태가 아니라 클라이언트 상태가 빈 값인지를 확인해서 현재 입력 중인 값이 빈 값인지 검증해요

```ts
 const existEmptyField = bankNameState.trim() === '' || accountNumberState.trim() === '';
```

여기도 마찬가지.. 상태 헷갈림입니다
새로운 상태가 빈 값인지를 체크해서 초기에 빈 값일 때 새로운 값이 반영이 되지 않는 버그를 수정했어요

```ts
 if (bankNameState.trim() !== '' && bankName !== bankNameState) {
      changedField.bankName = bankNameState;
    }

    if (accountNumberState.trim() !== '' && accountNumber !== accountNumberState) {
      changedField.accountNumber = accountNumberState;
    }
```

