### PR TITLE
[FE] Loading Button으로 인해 Layout이 깨지는 문제

### DIFF
--- a/client/src/components/Design/components/FixedButton/FixedButton.tsx
+++ b/client/src/components/Design/components/FixedButton/FixedButton.tsx
@@ -40,7 +40,7 @@ export const FixedButton: React.FC<FixedButtonProps> = forwardRef<HTMLButtonElem
           {...htmlProps}
         >
           {variants === 'loading' ? (
-            <Lottie animationData={loadingAnimation} loop={true} style={{width: 240, height: 20}} />
+            <Lottie animationData={loadingAnimation} loop={true} style={{height: '1.25rem'}} />
           ) : (
             children
           )}


### PR DESCRIPTION
## issue
- close #620 

## 구현 목적

https://github.com/user-attachments/assets/eb987e79-c3c4-44bb-a7db-77f8f65e53ec

FixedButton 에서 button의 variant가 loading인 경우에 아래의 영상처럼 layout이 깨져 이상하게 보이는 오류가 존재했습니다.
이를 올바르게 수정하여 좋은 사용자경험을 주고자 합니다.

## 구현 내용

기존에 FixedButton이 아닌, 버튼이 한개일 경우 사용되는 width 240 설정이 적용되어 있어 이를 해제함으로써 해결

## 🫡 참고사항

