### PR TITLE
[BE] 계좌 정보를 은행 정보과 계좌 번호로 분리해서 응답

### DIFF
--- a/server/src/main/java/server/haengdong/application/response/EventDetailAppResponse.java
+++ b/server/src/main/java/server/haengdong/application/response/EventDetailAppResponse.java
@@ -4,10 +4,11 @@ import server.haengdong.domain.event.Event;
 
 public record EventDetailAppResponse(
         String eventName,
-        String account
+        String bankName,
+        String accountNumber
 ) {
 
     public static EventDetailAppResponse of(Event event) {
-        return new EventDetailAppResponse(event.getName(), event.getAccount());
+        return new EventDetailAppResponse(event.getName(), event.getBankName(), event.getAccountNumber());
     }
 }

--- a/server/src/main/java/server/haengdong/domain/event/Event.java
+++ b/server/src/main/java/server/haengdong/domain/event/Event.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Arrays;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -92,7 +93,23 @@ public class Event {
         int accountLength = accountNumber.trim().length();
         if (accountLength < MIN_ACCOUNT_NUMBER_LENGTH || MAX_ACCOUNT_NUMBER_LENGTH < accountLength) {
             throw new HaengdongException(
-                    HaengdongErrorCode.ACCOUNT_LENGTH_INVALID, MIN_ACCOUNT_NUMBER_LENGTH, MAX_ACCOUNT_NUMBER_LENGTH);
+                HaengdongErrorCode.ACCOUNT_LENGTH_INVALID, MIN_ACCOUNT_NUMBER_LENGTH, MAX_ACCOUNT_NUMBER_LENGTH);
         }
+    }
+
+    public String getBankName() {
+        String[] bankNameAndAccountNumber = account.split(" ");
+        if (bankNameAndAccountNumber.length > 0) {
+            return bankNameAndAccountNumber[0];
+        }
+        return "";
+    }
+
+    public String getAccountNumber() {
+        String[] bankNameAndAccountNumber = account.split(" ");
+        if (bankNameAndAccountNumber.length > 1) {
+            return String.join(" ", Arrays.copyOfRange(bankNameAndAccountNumber, 1, bankNameAndAccountNumber.length));
+        }
+        return "";
     }
 }

--- a/server/src/main/java/server/haengdong/presentation/response/EventDetailResponse.java
+++ b/server/src/main/java/server/haengdong/presentation/response/EventDetailResponse.java
@@ -4,10 +4,11 @@ import server.haengdong.application.response.EventDetailAppResponse;
 
 public record EventDetailResponse(
         String eventName,
-        String account
+        String bankName,
+        String accountNumber
 ) {
 
     public static EventDetailResponse of(EventDetailAppResponse response) {
-        return new EventDetailResponse(response.eventName(), response.account());
+        return new EventDetailResponse(response.eventName(), response.bankName(), response.accountNumber());
     }
 }

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -76,7 +76,8 @@ class EventServiceTest extends ServiceTestSupport {
         Event updateEvent = eventRepository.findByToken(event.getToken()).get();
         assertAll(
                 () -> assertThat(updateEvent.getName()).isEqualTo("새로운 행사 이름"),
-                () -> assertThat(updateEvent.getAccount()).isEqualTo("토스뱅크 12345678")
+                () -> assertThat(updateEvent.getBankName()).isEqualTo("토스뱅크"),
+                () -> assertThat(updateEvent.getAccountNumber()).isEqualTo("12345678")
         );
     }
 
@@ -92,7 +93,8 @@ class EventServiceTest extends ServiceTestSupport {
         Event updateEvent = eventRepository.findByToken(event.getToken()).get();
         assertAll(
                 () -> assertThat(updateEvent.getName()).isEqualTo("행동대장 비대위"),
-                () -> assertThat(updateEvent.getAccount()).isEqualTo("토스뱅크 12345678")
+                () -> assertThat(updateEvent.getBankName()).isEqualTo("토스뱅크"),
+                () -> assertThat(updateEvent.getAccountNumber()).isEqualTo("12345678")
         );
     }
 
@@ -108,7 +110,8 @@ class EventServiceTest extends ServiceTestSupport {
         Event updateEvent = eventRepository.findByToken(event.getToken()).get();
         assertAll(
                 () -> assertThat(updateEvent.getName()).isEqualTo("행동대장 정상 영업"),
-                () -> assertThat(updateEvent.getAccount()).isEqualTo("")
+                () -> assertThat(updateEvent.getBankName()).isEqualTo(""),
+                () -> assertThat(updateEvent.getAccountNumber()).isEqualTo("")
         );
     }
 
@@ -124,7 +127,8 @@ class EventServiceTest extends ServiceTestSupport {
         Event updateEvent = eventRepository.findByToken(event.getToken()).get();
         assertAll(
                 () -> assertThat(updateEvent.getName()).isEqualTo("행동대장 비대위"),
-                () -> assertThat(updateEvent.getAccount()).isEqualTo("")
+                () -> assertThat(updateEvent.getBankName()).isEqualTo(""),
+                () -> assertThat(updateEvent.getAccountNumber()).isEqualTo("")
         );
     }
 

--- a/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/EventControllerDocsTest.java
@@ -57,7 +57,7 @@ class EventControllerDocsTest extends RestDocsSupport {
     @Test
     void findEventTest() throws Exception {
         String eventId = "망쵸토큰";
-        EventDetailAppResponse eventDetailAppResponse = new EventDetailAppResponse("행동대장 회식", "토스 12312455");
+        EventDetailAppResponse eventDetailAppResponse = new EventDetailAppResponse("행동대장 회식", "토스뱅크", "12312455");
         given(eventService.findEvent(eventId)).willReturn(eventDetailAppResponse);
 
         mockMvc.perform(get("/api/events/{eventId}", eventId))
@@ -73,7 +73,8 @@ class EventControllerDocsTest extends RestDocsSupport {
                                 ),
                                 responseFields(
                                         fieldWithPath("eventName").type(JsonFieldType.STRING).description("행사 이름"),
-                                        fieldWithPath("account").type(JsonFieldType.STRING).description("행사 계좌")
+                                        fieldWithPath("bankName").type(JsonFieldType.STRING).description("토스뱅크"),
+                                        fieldWithPath("accountNumber").type(JsonFieldType.STRING).description("12312455")
                                 )
                         )
                 );

--- a/server/src/test/java/server/haengdong/domain/event/EventTest.java
+++ b/server/src/test/java/server/haengdong/domain/event/EventTest.java
@@ -3,6 +3,7 @@ package server.haengdong.domain.event;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,10 @@ class EventTest {
 
         event.changeAccount("토스뱅크", "12345678");
 
-        assertThat(event.getAccount()).isEqualTo("토스뱅크 12345678");
+        assertAll(
+                () -> assertThat(event.getBankName()).isEqualTo("토스뱅크"),
+                () -> assertThat(event.getAccountNumber()).isEqualTo("12345678")
+        );
     }
 
     @DisplayName("계좌 정보에 은행 이름과 계좌 번호가 모두 포함되지 않으면 예외가 발생한다.")
@@ -131,5 +135,31 @@ class EventTest {
 
         assertThatThrownBy(() -> event.changeAccount("토스뱅크", accountNumber))
                 .isInstanceOf(HaengdongException.class);
+    }
+
+    @DisplayName("계좌 정보를 조회한다.")
+    @Test
+    void getBankNameTest() {
+        Event event = new Event("이름", "1234", "TEST_TOKEN");
+
+        event.changeAccount("토스뱅크", "12345678");
+
+        assertAll(
+                () -> assertThat(event.getBankName()).isEqualTo("토스뱅크"),
+                () -> assertThat(event.getAccountNumber()).isEqualTo("12345678")
+        );
+    }
+
+    @DisplayName("계좌 번호에 공백이 있어도 계좌 정보를 정상적으로 조회한다.")
+    @Test
+    void getBankNameTest1() {
+        Event event = new Event("이름", "1234", "TEST_TOKEN");
+
+        event.changeAccount("토스뱅크", "1234 5678 9012");
+
+        assertAll(
+                () -> assertThat(event.getBankName()).isEqualTo("토스뱅크"),
+                () -> assertThat(event.getAccountNumber()).isEqualTo("1234 5678 9012")
+        );
     }
 }

--- a/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
+++ b/server/src/test/java/server/haengdong/presentation/EventControllerTest.java
@@ -29,7 +29,7 @@ class EventControllerTest extends ControllerTestSupport {
     @Test
     void findEventTest() throws Exception {
         String eventId = "망쵸토큰";
-        EventDetailAppResponse eventDetailAppResponse = new EventDetailAppResponse("행동대장 회식", "토스 1231245");
+        EventDetailAppResponse eventDetailAppResponse = new EventDetailAppResponse("행동대장 회식", "토스뱅크", "1231245");
         given(eventService.findEvent(eventId)).willReturn(eventDetailAppResponse);
 
         mockMvc.perform(get("/api/events/{eventId}", eventId))


### PR DESCRIPTION
## issue
- close #606

## 구현 사항
- dto에 account 대신에 bankName과 accountNumber를 반환하도록 수정
- entity에 getBankName()과 getAccountNumber() 추가

## 논의하고 싶은 부분(선택)
현재 엔티티 내부에 account 필드가 있습니다. 
account를 bankName과 accountNumber로 변환해야 하지만, 그러지 않았습니다. 
이유는 현재 스키마 마이그레이션이 진행 중으로, 관련 작업에 영향을 주지 않기 위함입니다. 

## 🫡 참고사항
