### PR TITLE
[FE] merge 진행하면서 put, delete 요청 순서 보장 사라짐 + 수정 완료 Toast 없어짐 추가

### DIFF
--- a/client/cypress/e2e/createEvent.cy.ts
+++ b/client/cypress/e2e/createEvent.cy.ts
@@ -8,9 +8,9 @@ beforeEach(() => {
 });
 
 describe('Flow: 랜딩 페이지에서부터 이벤트를 생성 완료하는 flow', () => {
-  it('랜딩페이지에서 "행사 생성하기" 버튼을 눌러 행사 이름 입력 페이지로 이동해야 한다.', () => {
+  it('랜딩페이지에서 "정산 시작하기" 버튼을 눌러 행사 이름 입력 페이지로 이동해야 한다.', () => {
     cy.visit('/');
-    cy.get('header').find('button').click();
+    cy.get('button').contains('정산 시작하기').click();
     cy.url().should('include', ROUTER_URLS.createEvent);
   });
 

--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
@@ -31,7 +31,7 @@ const NumberKeyboardBottomSheet = ({isOpened, onClose, ...props}: Props) => {
         gap: 1rem;
         bottom: 0;
         background-color: ${theme.colors.white};
-        z-index: 20;
+        z-index: ${theme.zIndex.numberKeyboardBottomSheet};
         touch-action: none;
 
         transform: ${isOpened ? 'translate3d(0, 0, 0)' : 'translate3d(0, 100%, 0)'};

--- a/client/src/components/Design/components/TopNav/TopNav.style.ts
+++ b/client/src/components/Design/components/TopNav/TopNav.style.ts
@@ -4,6 +4,5 @@ export const topNavStyle = css({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  padding: '0 1rem',
   width: '100%',
 });

--- a/client/src/components/Design/components/TopNav/TopNav.tsx
+++ b/client/src/components/Design/components/TopNav/TopNav.tsx
@@ -8,7 +8,7 @@ type TopNavProps = React.PropsWithChildren & {
 
 const TopNav = ({children}: TopNavProps) => {
   return (
-    <nav>
+    <nav style={{margin: '0 1rem'}}>
       <ul css={topNavStyle}>{children}</ul>
     </nav>
   );

--- a/client/src/components/ShareEventButton/ShareEventButton.tsx
+++ b/client/src/components/ShareEventButton/ShareEventButton.tsx
@@ -39,7 +39,7 @@ const ShareEventButton = ({eventOutline}: ShareEventButtonProps) => {
   };
 
   return isMobile ? (
-    <Button size="small" variants="tertiary" onClick={induceBankInfoBeforeShare}>
+    <Button size="small" variants="tertiary" onClick={induceBankInfoBeforeShare} style={{marginRight: '1rem'}}>
       카카오톡으로 정산 초대하기
     </Button>
   ) : (

--- a/client/src/constants/message.ts
+++ b/client/src/constants/message.ts
@@ -1,0 +1,5 @@
+const MESSAGE = {
+  confirmEditEventMember: '수정이 완료되었어요 :)',
+};
+
+export default MESSAGE;

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -95,13 +95,13 @@ const useEventMember = (): ReturnUseEventMember => {
     // deleteMembers에 값이 하나라도 전재하면 반복문을 통해 DELETE api 요청
     if (deleteMembers.length > 0) {
       for (const id of deleteMembers) {
-        deleteAsyncMember({memberId: id});
+        await deleteAsyncMember({memberId: id});
       }
     }
 
     // 변경된 값(filteredChangedMembers)이 존재한다면 PUT 요청 실행
     if (reports.length > 0) {
-      putAsyncMember({
+      await putAsyncMember({
         members: reports.map(report => ({
           id: report.memberId,
           name: report.memberName,

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -3,6 +3,8 @@ import {useEffect, useState, useCallback, useMemo} from 'react';
 import {Report} from 'types/serviceType';
 import validateMemberName from '@utils/validate/validateMemberName';
 
+import MESSAGE from '@constants/message';
+
 import toast from './useToast/toast';
 import useRequestDeleteMember from './queries/member/useRequestDeleteMember';
 import useRequestPutMembers from './queries/member/useRequestPutMembers';
@@ -109,6 +111,8 @@ const useEventMember = (): ReturnUseEventMember => {
         })),
       });
     }
+
+    toast.confirm(MESSAGE.confirmEditEventMember);
   }, [deleteMembers, reports, initialReports, deleteAsyncMember, putAsyncMember]);
 
   return {reports, canSubmit, changeMemberName, handleDeleteMember, updateMembersOnServer, toggleDepositStatus};

--- a/client/src/pages/EventPage/AdminPage/EventMember.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventMember.tsx
@@ -46,7 +46,7 @@ const EventMember = () => {
         {reports.length === 0 ? (
           <></>
         ) : (
-          <FixedButton disabled={!canSubmit} onClick={updateMembersOnServer} style={{zIndex: '100'}}>
+          <FixedButton disabled={!canSubmit} onClick={updateMembersOnServer}>
             수정완료
           </FixedButton>
         )}

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -22,7 +22,7 @@ const EventPageLayout = () => {
 
   return (
     <MainLayout backgroundColor="gray">
-      <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem 0 0">
+      <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem">
         <TopNav>
           <TopNav.Item routePath="/">
             <IconButton variants="none">

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -22,7 +22,7 @@ const EventPageLayout = () => {
 
   return (
     <MainLayout backgroundColor="gray">
-      <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem">
+      <Flex justifyContent="spaceBetween" alignItems="center">
         <TopNav>
           <TopNav.Item routePath="/">
             <IconButton variants="none">

--- a/client/src/pages/MainPage/MainPage.tsx
+++ b/client/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,4 @@
-import {MainLayout} from '@HDesign/index';
+import {Flex, MainLayout} from '@HDesign/index';
 
 import Nav from './Nav/Nav';
 import MainSection from './Section/MainSection';

--- a/client/src/pages/MainPage/Nav/Nav.tsx
+++ b/client/src/pages/MainPage/Nav/Nav.tsx
@@ -10,7 +10,7 @@ const Nav = () => {
   const {theme} = useTheme();
   const navigate = useNavigate();
   return (
-    <Flex justifyContent="spaceBetween" alignItems="center" height="37px">
+    <header style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', height: '37px'}}>
       <TopNav>
         <TopNav.Item routePath="/">
           <IconButton variants="none">
@@ -29,7 +29,7 @@ const Nav = () => {
       >
         정산 시작하기
       </Button>
-    </Flex>
+    </header>
   );
 };
 

--- a/client/src/pages/MainPage/Nav/Nav.tsx
+++ b/client/src/pages/MainPage/Nav/Nav.tsx
@@ -1,29 +1,30 @@
 import {useNavigate} from 'react-router-dom';
 
-import Heundeut from '@assets/image/heundeut.svg';
 import {useTheme} from '@theme/HDesignProvider';
 
-import {Button, Flex, Text} from '@HDesign/index';
+import {Button, Flex, Text, Icon, TopNav, IconButton} from '@HDesign/index';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
-
-import {logoStyle, navStyle} from './Nav.style';
 
 const Nav = () => {
   const {theme} = useTheme();
   const navigate = useNavigate();
   return (
-    <header css={navStyle(theme)}>
-      <Flex gap="0.5rem">
-        <Heundeut />
-        <div css={logoStyle}>
+    <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem" height="37px">
+      <TopNav>
+        <TopNav.Item routePath="/">
+          <IconButton variants="none">
+            <Icon iconType="heundeut" />
+          </IconButton>
+        </TopNav.Item>
+        <TopNav.Item routePath="/">
           <Text size="subTitle">행동대장</Text>
-        </div>
-      </Flex>
+        </TopNav.Item>
+      </TopNav>
       <Button size="medium" variants="tertiary" onClick={() => navigate(ROUTER_URLS.createEvent)}>
         정산 시작하기
       </Button>
-    </header>
+    </Flex>
   );
 };
 

--- a/client/src/pages/MainPage/Nav/Nav.tsx
+++ b/client/src/pages/MainPage/Nav/Nav.tsx
@@ -10,7 +10,7 @@ const Nav = () => {
   const {theme} = useTheme();
   const navigate = useNavigate();
   return (
-    <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem" height="37px">
+    <Flex justifyContent="spaceBetween" alignItems="center" height="37px">
       <TopNav>
         <TopNav.Item routePath="/">
           <IconButton variants="none">
@@ -21,7 +21,12 @@ const Nav = () => {
           <Text size="subTitle">행동대장</Text>
         </TopNav.Item>
       </TopNav>
-      <Button size="medium" variants="tertiary" onClick={() => navigate(ROUTER_URLS.createEvent)}>
+      <Button
+        size="medium"
+        variants="tertiary"
+        onClick={() => navigate(ROUTER_URLS.createEvent)}
+        style={{marginRight: '1rem'}}
+      >
         정산 시작하기
       </Button>
     </Flex>


### PR DESCRIPTION
## issue
- close #646

## 구현 사항
- put, delete 요청 순서 보장 누락된 것 살리기
- '수정완료' 토스트 누락된 것 살리기
- 랜딩페이지와 메인페이지의 header 디자인이 일치하지 않는 문제 수정

   랜딩페이지에서는 Nav를 사용하고 메인페이지에서는 TopNav를 사용했어요.

   둘이 각자 다른 컴포넌트를 사용하고 있었기 때문에 디자인이 일치하지 않았어요.
   따라서 Nav 컴포넌트는 TopNav 컴포넌트를 적용하도록 수정했습니다.

   그러는 과정에서 margin이 '뒤로가기'에서는 적용되지 않았어요.
   그래서 그냥 TopNav에 margin 양옆 1rem을 적용해줬습니다.

   그러면 TopNav를 사용하는 곳에서 Flex에 항상` margin="0 1rem 0 0"`을 적용해줬는데 그럴 필요가 사라졌어요.
   대신 "정산 시작하기" , "카카오톡 정산 초대하기" 버튼은 TopNav에 들어가는 것이 아니기 때문에 margin 1rem이 적용되지 않았어요. 그래서 각 button 들에` marginRight: 1rem`을 적용해줬습니다.

- z-index 상수 미적용 코드 적용 및 불필요한 z-index 삭제

## 🫡 참고사항
