### PR TITLE
[FE] 지출 내역 100만원 이상 등록이 되지 않는 버그

### DIFF
--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -88,7 +88,7 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
       });
       postBill({
         title: billInfo.title,
-        price: Number(billInfo.price.replace(',', '')),
+        price: Number(billInfo.price.replace(/,/g, '')),
         memberIds: billInfo.members.map(member =>
           member.id === -1 ? newMembers.members.find(m => m.name === member.name)?.id || member.id : member.id,
         ),
@@ -96,7 +96,7 @@ const useMembersStep = ({billInfo, setBillInfo, currentMembers, setStep}: Props)
     } else {
       postBill({
         title: billInfo.title,
-        price: Number(billInfo.price.replace(',', '')),
+        price: Number(billInfo.price.replace(/,/g, '')),
         memberIds: billInfo.members.map(({id}) => id),
       });
     }


### PR DESCRIPTION
## issue
- close #669 

## 구현 사항
### String.replace(string, string) => String.replace(RegExp, string)으로 변경
첫 번째 인자에 string을 사용하면 가장 먼저 찾은 문자만 바뀌게 됩니다.
1,000,000의 경우 1000,000이 되어 숫자로 인식할 수 없는 문제였습니다.

그래서 /,/g 정규식을 사용해서 해당 문자의 모든 콤마를 지우도록 수정했습니다.

## 🫡 참고사항
