### PR TITLE
[FE] IOS 환경에서도 토스 송금 기능을 똑같이 이용할 수 있도록 설정

### DIFF
--- a/client/src/components/Design/components/ExpenseList/ExpenseList.tsx
+++ b/client/src/components/Design/components/ExpenseList/ExpenseList.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import Text from '@HDcomponents/Text/Text';
 
-import isMobileDevice from '@utils/isMobileDevice';
+import {isMobileDevice} from '@utils/detectDevice';
 
 import BankSendButton from '../BankSendButton/BankSendButton';
 import Icon from '../Icon/Icon';

--- a/client/src/components/ShareEventButton/ShareEventButton.tsx
+++ b/client/src/components/ShareEventButton/ShareEventButton.tsx
@@ -8,7 +8,7 @@ import useShareEvent from '@hooks/useShareEvent';
 
 import {Button} from '@components/Design';
 
-import isMobileDevice from '@utils/isMobileDevice';
+import {isMobileDevice} from '@utils/detectDevice';
 import getDeletedLastPath from '@utils/getDeletedLastPath';
 
 type ShareEventButtonProps = {

--- a/client/src/hooks/useReportsPage.ts
+++ b/client/src/hooks/useReportsPage.ts
@@ -3,6 +3,8 @@ import {useOutletContext} from 'react-router-dom';
 
 import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
 
+import {isAndroid, isIOS} from '@utils/detectDevice';
+
 import {ERROR_MESSAGE} from '@constants/errorMessage';
 
 import {useSearchReports} from './useSearchReports';
@@ -26,8 +28,17 @@ const useReportsPage = () => {
       return;
     }
 
-    const url = 'supertoss://';
-    window.location.href = url;
+    if (isAndroid()) {
+      const url = 'supertoss://';
+      window.location.href = url;
+      return;
+    }
+
+    if (isIOS()) {
+      const url = 'supertoss://send';
+      window.location.href = url;
+      return;
+    }
   };
 
   const expenseListProp = matchedReports.map(member => ({

--- a/client/src/utils/detectDevice.ts
+++ b/client/src/utils/detectDevice.ts
@@ -1,0 +1,20 @@
+export const isMobileDevice = () => {
+  const userAgent = window.navigator.userAgent;
+  const mobileRegex = [/Android/i, /iPhone/i, /iPad/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];
+
+  return mobileRegex.some(mobile => userAgent.match(mobile));
+};
+
+export const isIOS = () => {
+  const userAgent = window.navigator.userAgent;
+  const iosRegex = [/iPhone/i, /iPad/i, /iPod/i];
+
+  return iosRegex.some(device => userAgent.match(device));
+};
+
+export const isAndroid = () => {
+  const userAgent = window.navigator.userAgent;
+  const androidRegex = [/Android/i, /BlackBerry/i, /Windows Phone/i];
+
+  return androidRegex.some(device => userAgent.match(device));
+};

--- a/client/src/utils/isMobileDevice.ts
+++ b/client/src/utils/isMobileDevice.ts
@@ -1,8 +1,0 @@
-const isMobileDevice = () => {
-  const userAgent = window.navigator.userAgent;
-  const mobileRegex = [/Android/i, /iPhone/i, /iPad/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];
-
-  return mobileRegex.some(mobile => userAgent.match(mobile));
-};
-
-export default isMobileDevice;


### PR DESCRIPTION
## issue
- close #649 

## 구현 사항
### 안드로이드, IOS 환경 구분 기능 추가

userAgent에서  [/iPhone/i, /iPad/i, /iPod/i]가 포함되어 있다면 ios로 판별 [/Android/i, /BlackBerry/i, /Windows Phone/i]가 포함되어 있다면 안드로이드로 판별합니다.

### 안드로이드와 IOS에 따른 URL스킴 변경

```tsx
if (isAndroid()) {
  const url = 'supertoss://';
  window.location.href = url;
  return;
}

if (isIOS()) {
  const url = 'supertoss://send';
  window.location.href = url;
  return;
}
```

안드로이드는 기존 그대로
IOS는 토스의 송금하기 페이지로 보내버립니다.


## 🫡 참고사항
