### PR TITLE
[FE] 지출 추가에서 입력된 금액이 없을 시 layout이 변경되는 문제

### DIFF
--- a/client/src/components/AmountInput/AmountInput.tsx
+++ b/client/src/components/AmountInput/AmountInput.tsx
@@ -28,8 +28,8 @@ const AmountInput = ({value, onClick, underlined, activated}: Props) => {
       `}
       onClick={onClick}
     >
-      <Text size="head" textColor={value !== '0' ? 'black' : 'gray'}>
-        {value}
+      <Text size="head" textColor={value !== '' && value !== '0' ? 'black' : 'gray'}>
+        {value === '' ? '0' : value}
       </Text>
       <Text
         textColor="gray"


### PR DESCRIPTION
## issue
- close #630 

## 구현 목적
지출 추가 시 금액이 없는 경우 Text의 값이 없어 공간을 차지하지 않게 되면서
아래와 같이 layout이 변경됩니다.

https://github.com/user-attachments/assets/d6fa8b0c-46ca-417f-932f-265923988ba2

## 구현 내용
값이 없는 경우에도 "0" 값을 이용하여 가상의 placeholder를 구현하였습니다.
이로 인해 layout이 변경되지 않습니다.

## 🫡 참고사항
input과 비슷하게 작동을 하는 `AmountInput` component이지만 NumberKeyboard를 사용하기 때문에 실제 input으로 구현하지는 않았습니다.
하지만 추후 접근성을 위해서라면 input 태그를 사용하는 방식으로 변경해야 할 것 같은데 어떻게 생각하시나요? 이 component는 input일까요? 그냥 값을 보여주는 div일까요?

`Top/Linte.tsx`와 `Top/EditableLine.tsx`,
`Amount/Amount`와 `Amount/EditableAmount.tsx`의 차이점을 보시면
쉽게 이해가 되실 것이라 생각합니다~