### PR TITLE
 [FE] 지출 생성 시 나갔던 멤버를 다시 추가할 수 없는 오류

### DIFF
--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 
 import {BillInfo} from '@pages/AddBillFunnel/AddBillFunnel';
-import {Member} from 'types/serviceType';
+import {Member, AllMembers} from 'types/serviceType';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
@@ -11,6 +11,7 @@ import REGEXP from '@constants/regExp';
 import useRequestPostMembers from './queries/member/useRequestPostMembers';
 import useRequestPostBill from './queries/bill/useRequestPostBill';
 import {BillStep} from './useAddBillFunnel';
+import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
 
 interface Props {
   billInfo: BillInfo;
@@ -23,6 +24,7 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
   const [errorMessage, setErrorMessage] = useState('');
   const [nameInput, setNameInput] = useState('');
 
+  const {members: allMembers} = useRequestGetAllMembers();
   const {postMembersAsync, isPending: isPendingPostMembers} = useRequestPostMembers();
 
   const {postBill, isSuccess: isSuccessPostBill, isPending: isPendingPostBill} = useRequestPostBill();
@@ -50,7 +52,7 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
   const canSubmitMembers = billInfo.members.length !== 0;
 
   const setBillInfoMemberWithId = (name: string) => {
-    const existingMember = currentMembers.find(currentMember => currentMember.name === name);
+    const existingMember = allMembers.find(currentMember => currentMember.name === name);
     if (existingMember) {
       setBillInfo(prev => ({...prev, members: [...prev.members, {id: existingMember.id, name: name}]}));
     } else {


### PR DESCRIPTION
## issue
- close #620

## 구현 목적
지출 생성 시 지워졌던 멤버를 다시 추가할 수 없는 오류가  발생합니다.
예를 들어 1차에 이상, 감자, 망쵸 가 있을 때, 2차에서는 망쵸가 나가고 이상, 감자가 남습니다.
3차에서 망쵸를 다시 추가하려고 할 때, "현재 참여하고 있는 인원이 존재합니다" 에러가 발생합니다.

https://github.com/user-attachments/assets/617eac71-bdb3-426e-a3e9-e7578fd881ab

## 구현 내용
기존에는 새로 멤버를 추가할 때, 이미 있는 멤버인지 판별하기 위해 `currentMember`와 비교했었습니다.

```tsx
// useMembersStep.tsx
// ...
    const setBillInfoMemberWithId = (name: string) => {
    const existingMember = currentMembers.find(currentMember => currentMember.name === name);
    if (existingMember) {
      setBillInfo(prev => ({...prev, members: [...prev.members, {id: existingMember.id, name: name}]}));
    } else {
      setBillInfo(prev => ({...prev, members: [...prev.members, {id: -1, name: name}]}));
    }
  };
// ...
```

하지만, 한번 나갔던 멤버의 정보는 currentMember에 존재하지 않고, allMember에 존재하기 때문에 비교하는 대상을 currentMember에서 `allMember`로 변경해 주었습니다.

```tsx
// useMembersStep.tsx
// ...
    const setBillInfoMemberWithId = (name: string) => {
    const existingMember = allMembers.find(currentMember => currentMember.name === name);
    if (existingMember) {
      setBillInfo(prev => ({...prev, members: [...prev.members, {id: existingMember.id, name: name}]}));
    } else {
      setBillInfo(prev => ({...prev, members: [...prev.members, {id: -1, name: name}]}));
    }
  };
// ...
```