### PR TITLE
[FE] useEventMember 불필요한 상태 제거 및 렌더링 성능 개선

### DIFF
--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -91,12 +91,12 @@ const useEventMember = (): ReturnUseEventMember => {
     setReports(prevReports => prevReports.filter(report => report.memberId !== memberId));
   }, []);
 
-  const updateMembersOnServer = useCallback(() => {
+  const updateMembersOnServer = useCallback(async () => {
     // DELETE 요청 선행
     // deleteMembers에 값이 하나라도 전재하면 반복문을 통해 DELETE api 요청
     if (deleteMembers.length > 0) {
       for (const id of deleteMembers) {
-        deleteMember({memberId: id});
+        await deleteMember({memberId: id});
       }
     }
 
@@ -122,7 +122,7 @@ const useEventMember = (): ReturnUseEventMember => {
 
     // 변경된 사항이 존재한다면 해당 reports만을 PUT api 요청
     if (changedMembers.length > 0) {
-      putMember({members: changedMembers});
+      await putMember({members: changedMembers});
     }
   }, [deleteMembers, reports, initialReports, deleteMember, putMember]);
 

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -31,16 +31,8 @@ const useEventMember = (): ReturnUseEventMember => {
   const isCanSubmit = useMemo(() => {
     // 중복되는 이름이 존재하는지 확인
     const hasDuplicateMemberName = (): boolean => {
-      const nameCount: {[key: string]: number} = {};
-
-      for (const member of reports) {
-        if (nameCount[member.memberName]) {
-          return true;
-        }
-        nameCount[member.memberName] = 1;
-      }
-
-      return false;
+      const nameSet = new Set(reports.map(member => member.memberName));
+      return nameSet.size !== reports.length;
     };
 
     if (hasDuplicateMemberName()) {

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -57,16 +57,19 @@ const useEventMember = (): ReturnUseEventMember => {
     return hasChanges || deleteMembers.length > 0;
   }, [reports, initialReports, deleteMembers]);
 
-  const changeMemberName = useCallback((memberId: number, newName: string) => {
-    // 유효성 검사 (4자 이하)
-    if (!validateMemberName(newName).isValid) {
-      return;
-    }
+  const changeMemberName = useCallback(
+    (memberId: number, newName: string) => {
+      // 유효성 검사 (4자 이하)
+      if (!validateMemberName(newName).isValid) {
+        return;
+      }
 
-    setReports(prevReports =>
-      prevReports.map(report => (report.memberId === memberId ? {...report, memberName: newName} : report)),
-    );
-  }, []);
+      setReports(prevReports =>
+        prevReports.map(report => (report.memberId === memberId ? {...report, memberName: newName} : report)),
+      );
+    },
+    [setReports, validateMemberName],
+  );
 
   const toggleDepositStatus = useCallback((memberId: number) => {
     setReports(prevReports =>

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -9,7 +9,7 @@ import useRequestGetReports from './queries/report/useRequestGetReports';
 
 interface ReturnUseEventMember {
   reports: Report[];
-  isCanRequest: boolean;
+  isCanSubmit: boolean;
   changeMemberName: (memberId: number, newName: string) => void;
   toggleDepositStatus: (memberId: number) => void;
   handleDeleteMember: (memberId: number) => void;
@@ -28,7 +28,7 @@ const useEventMember = (): ReturnUseEventMember => {
     setReports(initialReports);
   }, [initialReports]);
 
-  const isCanRequest = useMemo(() => {
+  const isCanSubmit = useMemo(() => {
     // 중복되는 이름이 존재하는지 확인
     const hasDuplicateMemberName = (): boolean => {
       const nameCount: {[key: string]: number} = {};
@@ -126,7 +126,7 @@ const useEventMember = (): ReturnUseEventMember => {
     }
   }, [deleteMembers, reports, initialReports, deleteMember, putMember]);
 
-  return {reports, isCanRequest, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus};
+  return {reports, isCanSubmit, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus};
 };
 
 export default useEventMember;

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -1,6 +1,6 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useCallback, useMemo} from 'react';
 
-import {Reports, Report, AllMembers, MemberWithDeposited} from 'types/serviceType';
+import {Report} from 'types/serviceType';
 import validateMemberName from '@utils/validate/validateMemberName';
 
 import useRequestDeleteMember from './queries/member/useRequestDeleteMember';
@@ -23,34 +23,50 @@ const useEventMember = (): ReturnUseEventMember => {
 
   const [reports, setReports] = useState<Report[]>(initialReports);
   const [deleteMembers, setDeleteMembers] = useState<number[]>([]);
-  const [changedMembers, setChangedMembers] = useState<MemberWithDeposited[]>([]);
-  const [isCanRequest, setIsCanRequest] = useState<boolean>(false);
-  const [filteredChangedMembers, setFilteredChangedMembers] = useState<MemberWithDeposited[]>([]);
 
   useEffect(() => {
     setReports(initialReports);
   }, [initialReports]);
 
-  useEffect(() => {
-    const changedMembers = getChangedMembers();
+  const isCanRequest = useMemo(() => {
+    // 중복되는 이름이 존재하는지 확인
+    const hasDuplicateMemberName = (): boolean => {
+      const nameCount: {[key: string]: number} = {};
 
-    // 중복된 이름이 존재할 경우 isCanRequest를 false로 변경
+      for (const member of reports) {
+        if (nameCount[member.memberName]) {
+          return true;
+        }
+        nameCount[member.memberName] = 1;
+      }
+
+      return false;
+    };
+
     if (hasDuplicateMemberName()) {
-      setIsCanRequest(false);
-    } else {
-      // 변경된 사항이 존재하거나 삭제한 member가 존재한다면 isCanRequest를 true로 변경
-      setIsCanRequest(changedMembers.length > 0 || deleteMembers.length > 0);
+      // 중복 이름이라면 false
+      return false;
     }
 
-    // memberName 유효성 검사 (0글자)
-    const hasEmptyName = changedMembers.some(member => member.name.trim().length === 0);
-    if (hasEmptyName) setIsCanRequest(false);
+    // 이름이 공백이라면 false
+    const hasEmptyName = reports.some(report => report.memberName.trim().length === 0);
+    if (hasEmptyName) return false;
 
-    setFilteredChangedMembers(changedMembers);
-  }, [reports, changedMembers, deleteMembers]);
+    // 초기 값과 비교하여 변경된 사항이 존재하는지 확인
+    const hasChanges = reports.some(report =>
+      initialReports.find(
+        initial =>
+          initial.memberId === report.memberId &&
+          (initial.memberName !== report.memberName || initial.isDeposited !== report.isDeposited),
+      ),
+    );
 
-  const changeMemberName = (memberId: number, newName: string) => {
-    // 유효성 검사 (4글자)
+    // 변경된 사항이 존재 혹은 삭제된 member가 존재한다면 true
+    return hasChanges || deleteMembers.length > 0;
+  }, [reports, initialReports, deleteMembers]);
+
+  const changeMemberName = useCallback((memberId: number, newName: string) => {
+    // 유효성 검사 (4자 이하)
     if (!validateMemberName(newName).isValid) {
       return;
     }
@@ -58,92 +74,57 @@ const useEventMember = (): ReturnUseEventMember => {
     setReports(prevReports =>
       prevReports.map(report => (report.memberId === memberId ? {...report, memberName: newName} : report)),
     );
+  }, []);
 
-    setChangedMembers(prev => {
-      const existing = prev.find(member => member.id === memberId);
-      const isDeposited = reports.find(report => report.memberId === memberId)?.isDeposited ?? false; // 기본값 제공
-
-      if (existing) {
-        return prev.map(member => (member.id === memberId ? {...member, name: newName, isDeposited} : member));
-      }
-      return [...prev, {id: memberId, name: newName, isDeposited}];
-    });
-
-    setIsCanRequest(true);
-  };
-
-  const toggleDepositStatus = (memberId: number) => {
+  const toggleDepositStatus = useCallback((memberId: number) => {
     setReports(prevReports =>
       prevReports.map(report =>
         report.memberId === memberId ? {...report, isDeposited: !report.isDeposited} : report,
       ),
     );
+  }, []);
 
-    setChangedMembers(prev => {
-      const existing = prev.find(member => member.id === memberId);
-      const name = reports.find(report => report.memberId === memberId)?.memberName ?? ''; // 기본값 제공
-      const newIsDeposited = !reports.find(report => report.memberId === memberId)?.isDeposited ?? false;
-
-      if (existing) {
-        return prev.map(member => (member.id === memberId ? {...member, isDeposited: newIsDeposited} : member));
-      }
-      return [...prev, {id: memberId, name, isDeposited: newIsDeposited}];
-    });
-
-    setIsCanRequest(true);
-  };
-
-  const handleDeleteMember = (memberId: number) => {
+  // 삭제할 member를 따로 deleteMembers 상태에서 id만 저장
+  const handleDeleteMember = useCallback((memberId: number) => {
     setDeleteMembers(prev => [memberId, ...prev]);
+    // 삭제할 member들의 데이터를 reports에서 제거
     setReports(prevReports => prevReports.filter(report => report.memberId !== memberId));
-    setChangedMembers(prev => prev.filter(member => member.id !== memberId));
-  };
+  }, []);
 
-  const updateMembersOnServer = () => {
-    // 삭제할 member(deleteMembers)가 존재한다면 Delete 요청 실행
+  const updateMembersOnServer = useCallback(() => {
+    // DELETE 요청 선행
+    // deleteMembers에 값이 하나라도 전재하면 반복문을 통해 DELETE api 요청
     if (deleteMembers.length > 0) {
       for (const id of deleteMembers) {
         deleteMember({memberId: id});
       }
     }
 
-    // 변경된 값(filteredChangedMembers)이 존재한다면 PUT 요청 실행
-    if (filteredChangedMembers.length > 0) {
-      putMember({members: filteredChangedMembers});
+    // DELETE 요청이 선행 된 후, PUT 요청 진행
+    // 초기 reports와 비교하여 달라진 member 데이터만을 filter
+    const changedMembers = reports
+      .filter(report => {
+        // 각 report와 동일한 초기 report 데이터를 찾기
+        const initialReport = initialReports.find(initial => initial.memberId === report.memberId);
+
+        // 초기 데이터와 비교했을 때, 변경사항이 발생한 것만을 filter
+        return (
+          initialReport &&
+          (initialReport.memberName !== report.memberName || initialReport.isDeposited !== report.isDeposited)
+        );
+      })
+      .map(report => ({
+        // server로 요청할 때, price는 제외해야 하기 때문에 map 진행
+        id: report.memberId,
+        name: report.memberName,
+        isDeposited: report.isDeposited,
+      }));
+
+    // 변경된 사항이 존재한다면 해당 reports만을 PUT api 요청
+    if (changedMembers.length > 0) {
+      putMember({members: changedMembers});
     }
-  };
-
-  const getChangedMembers = () => {
-    // 초기 상태에서 변경된 값이 존재하는 것만 filtering하여 return 한다.
-
-    // 초기 상태에서 memberId를 키로 갖는 맵 생성
-    const initialReportsMap = new Map(initialReports.map(report => [report.memberId, report]));
-
-    // 변경된 값(changedMembers)에서 초기 상태와 동일한 값을 삭제
-    const filteredChangedMembers = changedMembers.filter(changedMember => {
-      const initialMember = initialReportsMap.get(changedMember.id);
-      return (
-        !initialMember ||
-        initialMember.memberName !== changedMember.name ||
-        initialMember.isDeposited !== changedMember.isDeposited
-      );
-    });
-
-    return filteredChangedMembers;
-  };
-
-  const hasDuplicateMemberName = (): boolean => {
-    const nameCount: {[key: string]: number} = {};
-
-    for (const member of reports) {
-      if (nameCount[member.memberName]) {
-        return true; // 중복된 이름이 존재하면 즉시 true 반환
-      }
-      nameCount[member.memberName] = 1;
-    }
-
-    return false; // 중복된 이름이 없으면 false 반환
-  };
+  }, [deleteMembers, reports, initialReports, deleteMember, putMember]);
 
   return {reports, isCanRequest, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus};
 };

--- a/client/src/pages/EventPage/AdminPage/EventMember.style.ts
+++ b/client/src/pages/EventPage/AdminPage/EventMember.style.ts
@@ -3,7 +3,7 @@ import {css} from '@emotion/react';
 import {Theme} from '@components/Design/theme/theme.type';
 import TYPOGRAPHY from '@components/Design/token/typography';
 
-export const eventMemberMangeStyle = () =>
+export const eventMemberStyle = () =>
   css({
     padding: '0 1rem',
   });

--- a/client/src/pages/EventPage/AdminPage/EventMember.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventMember.tsx
@@ -17,9 +17,9 @@ import {
 } from '@components/Design';
 import {useTheme} from '@components/Design';
 
-import {eventMemberMangeStyle, memberList, eventMember, memberEditInput, noneReports} from './EventMemberManage.style';
+import {eventMemberStyle, memberList, eventMember, memberEditInput, noneReports} from './EventMember.style';
 
-const EventMemberManage = () => {
+const EventMember = () => {
   const {reports, isCanSubmit, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus} =
     useEventMember();
 
@@ -28,7 +28,7 @@ const EventMemberManage = () => {
       <TopNav>
         <Back />
       </TopNav>
-      <section css={eventMemberMangeStyle}>
+      <section css={eventMemberStyle}>
         <Top>
           <Top.Line text="전체 참여자 관리" emphasize={['전체 참여자 관리']}></Top.Line>
         </Top>
@@ -43,7 +43,7 @@ const EventMemberManage = () => {
           ) : (
             reports.map(member => {
               return (
-                <EventMember
+                <Member
                   key={member.memberId}
                   member={member}
                   changeMemberName={changeMemberName}
@@ -66,14 +66,14 @@ const EventMemberManage = () => {
   );
 };
 
-interface EventMemberProps {
+interface MemberProps {
   member: Report;
   changeMemberName: (memberId: number, newName: string) => void;
   handleDeleteMember: (memberId: number) => void;
   toggleDepositStatus: (memberId: number) => void;
 }
 
-const EventMember = ({member, changeMemberName, handleDeleteMember, toggleDepositStatus}: EventMemberProps) => {
+const Member = ({member, changeMemberName, handleDeleteMember, toggleDepositStatus}: MemberProps) => {
   const {theme} = useTheme();
 
   const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -102,4 +102,4 @@ const EventMember = ({member, changeMemberName, handleDeleteMember, toggleDeposi
   );
 };
 
-export default EventMemberManage;
+export default EventMember;

--- a/client/src/pages/EventPage/AdminPage/EventMemberManage.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventMemberManage.tsx
@@ -20,7 +20,7 @@ import {useTheme} from '@components/Design';
 import {eventMemberMangeStyle, memberList, eventMember, memberEditInput, noneReports} from './EventMemberManage.style';
 
 const EventMemberManage = () => {
-  const {reports, isCanRequest, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus} =
+  const {reports, isCanSubmit, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus} =
     useEventMember();
 
   return (
@@ -57,7 +57,7 @@ const EventMemberManage = () => {
         {reports.length === 0 ? (
           <></>
         ) : (
-          <FixedButton disabled={!isCanRequest} onClick={updateMembersOnServer} style={{zIndex: '100'}}>
+          <FixedButton disabled={!isCanSubmit} onClick={updateMembersOnServer} style={{zIndex: '100'}}>
             수정완료
           </FixedButton>
         )}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -6,7 +6,7 @@ import ErrorPage from '@pages/ErrorPage/ErrorPage';
 import EventLoginPage from '@pages/EventPage/AdminPage/EventLoginPage';
 import AddBillFunnel from '@pages/AddBillFunnel/AddBillFunnel';
 import CreateEventFunnel from '@pages/CreateEventPage/CreateEventFunnel';
-import EventMemberManage from '@pages/EventPage/AdminPage/EventMemberManage';
+import EventMember from '@pages/EventPage/AdminPage/EventMember';
 import EditBillPage from '@pages/EditBillPage/EditBillPage';
 import Account from '@pages/AccountPage/Account';
 
@@ -50,7 +50,7 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTER_URLS.member,
-        element: <EventMemberManage />,
+        element: <EventMember />,
       },
       {
         path: ROUTER_URLS.editBill,


### PR DESCRIPTION
## issue
- close #612

# 🚨 600번이 선행 merge 되어야 합니다!

## 구현 사항
### changedMembers라는 불필요한 상태를 제거 했어요! 
해당 상태를 추가했던 이유는 불필요한 렌더링을 줄이기 위해서였습니다. 그러나 이런 문제를 useMemo나 useCallback을 사용하여 불필요한 렌더링을 줄이면서 불필요한 상태도 제거하였습니다!

### 렌더링 성능 개선
불필요한 렌더링을 줄이기 위해서 useCallback과 useMemo를 사용했습니다.

### EventMemberManage 파일명 변경
Manage라는 것은 굳이 붙이지 않아도 될 것 같습니다. AdminPage 폴더에 존재하기 때문입니다.
따라서 EventMemberManage 파일 이름을 EventMember로 변경했습니다.

### isCanRequest 변수명 변경
리뷰할 때, 이름에 대한 의견이 들어와서 isCanRequest를 isCanSubmit으로 다른 페이지들과 통일시켰습니다.

## 🫡 참고사항
