### PR TITLE
[FE] 입금 완료를 했는데 송금 버튼이 눌리는 버그

### DIFF
--- a/client/src/components/Design/components/ExpenseList/ExpenseList.tsx
+++ b/client/src/components/Design/components/ExpenseList/ExpenseList.tsx
@@ -42,7 +42,7 @@ function ExpenseItem({
           <BankSendButton
             clipboardText={clipboardText}
             onBankButtonClick={onBankButtonClick}
-            isDeposited={price <= 0}
+            isDeposited={price <= 0 || isDeposited}
           />
         ) : (
           <IconButton variants="none" size="small">


### PR DESCRIPTION
## issue
- close #674 

## 구현 사항
BankSendButton에 isDeposited prop을 넣어줬습니다.
기존에는 price가 0보다 작거나 같은지만 넣어줬다면 isDeposited 값도 넣어줍니다.

```tsx
<BankSendButton
            clipboardText={clipboardText}
            onBankButtonClick={onBankButtonClick}
            isDeposited={price <= 0 || isDeposited}
          />
```

![image](https://github.com/user-attachments/assets/1367bd79-1a65-4f7b-aac4-f4d50c96e425)


## 🫡 참고사항
