### PR TITLE
[FE] 멤버 추가 시 제대로 작동하지 않는 문제 수정

### DIFF
--- a/client/src/components/Design/components/Input/Input.tsx
+++ b/client/src/components/Design/components/Input/Input.tsx
@@ -14,7 +14,7 @@ export const Input: React.FC<InputProps> = forwardRef<HTMLInputElement, InputPro
     onChange,
     onFocus,
     onBlur,
-    inputType,
+    inputType = 'input',
     isError,
     placeholder,
     autoFocus,

--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -60,19 +60,16 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
   };
 
   const handleNameInputEnter = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter' && canAddMembers) {
+    if (event.key === 'Enter' && canAddMembers && inputRef.current) {
+      event.preventDefault();
       if (!billInfo.members.map(({name}) => name).includes(nameInput)) {
         setBillInfoMemberWithId(nameInput);
-      }
-      setNameInput('');
-      if (inputRef.current) {
+        setNameInput('');
+        inputRef.current.value = '';
         inputRef.current.blur();
         setTimeout(() => {
-          inputRef.current?.focus();
-        }, 0);
-      }
-      if (event.nativeEvent.isComposing) {
-        return;
+          if (inputRef.current) inputRef.current?.focus();
+        }, 10);
       }
     }
   };


### PR DESCRIPTION
## issue
- close #660 0 

## 구현 목적
#619 
#631 
에서 구현한 문제가 해결되지 않았습니다.

멤버를 추가할 경우, 인풋에 focus가 해제되는 경우도 있고,
전에 입력한 부분이 함께 입력되는 오류도 있습니다.

## 구현 사항
enter를 입력해도, isComposing이 true인 경우가 모바일에서 존재했습니다.
각 입력 상태를 검증하는 순서를 변경하고,
blur 후 focus를 줌으로써 isComposing을 초기화하는 방향을 선택했습니다.

## 🫡 참고사항
