### PR TITLE
[FE] 계좌번호 입력 제한 추가

### DIFF
--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -45,6 +45,7 @@ export const ERROR_MESSAGE = {
   preventEmpty: '값은 비어있을 수 없어요',
   invalidInput: '올바르지 않은 입력이에요.',
   emptyBank: '계좌번호가 입력되지 않아서\n토스 송금 기능을 사용할 수 없어요',
+  invalidAccountNumber: '계좌번호는 8자에서 30자 사이로 입력 가능해요',
 };
 
 export const UNKNOWN_ERROR = 'UNKNOWN_ERROR';

--- a/client/src/constants/regExp.ts
+++ b/client/src/constants/regExp.ts
@@ -3,6 +3,7 @@ const REGEXP = {
   eventUrl: /\/event\/([a-zA-Z0-9-]+)\//,
   billTitle: /^([ㄱ-ㅎ가-힣a-zA-Z0-9ㆍᆢ]\s?)*$/,
   memberName: /^([ㄱ-ㅎ가-힣a-zA-Zㆍᆢ]\s?)*$/,
+  accountNumber: /^[0-9\s\-]*$/,
 };
 
 export default REGEXP;

--- a/client/src/constants/rule.ts
+++ b/client/src/constants/rule.ts
@@ -3,6 +3,8 @@ const RULE = {
   maxEventPasswordLength: 4,
   maxMemberNameLength: 4,
   maxPrice: 10000000,
+  minAccountNumberLength: 8,
+  maxAccountNumberLength: 30,
 };
 
 export default RULE;

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -2,15 +2,20 @@ import type {Event} from 'types/serviceType';
 
 import {useEffect, useState} from 'react';
 
+import validateAccountNumber from '@utils/validate/validateAccountNumber';
+
+import RULE from '@constants/rule';
+
 import useRequestPatchEvent from './queries/event/useRequestPatchEvent';
 import useRequestGetEvent from './queries/event/useRequestGetEvent';
 
 const useAccount = () => {
   const {bankName, accountNumber} = useRequestGetEvent();
-
   const [bankNameState, setBankName] = useState(bankName);
   const [accountNumberState, setAccountNumber] = useState(accountNumber);
+  const [accountNumberErrorMessage, setAccountNumberErrorMessage] = useState<string | null>(null);
   const [canSubmit, setCanSubmit] = useState(false);
+  const [isPasting, setIsPasting] = useState(false);
 
   useEffect(() => {
     setBankName(bankName);
@@ -24,7 +29,32 @@ const useAccount = () => {
   };
 
   const handleAccount = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAccountNumber(event.target.value);
+    if (isPasting) return;
+
+    const newValue = event.target.value;
+    const {isValid, errorMessage} = validateAccountNumber(newValue);
+    setAccountNumberErrorMessage(errorMessage);
+
+    const isValidMinLength = newValue.length >= RULE.minAccountNumberLength;
+
+    if (isValid) {
+      setAccountNumber(event.target.value);
+    } else if (!isValid && !isValidMinLength) {
+      setAccountNumber(event.target.value.replace(/[^0-9\s\-]/g, '').trim());
+    }
+  };
+
+  const handleAccountOnPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    setIsPasting(true);
+
+    const value = `${accountNumberState}${event.clipboardData.getData('text')}`;
+    const newValue = value.replace(/[^0-9\s\-]/g, '').trim();
+    const {isValid, errorMessage} = validateAccountNumber(newValue);
+
+    setAccountNumberErrorMessage(errorMessage);
+    if (isValid) setAccountNumber(newValue);
+
+    setTimeout(() => setIsPasting(false), 0);
   };
 
   const getChangedField = () => {
@@ -49,15 +79,21 @@ const useAccount = () => {
     const existEmptyField = bankName.trim() === '' && accountNumber.trim() === '';
     const isChanged = bankName !== bankNameState || accountNumber !== accountNumberState;
 
-    setCanSubmit(!existEmptyField && isChanged);
-  }, [bankName, accountNumber, bankNameState, accountNumberState]);
+    setCanSubmit(!existEmptyField && isChanged && accountNumberErrorMessage === null);
+  }, [bankName, accountNumber, bankNameState, accountNumberState, accountNumberErrorMessage]);
+
+  useEffect(() => {
+    console.log(accountNumberErrorMessage);
+  }, [accountNumberErrorMessage]);
 
   return {
     bankName: bankNameState,
     accountNumber: accountNumberState,
+    accountNumberErrorMessage,
     canSubmit,
     selectBank,
     handleAccount,
+    handleAccountOnPaste,
     enrollAccount,
   };
 };

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -82,10 +82,6 @@ const useAccount = () => {
     setCanSubmit(!existEmptyField && isChanged && accountNumberErrorMessage === null);
   }, [bankName, accountNumber, bankNameState, accountNumberState, accountNumberErrorMessage]);
 
-  useEffect(() => {
-    console.log(accountNumberErrorMessage);
-  }, [accountNumberErrorMessage]);
-
   return {
     bankName: bankNameState,
     accountNumber: accountNumberState,

--- a/client/src/pages/AccountPage/Account.tsx
+++ b/client/src/pages/AccountPage/Account.tsx
@@ -15,7 +15,16 @@ const Account = () => {
 
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
-  const {bankName, accountNumber, canSubmit, selectBank, handleAccount, enrollAccount} = useAccount();
+  const {
+    bankName,
+    accountNumber,
+    accountNumberErrorMessage,
+    canSubmit,
+    selectBank,
+    handleAccount,
+    handleAccountOnPaste,
+    enrollAccount,
+  } = useAccount();
 
   const enrollAccountAndNavigateAdmin = async () => {
     await enrollAccount();
@@ -40,19 +49,19 @@ const Account = () => {
             errorText={null}
             autoFocus={false}
             isAlwaysOnLabel
-            isAlwaysOnInputBorder
             readOnly
             onClick={() => setIsBottomSheetOpen(true)}
           />
           <LabelInput
             labelText="계좌번호"
-            placeholder="030302-04-191806"
-            errorText={null}
+            placeholder="ex) 030302-04-191806"
+            errorText={accountNumberErrorMessage}
+            isError={accountNumberErrorMessage !== null}
             value={accountNumber ?? ''}
             onChange={handleAccount}
+            onPaste={handleAccountOnPaste}
             autoFocus={false}
             isAlwaysOnLabel
-            isAlwaysOnInputBorder
           />
           {isBottomSheetOpen && (
             <BankSelectModal

--- a/client/src/utils/validate/validateAccountNumber.ts
+++ b/client/src/utils/validate/validateAccountNumber.ts
@@ -1,0 +1,23 @@
+import {ERROR_MESSAGE} from '@constants/errorMessage';
+import REGEXP from '@constants/regExp';
+import RULE from '@constants/rule';
+
+import {ValidateResult} from './type';
+
+const validateAccountNumber = (accountNumber: string): ValidateResult => {
+  const isValidateType = () => {
+    return REGEXP.accountNumber.test(accountNumber);
+  };
+
+  const isValidateLength = () => {
+    return accountNumber.length >= RULE.minAccountNumberLength && accountNumber.length <= RULE.maxAccountNumberLength;
+  };
+
+  if (isValidateType() && isValidateLength()) {
+    return {isValid: true, errorMessage: null};
+  }
+
+  return {isValid: false, errorMessage: ERROR_MESSAGE.invalidAccountNumber};
+};
+
+export default validateAccountNumber;


### PR DESCRIPTION
## issue
- close #629 

## 구현 사항
### 계좌번호 입력 제한
계좌번호 입력을 제한하는 기능을 추가했습니다.
올 수 있는 문자는 숫자, 공백, 하이픈(-)이며 8자에서 30자 이하입니다.

8자 이하로 오는 경우는 글자가 지워지도록 따로 예외로 문자를 수정할 수 있도록 열어뒀어요.
30자 이상은 입력을 막았습니다.

이외 다른 문자들은 허용하지 않도록 막았습니다.

### 복사 붙여넣기 대응
계좌번호의 경우 은행 앱에서 복사 붙여넣기 하는 경우가 많습니다.
그 때 은행마다 복사되는 형식이 달라서 은행 이름 정보가 포함된 경우에 입력이 안 될 수 있다는 우려가 있었습니다.

하지만 토스를 참고한 결과 토스는 "1213123123213 신한"을 복사 붙여넣기 할 경우 "1213123123213"이 입력되는 것을 확인하고 이처럼 구현하면 좋겠다 생각하고 구현했습니다.

복붙의 경우 onChange가 아닌 onPaste를 사용해서 따로 검증하도록 설정했습니다.
paste된 값에서 먼저 숫자, 공백, 하이픈을 제외한 문자만 남겨서 검증을 해서 유효하지 않은 문자를 제거했습니다.
또한 paste 이벤트가 일어났을 때 onChange callback이 실행되지 않도록 설정해 onPaste한 값이 검증되고 상태로 관리되도록 설정했어요.


### 데모영상
https://github.com/user-attachments/assets/06d32c87-4f0d-4514-a8c1-021fee07f986


## 🫡 참고사항
