### PR TITLE
 [FE] 참여인원이 많을 때, 지출 내역 카드에서 멤버 칩의 레이아웃이 깨지는 문제

### DIFF
--- a/client/src/components/Design/components/ChipGroup/ChipGroup.style.ts
+++ b/client/src/components/Design/components/ChipGroup/ChipGroup.style.ts
@@ -3,4 +3,5 @@ import {css} from '@emotion/react';
 export const chipGroupStyle = css({
   display: 'flex',
   gap: '0.25rem',
+  flexWrap: 'wrap',
 });

--- a/client/src/components/Design/components/ChipGroup/ChipGroup.style.ts
+++ b/client/src/components/Design/components/ChipGroup/ChipGroup.style.ts
@@ -4,4 +4,5 @@ export const chipGroupStyle = css({
   display: 'flex',
   gap: '0.25rem',
   flexWrap: 'wrap',
+  overflow: 'hidden',
 });

--- a/client/src/components/StepList/Step.tsx
+++ b/client/src/components/StepList/Step.tsx
@@ -9,6 +9,7 @@ import {Bill, Step as StepType} from 'types/serviceType';
 import {Text} from '@components/Design';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
+import {css} from '@emotion/react';
 
 interface Prop {
   step: StepType;
@@ -25,7 +26,17 @@ const Step = ({step}: Prop) => {
     <ListItem>
       <ListItem.Row>
         <ChipGroup color="gray" texts={step.members.map(member => member.name)} />
-        <Text size="caption" textColor="gray">
+
+        <Text
+          size="caption"
+          textColor="gray"
+          css={css`
+            flex-shrink: 0;
+            width: 2rem;
+            text-align: end;
+            margin-left: 0.5rem;
+          `}
+        >
           {step.members.length}명
         </Text>
       </ListItem.Row>


### PR DESCRIPTION
## issue
- close #625 

## 구현 목적

![Image](https://github.com/user-attachments/assets/be52fa4f-8ae5-4246-8700-c4fff0af391c)

위 사진처럼 일정 길이 이상으로 칩이 길어진다면 layout이 깨지는 현상이 발생합니다.
이를 해결해서 예상치 못한 화면이 유저에게 출력되지 않도록 하고자 합니다.

## 구현 내용

### `ChipGroup.tsx`

```tsx
export const chipGroupStyle = css({
  display: 'flex',
  gap: '0.25rem',
  flexWrap: 'wrap',
  overflow: 'hidden',
});
```

- chipGroupStyle에 flexWrap과 overflow 속성을 사용하여 예상된 길이보다 길어지지 않도록 설정

