### PR TITLE
[FE] 모바일 환경에서 Font가 제대로 적용되지 않는 문제

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -2,159 +2,148 @@ import {css} from '@emotion/react';
 
 // reset css -> index css
 export const GlobalStyle = css`
-  html,
-  body,
-  div,
-  span,
-  applet,
-  object,
-  iframe,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p,
-  blockquote,
-  pre,
-  a,
-  abbr,
-  acronym,
-  address,
-  big,
-  cite,
-  code,
-  del,
-  dfn,
-  em,
-  img,
-  ins,
-  kbd,
-  q,
-  s,
-  samp,
-  small,
-  strike,
-  strong,
-  sub,
-  sup,
-  tt,
-  b,
-  u,
-  i,
-  center,
-  dl,
-  dt,
-  dd,
-  ol,
-  ul,
-  li,
-  fieldset,
-  form,
-  label,
-  legend,
-  table,
-  caption,
-  tbody,
-  tfoot,
-  thead,
-  tr,
-  th,
-  td,
-  article,
-  aside,
-  canvas,
-  details,
-  embed,
-  figure,
-  figcaption,
-  footer,
-  header,
-  hgroup,
-  menu,
-  nav,
-  output,
-  ruby,
-  section,
-  summary,
-  time,
-  mark,
-  audio,
-  video {
-    vertical-align: baseline;
-    margin: 0;
-    border: 0;
-    padding: 0;
-    font-size: 100%;
-    font: inherit;
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+  *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
+    all: unset;
+    display: revert;
   }
-  /* HTML5 display-role reset for older browsers */
-  article,
-  aside,
-  details,
-  figcaption,
-  figure,
-  footer,
-  header,
-  hgroup,
-  menu,
-  nav,
-  section {
-    display: block;
-  }
-  body {
-    line-height: 1;
-  }
-  ol,
-  ul {
-    list-style: none;
-  }
-  blockquote,
-  q {
-    quotes: none;
-  }
-  blockquote:before,
-  blockquote:after,
-  q:before,
-  q:after {
-    content: '';
-    content: none;
-  }
-  table {
-    border-collapse: collapse;
-    border-spacing: 0;
-  }
-  button {
-    cursor: pointer;
-    border: none;
-    background-color: transparent;
-  }
-  * {
+
+  /* Preferred box-sizing value */
+  *,
+  *::before,
+  *::after {
     box-sizing: border-box;
   }
 
+  /* Fix mobile Safari increase font-size on landscape mode */
   html {
-    height: 100%;
+    -moz-text-size-adjust: none;
+    -webkit-text-size-adjust: none;
+    text-size-adjust: none;
   }
 
-  body {
-    max-width: 768px;
-    height: 100%;
-    margin: 0 auto;
-
-    overflow-y: scroll;
-    &::-webkit-scrollbar {
-      display: none;
-    }
+  /* Reapply the pointer cursor for anchor tags */
+  a,
+  button {
+    cursor: revert;
+    line-height: 0;
   }
 
-  section {
-    width: 100%;
+  button:disabled {
+    cursor: default;
+  }
+
+  /* Remove list styles (bullets/numbers) */
+  ol,
+  ul,
+  menu,
+  summary {
+    list-style: none;
+  }
+
+  /* Removes spacing between cells in tables */
+  table {
+    border-collapse: collapse;
+  }
+
+  /* Safari - solving issue when using user-select:none on the <body> text input doesn't working */
+  input,
+  textarea {
+    -webkit-user-select: auto;
+  }
+
+  /* Revert the 'white-space' property for textarea elements on Safari */
+  textarea {
+    white-space: revert;
+  }
+
+  /* Minimum style to allow to style meter element */
+  meter {
+    -webkit-appearance: revert;
+    appearance: revert;
+  }
+
+  /* Preformatted text - use only for this feature */
+  :where(pre) {
+    all: revert;
+    box-sizing: border-box;
+  }
+
+  /* Fix the feature of 'hidden' attribute.
+       display: revert; revert to element instead of attribute */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /* Revert for bug in Chromium browsers
+       - Fix for the content editable attribute will work properly.
+       - webkit-user-select: auto; added for Safari in case of using user-select:none on wrapper element */
+  :where([contenteditable]:not([contenteditable='false'])) {
+    -moz-user-modify: read-write;
+    -webkit-user-modify: read-write;
+    overflow-wrap: break-word;
+    -webkit-line-break: after-white-space;
+    -webkit-user-select: auto;
+  }
+
+  /* Apply back the draggable feature - exist only in Chromium and Safari */
+  :where([draggable='true']) {
+    -webkit-user-drag: element;
+  }
+
+  /* Revert Modal native behavior */
+  :where(dialog:modal) {
+    all: revert;
+    box-sizing: border-box;
+  }
+
+  /* Remove details summary webkit styles */
+  ::-webkit-details-marker {
+    display: none;
+  }
+
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox  */
+  input[type='number'] {
+    -moz-appearance: textfield;
   }
 
   #root {
     display: flex;
-    flex-direction: column;
+    justify-content: center;
+  }
+
+  button {
+    cursor: pointer;
+  }
+
+  body {
+    font-family:
+      'Pretendard',
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      Roboto,
+      'Helvetica Neue',
+      'Segoe UI',
+      'Apple SD Gothic Neo',
+      'Noto Sans KR',
+      'Malgun Gothic',
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol',
+      sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: 'tnum';
+    max-width: 768px;
+    margin: 0 auto;
   }
 `;

--- a/client/src/components/Design/theme/GlobalStyle.ts
+++ b/client/src/components/Design/theme/GlobalStyle.ts
@@ -1,6 +1,9 @@
 import {css} from '@emotion/react';
 
+// reset css -> index css
 export const GlobalStyle = css`
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
   *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
     all: unset;
     display: revert;
@@ -119,5 +122,27 @@ export const GlobalStyle = css`
 
   button {
     cursor: pointer;
+  }
+
+  body {
+    font-family:
+      'Pretendard',
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      Roboto,
+      'Helvetica Neue',
+      'Segoe UI',
+      'Apple SD Gothic Neo',
+      'Noto Sans KR',
+      'Malgun Gothic',
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol',
+      sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    max-width: 768px;
+    margin: 0 auto;
   }
 `;


### PR DESCRIPTION
## issue
- close #615

## 구현 목적
일부 모바일 환경에서 pretendart font가 적용되지 않는 문제가 있었습니다.
의도한 디자인을 전달할 수 없는 문제가 있어 이를 해결하려고 했습니다.

## 구현 사항
기존에 `font-family : "Pretendart"`를 사용해 줬지만, web font를 import 하는 코드가 없었습니다.
client 에서 pretendard font를 가지고 있는 데스크탑 환경에서는 정상 작동했지만,
그렇지 않을 수 있는 모바일 환경에서는 대체 폰트를 사용하기 때문에 발생한 문제라고 판단했습니다.

따라서
```tsx
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
```
를 이용해 webfont 주소를 명시해 주었습니다.