### PR TITLE
[FE] GlobalStyle tnum 삭제

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -142,7 +142,6 @@ export const GlobalStyle = css`
       sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    font-feature-settings: 'tnum';
     max-width: 768px;
     margin: 0 auto;
   }


### PR DESCRIPTION
## issue
- close #647 

## 구현 목적
코드 수정 중 잘못 입력된 tnum attribute로 인해 예상된 폰트 디자인이 출력되지 않습니다.

## 구현 내용
tnum attribute 를 제거했습니다.

## 🫡 참고사항
