### PR TITLE
[BE] 멤버 정보 수정 API 호출 버그 수정

### DIFF
--- a/server/src/docs/asciidoc/member.adoc
+++ b/server/src/docs/asciidoc/member.adoc
@@ -106,8 +106,8 @@ operation::updateMembers[snippets="path-parameters,http-request,request-body,req
       "message":"존재하지 않는 행사입니다."
     },
     {
-	  "code": "MEMBER_NOT_FOUND",
-	  "message": "존재하지 않는 참여자입니다."
+	  "code": "MEMBER_UPDATE_MISMATCH",
+	  "message": "업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다."
     },
     {
 	  "code": "MEMBER_NAME_DUPLICATE",

--- a/server/src/main/java/server/haengdong/domain/member/Member.java
+++ b/server/src/main/java/server/haengdong/domain/member/Member.java
@@ -56,8 +56,13 @@ public class Member {
     private void validateName(String name) {
         int nameLength = name.length();
         if (nameLength < MIN_NAME_LENGTH || nameLength > MAX_NAME_LENGTH) {
-            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID, MIN_NAME_LENGTH, MAX_NAME_LENGTH);
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_LENGTH_INVALID, MIN_NAME_LENGTH,
+                    MAX_NAME_LENGTH);
         }
+    }
+
+    public boolean hasName(String name) {
+        return this.name.equals(name);
     }
 
     @Override

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -19,7 +19,7 @@ public enum HaengdongErrorCode {
     MEMBER_NOT_FOUND("존재하지 않는 참여자입니다."),
     MEMBER_ALREADY_EXIST("현재 참여하고 있는 인원이 존재합니다."),
     MEMBER_NAME_CHANGE_DUPLICATE("중복된 참여 인원 이름 변경 요청이 존재합니다."),
-    MEMBER_UPDATE_MISMATCH("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다."),
+    MEMBER_UPDATE_MISMATCH("업데이트 요청된 참여자 ID 목록과 기존 행사 참여자 ID 목록이 일치하지 않습니다."),
 
     BILL_NOT_FOUND("존재하지 않는 지출입니다."),
     BILL_TITLE_INVALID("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다."),

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -19,6 +19,7 @@ public enum HaengdongErrorCode {
     MEMBER_NOT_FOUND("존재하지 않는 참여자입니다."),
     MEMBER_ALREADY_EXIST("현재 참여하고 있는 인원이 존재합니다."),
     MEMBER_NAME_CHANGE_DUPLICATE("중복된 참여 인원 이름 변경 요청이 존재합니다."),
+    MEMBER_UPDATE_MISMATCH("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다."),
 
     BILL_NOT_FOUND("존재하지 않는 지출입니다."),
     BILL_TITLE_INVALID("앞뒤 공백을 제거한 지출 내역 제목은 %d ~ %d자여야 합니다."),

--- a/server/src/test/java/server/haengdong/application/MemberServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberServiceTest.java
@@ -290,7 +290,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.updateMembers(event1.getToken(), membersUpdateAppRequest))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다.");
+                .hasMessage("업데이트 요청된 참여자 ID 목록과 기존 행사 참여자 ID 목록이 일치하지 않습니다.");
     }
 
     @DisplayName("수정하려는 행사 참여 인원 이름이 이미 존재하는 경우 예외가 발생한다.")
@@ -309,7 +309,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.updateMembers(event1.getToken(), membersUpdateAppRequest))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다.");
+                .hasMessage("업데이트 요청된 참여자 ID 목록과 기존 행사 참여자 ID 목록이 일치하지 않습니다.");
     }
 
     @DisplayName("참여자 간 서로의 이름으로 수정하려는 경우 예외가 발생한다.")

--- a/server/src/test/java/server/haengdong/application/MemberServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static server.haengdong.support.fixture.Fixture.BILL1;
 import static server.haengdong.support.fixture.Fixture.EVENT1;
@@ -30,10 +31,10 @@ import server.haengdong.domain.bill.Bill;
 import server.haengdong.domain.bill.BillDetail;
 import server.haengdong.domain.bill.BillDetailRepository;
 import server.haengdong.domain.bill.BillRepository;
-import server.haengdong.domain.member.Member;
-import server.haengdong.domain.member.MemberRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
+import server.haengdong.domain.member.Member;
+import server.haengdong.domain.member.MemberRepository;
 import server.haengdong.exception.HaengdongException;
 
 class MemberServiceTest extends ServiceTestSupport {
@@ -146,7 +147,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.deleteMember(event1.getToken(), member.getId()))
                 .isInstanceOf(HaengdongException.class);
-        
+
         assertThat(memberRepository.findById(member.getId())).isNotEmpty();
     }
 
@@ -190,9 +191,9 @@ class MemberServiceTest extends ServiceTestSupport {
                 .orElseThrow();
     }
 
-    @DisplayName("멤버 정보를 수정한다.")
+    @DisplayName("멤버 이름 정보를 수정한다.")
     @Test
-    void updateMembersTest() {
+    void updateMembersNameTest() {
         Event event = EVENT1;
         Member member = MEMBER1;
         eventRepository.save(event);
@@ -209,6 +210,28 @@ class MemberServiceTest extends ServiceTestSupport {
         assertAll(
                 () -> assertThat(updatedMember.getName()).isEqualTo("수정된이름"),
                 () -> assertTrue(updatedMember.isDeposited())
+        );
+    }
+
+    @DisplayName("멤버 정보를 수정한다.")
+    @Test
+    void updateMembersIsDepositedTest() {
+        Event event = EVENT1;
+        Member member = MEMBER1;
+        eventRepository.save(event);
+        memberRepository.save(member);
+        MembersUpdateAppRequest membersUpdateAppRequest = new MembersUpdateAppRequest(
+                List.of(
+                        new MemberUpdateAppRequest(member.getId(), member.getName(), false)
+                )
+        );
+
+        memberService.updateMembers(event.getToken(), membersUpdateAppRequest);
+
+        Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+        assertAll(
+                () -> assertThat(updatedMember.getName()).isEqualTo(member.getName()),
+                () -> assertFalse(updatedMember.isDeposited())
         );
     }
 
@@ -267,7 +290,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.updateMembers(event1.getToken(), membersUpdateAppRequest))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("존재하지 않는 참여자입니다.");
+                .hasMessage("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다.");
     }
 
     @DisplayName("수정하려는 행사 참여 인원 이름이 이미 존재하는 경우 예외가 발생한다.")
@@ -286,7 +309,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.updateMembers(event1.getToken(), membersUpdateAppRequest))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("중복된 행사 참여 인원 이름이 존재합니다.");
+                .hasMessage("업데이트 요청된 참여자 정보와 기존 행사 참여자 정보가 일치하지 않습니다.");
     }
 
     @DisplayName("참여자 간 서로의 이름으로 수정하려는 경우 예외가 발생한다.")


### PR DESCRIPTION
## issue
- close #609

## 구현 사항
멤버 정보 수정 API 예외 처리 로직을 수정했습니다.

```java
private void validateUpdatedNamesUnique(List<Member> eventMembers, List<Member> updatedMembers) {
        Set<String> eventMemberNames = eventMembers.stream()
                .map(Member::getName)
                .collect(Collectors.toSet());

        boolean memberNameDuplicated = updatedMembers.stream()
                .map(Member::getName)
                .anyMatch(eventMemberNames::contains);

        if (memberNameDuplicated) {
            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE);
        }
    }
```
위와 같이 updatedMembers로 들어온 모든 멤버에 대해 이름 중복을 검증하고 있었는데, 이름 변경이 있는 멤버에 대해서만 검증을 수행하도록 수정했습니다.

```java
private void validateUpdatedNamesUnique(List<Member> eventMembers, List<Member> updatedMembers) {
        Map<Long, String> eventMemberNames = eventMembers.stream()
                .collect(toMap(Member::getId, Member::getName));
        Set<String> existNames = new HashSet<>(eventMemberNames.values());

        boolean memberNameDuplicated = updatedMembers.stream()
                .filter(updatedMember -> isMemberNameUpdated(eventMemberNames, updatedMember))
                .map(Member::getName)
                .anyMatch(existNames::contains);

        if (memberNameDuplicated) {
            throw new HaengdongException(HaengdongErrorCode.MEMBER_NAME_DUPLICATE);
        }
    }
```