### PR TITLE
[FE] NumberKeyboardBottomSheet 영역에서 스크롤이 가능한 문제

### DIFF
--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
@@ -1,21 +1,26 @@
 import {css} from '@emotion/react';
 import {createPortal} from 'react-dom';
+import {useEffect, useRef} from 'react';
 
 import {useTheme} from '@components/Design/theme/HDesignProvider';
 
 import FixedButton from '../FixedButton/FixedButton';
 
 import NumberKeyboard, {NumberKeyboardProps} from './NumberKeyboard';
+import useNumberKeyboardBottomSheet from './useNumberKeyboardBottomSheet';
 
 interface Props extends NumberKeyboardProps {
-  isOpened?: boolean;
+  isOpened: boolean;
   onClose: () => void;
 }
 
 const NumberKeyboardBottomSheet = ({isOpened, onClose, ...props}: Props) => {
   const {theme} = useTheme();
+  const {bottomSheetRef} = useNumberKeyboardBottomSheet({isOpened});
+
   return createPortal(
     <div
+      ref={bottomSheetRef}
       css={css`
         position: fixed;
         padding-bottom: 6.25rem;
@@ -26,6 +31,8 @@ const NumberKeyboardBottomSheet = ({isOpened, onClose, ...props}: Props) => {
         gap: 1rem;
         bottom: 0;
         background-color: ${theme.colors.white};
+        z-index: 20;
+        touch-action: none;
 
         transform: ${isOpened ? 'translate3d(0, 0, 0)' : 'translate3d(0, 100%, 0)'};
         transition: 0.2s ease-in-out;

--- a/client/src/components/Design/components/NumberKeyboard/useNumberKeyboardBottomSheet.ts
+++ b/client/src/components/Design/components/NumberKeyboard/useNumberKeyboardBottomSheet.ts
@@ -1,0 +1,32 @@
+import {useEffect, useRef} from 'react';
+
+interface Props {
+  isOpened: boolean;
+}
+
+const useNumberKeyboardBottomSheet = ({isOpened}: Props) => {
+  const bottomSheetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const bottomSheet = bottomSheetRef.current;
+    if (!bottomSheet) return;
+
+    const preventScroll = (e: TouchEvent) => {
+      if (bottomSheet.contains(e.target as Node)) {
+        e.preventDefault();
+      }
+    };
+
+    if (isOpened) {
+      document.addEventListener('touchmove', preventScroll, {passive: false});
+    }
+
+    return () => {
+      document.removeEventListener('touchmove', preventScroll);
+    };
+  }, [isOpened]);
+
+  return {bottomSheetRef};
+};
+
+export default useNumberKeyboardBottomSheet;


### PR DESCRIPTION
## issue
- close #617 

## 구현 목적

https://github.com/user-attachments/assets/08bc4d63-2236-4788-90c6-deb5b1bfaf3d
 
NumberKeyboardBottomSheet가 올라온 경우 해당 영역을 드래그 해도 스크롤이 가능한 문제가 있습니다.
이 경우 사용자가 의도하지 않은 대로 동작할 수 있고, 안좋은 유저 경험의 원인이 될 수 있다고 생각합니다.

## 구현 사항
```tsx
  useEffect(() => {
    const bottomSheet = bottomSheetRef.current;
    if (!bottomSheet) return;

    const preventScroll = (e: TouchEvent) => {
      if (bottomSheet.contains(e.target as Node)) {
        e.preventDefault();
      }
    };

    if (isOpened) {
      document.addEventListener('touchmove', preventScroll, {passive: false});
    }

    return () => {
      document.removeEventListener('touchmove', preventScroll);
    };
  }, [isOpened]);
```

- bottomSheet 영역에 touchMove Event가 있다면, touchEvent를 prevent 하도록 하는 코드를 작성했습니다.
- 따라서 BottomSheet 영역을 드래그해도 preventEvent로 인해 뒷 영역의 스크롤이 작동하지 않습니다.