### PR TITLE
[FE] 멤버 추가 시 제대로 작동하지 않는 문제 수정

### DIFF
--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -2,7 +2,7 @@ import {RefObject, useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 
 import {BillInfo} from '@pages/AddBillFunnel/AddBillFunnel';
-import {Member, AllMembers} from 'types/serviceType';
+import {Member} from 'types/serviceType';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
@@ -11,7 +11,6 @@ import REGEXP from '@constants/regExp';
 import useRequestPostMembers from './queries/member/useRequestPostMembers';
 import useRequestPostBill from './queries/bill/useRequestPostBill';
 import {BillStep} from './useAddBillFunnel';
-import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
 
 interface Props {
   billInfo: BillInfo;
@@ -25,7 +24,6 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
   const [nameInput, setNameInput] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const {members: allMembers} = useRequestGetAllMembers();
   const {postMembersAsync, isPending: isPendingPostMembers} = useRequestPostMembers();
 
   const {postBill, isSuccess: isSuccessPostBill, isPending: isPendingPostBill} = useRequestPostBill();
@@ -48,12 +46,12 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
     }
   };
 
-  const canAddMembers = nameInput && !errorMessage;
+  const canAddMembers = nameInput && nameInput.length <= 4;
 
   const canSubmitMembers = billInfo.members.length !== 0;
 
   const setBillInfoMemberWithId = (name: string) => {
-    const existingMember = allMembers.find(currentMember => currentMember.name === name);
+    const existingMember = currentMembers.find(currentMember => currentMember.name === name);
     if (existingMember) {
       setBillInfo(prev => ({...prev, members: [...prev.members, {id: existingMember.id, name: name}]}));
     } else {
@@ -63,16 +61,21 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
 
   const handleNameInputEnter = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && canAddMembers) {
-      event.preventDefault();
       if (!billInfo.members.map(({name}) => name).includes(nameInput)) {
         setBillInfoMemberWithId(nameInput);
       }
       setNameInput('');
       if (inputRef.current) {
         inputRef.current.blur();
-        setTimeout(() => inputRef.current?.focus(), 0);
+        setTimeout(() => {
+          inputRef.current?.focus();
+        }, 0);
+      }
+      if (event.nativeEvent.isComposing) {
+        return;
       }
     }
+    console.log(event.nativeEvent.isComposing);
   };
 
   const handlePostBill = async () => {

--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -75,7 +75,6 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
         return;
       }
     }
-    console.log(event.nativeEvent.isComposing);
   };
 
   const handlePostBill = async () => {
@@ -108,10 +107,6 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
       navigate(`/event/${eventId}/admin`);
     }
   }, [isSuccessPostBill]);
-
-  useEffect(() => {
-    console.log(nameInput);
-  }, [nameInput]);
 
   const handlePrevStep = () => {
     setStep('title');


### PR DESCRIPTION
## issue
- close #650 

## 구현 목적
#619 
#631 
에서 구현한 문제가 해결되지 않았습니다.

멤버를 추가할 경우, 인풋에 focus가 해제되는 경우도 있고,
전에 입력한 부분이 함께 입력되는 오류도 있습니다.

## 구현 사항
enter를 입력해도, isComposing이 true인 경우가 모바일에서 존재했습니다.
각 입력 상태를 검증하는 순서를 변경하고,
blur 후 focus를 줌으로써 isComposing을 초기화하는 방향을 선택했습니다.

## 🫡 참고사항
