### PR TITLE
[FE] login 페이지 레이아웃 오류

### DIFF
--- a/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
@@ -5,17 +5,28 @@ import useEventLogin from '@hooks/useEventLogin';
 import {FixedButton, LabelInput} from '@HDesign/index';
 
 import RULE from '@constants/rule';
+import {css} from '@emotion/react';
 
 const EventLoginPage = () => {
   const {password, errorMessage, handleChange, canSubmit, submitPassword} = useEventLogin();
 
   return (
-    <>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1rem;
+      `}
+    >
       <Top>
-        <Top.Line text="행사 생성 시 설정한" />
-        <Top.Line text={`${RULE.maxEventPasswordLength}자리 숫자 비밀번호를 입력해 주세요.`} />
+        <Top.Line
+          text={`행사 생성 시 설정한 ${RULE.maxEventPasswordLength}자리`}
+          emphasize={[`${RULE.maxEventPasswordLength}자리`]}
+        />
+        <Top.Line text="숫자 비밀번호를 입력해 주세요." emphasize={['비밀번호']} />
       </Top>
-      <form onSubmit={submitPassword} style={{padding: '0 1rem'}}>
+      <form onSubmit={submitPassword}>
         <LabelInput
           labelText="비밀번호"
           errorText={errorMessage}
@@ -29,7 +40,7 @@ const EventLoginPage = () => {
         ></LabelInput>
         <FixedButton disabled={!canSubmit}>관리 페이지로</FixedButton>
       </form>
-    </>
+    </div>
   );
 };
 

--- a/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/EventLoginPage.tsx
@@ -1,3 +1,5 @@
+import {css} from '@emotion/react';
+
 import Top from '@components/Design/components/Top/Top';
 
 import useEventLogin from '@hooks/useEventLogin';
@@ -5,7 +7,6 @@ import useEventLogin from '@hooks/useEventLogin';
 import {FixedButton, LabelInput} from '@HDesign/index';
 
 import RULE from '@constants/rule';
-import {css} from '@emotion/react';
 
 const EventLoginPage = () => {
   const {password, errorMessage, handleChange, canSubmit, submitPassword} = useEventLogin();


### PR DESCRIPTION
## issue
- close #654 

## 구현 목적
top component가 변경되면서 login 페이지 레이아웃이 변경되었습니다.

![Image](https://github.com/user-attachments/assets/d2a9fe64-c10e-4bef-a753-75bce21aabd3)

로그인 페이지 레이아웃이 의도치 않게 망가져 있어 사용자 개선을 위해 이를 변경합니다.

## 구현 사항
css를 적용해주고, 문구를 변경하였습니다.

![image](https://github.com/user-attachments/assets/bdd86d59-833c-4dcd-8199-3563eb620c91)
