### PR TITLE
[FE] staleTime, gcTime 기본 값 설정

### DIFF
--- a/client/src/components/QueryClientBoundary/QueryClientBoundary.tsx
+++ b/client/src/components/QueryClientBoundary/QueryClientBoundary.tsx
@@ -12,6 +12,11 @@ const QueryClientBoundary = ({children}: React.PropsWithChildren) => {
     defaultOptions: {
       queries: {
         throwOnError: true,
+
+        staleTime: 1000 * 60, // 1 minute
+        gcTime: 1000 * 60, // 1 minute
+
+        refetchOnWindowFocus: false, // window focus가 다시 일어났을 때 refetch하지 않음
       },
     },
     queryCache: new QueryCache({


### PR DESCRIPTION
## issue
- close #593 

## 구현 사항
react-query의 stale time, gc time을 설정했습니다.
stale time과 gc time을 동일하게 1분으로 설정했습니다.

이 근거를 설명하겠습니다.

1분으로 짧게 가져간 이유는 행동대장 서비스가 "정산"을 다루기 때문입니다.
정산 프로그램은 사용자에게 정확한 데이터를 보여주어야 합니다. 실수로 수정되기 전의 데이터가 보여진다면 큰 혼란을 겪을 수 있습니다.

예로 들자면 정산 링크를 공유한 뒤에 잘못 작성한 내용이 있어 급하게 수정했다면, 주최자가 보고 있는 화면과 참여자가 보고 있는 화면이 다를 수 있습니다. 이 때 1분이라는 아주 짧은 시간을 가진다면 1분 뒤 다시 데이터를 조회했을 때 수정된 값을 보여줄 수 있습니다. 즉 캐시 시간을 짧게 가져가서 사용자에게 올바른 데이터를 보여줄 확률을 높이려고 했습니다.

그렇다면 아에 캐싱을 하지 않으면 정확한 정보를 가져올 수 있지 않나 생각할 수 있지만, 근거가 있습니다.

1. 네트워크 상황이 좋지 않은 경우
네트워크 상황이 좋지 않은 상황에서(야구장에서 사용할 경우) 서버로 재요청을 날릴 때 이미 조회를 했으니 데이터를 다시 불러오지 않게 되어 빠르게 보여줄 수 있습니다

2.  불필요한 api 호출 줄임
탭을 왔다갔다 하는 경우 계속 요청을 하게 되는데 캐싱을 해놓으면 재요청을 하지 않으니 서버로의 불필요한 요청을 줄일 수 있어서 설정했습니다.


## 논의하고 싶은 부분
다른 의견이 있다면 적극 반영할게요!

## 🫡 참고사항
