### PR TITLE
[FE] 입금 상태를 변경하고 '수정완료' 버튼 클릭 시, 중복 이름 버그 발생

### DIFF
--- a/client/src/hooks/queries/member/useRequestDeleteMember.ts
+++ b/client/src/hooks/queries/member/useRequestDeleteMember.ts
@@ -10,7 +10,7 @@ const useRequestDeleteMember = () => {
   const eventId = getEventIdByUrl();
   const queryClient = useQueryClient();
 
-  const {mutate, ...rest} = useMutation({
+  const {mutateAsync, ...rest} = useMutation({
     mutationFn: ({memberId}: RequestDeleteMember) => requestDeleteMember({eventId, memberId}),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
@@ -20,7 +20,7 @@ const useRequestDeleteMember = () => {
     },
   });
 
-  return {deleteMember: mutate, ...rest};
+  return {deleteMember: mutateAsync, ...rest};
 };
 
 export default useRequestDeleteMember;

--- a/client/src/hooks/queries/member/useRequestDeleteMember.ts
+++ b/client/src/hooks/queries/member/useRequestDeleteMember.ts
@@ -20,7 +20,7 @@ const useRequestDeleteMember = () => {
     },
   });
 
-  return {deleteMember: mutateAsync, ...rest};
+  return {deleteAsyncMember: mutateAsync, ...rest};
 };
 
 export default useRequestDeleteMember;

--- a/client/src/hooks/queries/member/useRequestPutMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPutMembers.ts
@@ -10,7 +10,7 @@ const useRequestPutMembers = () => {
   const eventId = getEventIdByUrl();
   const queryClient = useQueryClient();
 
-  const {mutate, ...rest} = useMutation({
+  const {mutateAsync, ...rest} = useMutation({
     mutationFn: ({members}: RequestPutMembers) => requestPutMembers({eventId, members}),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
@@ -20,7 +20,7 @@ const useRequestPutMembers = () => {
     },
   });
 
-  return {putMember: mutate, ...rest};
+  return {putMember: mutateAsync, ...rest};
 };
 
 export default useRequestPutMembers;

--- a/client/src/hooks/queries/member/useRequestPutMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPutMembers.ts
@@ -20,7 +20,7 @@ const useRequestPutMembers = () => {
     },
   });
 
-  return {putMember: mutateAsync, ...rest};
+  return {putAsyncMember: mutateAsync, ...rest};
 };
 
 export default useRequestPutMembers;

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -18,8 +18,8 @@ interface ReturnUseEventMember {
 
 const useEventMember = (): ReturnUseEventMember => {
   const {reports: initialReports} = useRequestGetReports();
-  const {deleteMember} = useRequestDeleteMember();
-  const {putMember} = useRequestPutMembers();
+  const {deleteAsyncMember} = useRequestDeleteMember();
+  const {putAsyncMember} = useRequestPutMembers();
 
   const [reports, setReports] = useState<Report[]>(initialReports);
   const [deleteMembers, setDeleteMembers] = useState<number[]>([]);
@@ -103,13 +103,13 @@ const useEventMember = (): ReturnUseEventMember => {
     // 삭제할 member(deleteMembers)가 존재한다면 Delete 요청 실행
     if (deleteMembers.length > 0) {
       for (const id of deleteMembers) {
-        deleteMember({memberId: id});
+        deleteAsyncMember({memberId: id});
       }
     }
 
     // 변경된 값(filteredChangedMembers)이 존재한다면 PUT 요청 실행
     if (filteredChangedMembers.length > 0) {
-      putMember({members: filteredChangedMembers});
+      putAsyncMember({members: filteredChangedMembers});
     }
   };
 


### PR DESCRIPTION
## issue
- close #600

## 구현 사항

# 🚨 백엔드 api 수정 이후, merge 진행

### 버그 발생 상황
입금 상태만을 변경하고 '수정완료' 버튼을 클릭하면 "중복 이름입니다" 버그가 발생했습니다.
이에 대한 문제는 api 구조의 문제로 결론이 났습니다. 따라서 해당 문제의 해결은 백엔드의 수정 후에 정확히 확인해봐야 할 것 같습니다.

### 또 다른 버그 발생 상황 사전 방지
전체 참여자 delete,put 요청 mutate대신 mutateAsync를 사용하여 요청 순서 보장했습니다.
순서를 보장하지 않는다면 delete 요청 전에 put 요청이 먼저 갈 수 있다는 문제가 존재합니다. 
delete 요청 전, put 요청이 가는 것이 왜 문제냐? 생각하실 수 있습니다. put 요청은 delete가 요청이 된 것을 기반으로 데이터가 존재합니다. 따라서 delete 요청이 무조건 선행 되어야 put 요청을 전송할 수 있습니다.

## 🫡 참고사항
