### PR TITLE
[BE] API 명세서에 작성된 예외 최신화 및 코드 수정

### DIFF
--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -14,8 +14,8 @@ public enum HaengdongErrorCode {
     BANK_NAME_INVALID("지원하지 않는 은행입니다. 지원하는 은행 목록: %s"),
     ACCOUNT_LENGTH_INVALID("계좌번호는 %d자 이상 %d자 이하만 입력 가능합니다."),
 
-    MEMBER_NAME_LENGTH_INVALID("멤버 이름은 %d자 이상 %d자 이하만 입력 가능합니다."),
-    MEMBER_NAME_DUPLICATE("중복된 행사 참여 인원 이름이 존재합니다."),
+    MEMBER_NAME_LENGTH_INVALID("참여자 이름은 %d자 이상 %d자 이하만 입력 가능합니다."),
+    MEMBER_NAME_DUPLICATE("행사에 중복된 참여자 이름이 존재합니다."),
     MEMBER_NOT_FOUND("존재하지 않는 참여자입니다."),
     MEMBER_ALREADY_EXIST("현재 참여하고 있는 인원이 존재합니다."),
     MEMBER_NAME_CHANGE_DUPLICATE("중복된 참여 인원 이름 변경 요청이 존재합니다."),
@@ -27,14 +27,13 @@ public enum HaengdongErrorCode {
     BILL_DETAIL_NOT_FOUND("존재하지 않는 참여자 지출입니다."),
     BILL_PRICE_NOT_MATCHED("지출 총액이 일치하지 않습니다."),
 
-    DIFFERENT_STEP_MEMBERS("회원 목록이 일치하지 않습니다."),
+    DIFFERENT_STEP_MEMBERS("참여자 목록이 일치하지 않습니다."),
 
     /* Authentication */
 
     PASSWORD_INVALID("비밀번호가 일치하지 않습니다."),
 
     TOKEN_NOT_FOUND("토큰이 존재하지 않습니다."),
-    TOKEN_EXPIRED("만료된 토큰입니다."),
     TOKEN_INVALID("유효하지 않은 토큰입니다."),
 
     FORBIDDEN("접근할 수 없는 행사입니다."),

--- a/server/src/main/java/server/haengdong/presentation/request/BillDetailUpdateRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/BillDetailUpdateRequest.java
@@ -11,7 +11,6 @@ public record BillDetailUpdateRequest(
         @NotNull(message = "지출 금액은 공백일 수 없습니다.")
         Long price,
 
-        @NotNull(message = "지출 금액은 공백일 수 없습니다.")
         boolean isFixed
 ) {
     public BillDetailUpdateAppRequest toAppRequest() {

--- a/server/src/main/java/server/haengdong/presentation/request/MemberSaveRequest.java
+++ b/server/src/main/java/server/haengdong/presentation/request/MemberSaveRequest.java
@@ -1,4 +1,10 @@
 package server.haengdong.presentation.request;
 
-public record MemberSaveRequest(String name) {
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberSaveRequest(
+
+        @NotBlank(message = "참여자 이름은 공백일 수 없습니다.")
+        String name
+) {
 }

--- a/server/src/test/java/server/haengdong/application/MemberServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/MemberServiceTest.java
@@ -120,7 +120,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.saveMembers(event.getToken(), request))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessageContaining("중복된 행사 참여 인원 이름이 존재합니다.");
+                .hasMessageContaining("행사에 중복된 참여자 이름이 존재합니다.");
     }
 
     @DisplayName("행사 참여 인원을 삭제한다.")
@@ -329,7 +329,7 @@ class MemberServiceTest extends ServiceTestSupport {
 
         assertThatThrownBy(() -> memberService.updateMembers(event.getToken(), membersUpdateAppRequest))
                 .isInstanceOf(HaengdongException.class)
-                .hasMessage("중복된 행사 참여 인원 이름이 존재합니다.");
+                .hasMessage("행사에 중복된 참여자 이름이 존재합니다.");
     }
 
     @DisplayName("행사에 참여한 전체 인원을 조회한다.")


### PR DESCRIPTION
## issue
- close #642 

## 구현 사항
노션 API 명세서에 작성된 예외 상황별 예외코드와 메세지를 백엔드 코드에 맞게 동기화하고,
`HaengdongErrorCode` enum에서 더이상 사용하지 않는 `TOKEN_EXPIRED`을 삭제했습니다.

`지출 상세 수정` API 에서 사용하는 DTO `BillDetailUpdateRequest`의 `isFixed` 필드의 잘못된 검증 메세지를 제거하고 primitive 타입으로 변환했습니다. 또 `참여자 추가` API 에서 사용하는 DTO `MemberSaveRequest`의 `name` 필드에 검증을 추가했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
