### PR TITLE
[FE] 관리 입장시 잘못된 비밀번호 입력하면 '알수 없는 페이지'로 이동함

### DIFF
--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -36,6 +36,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   TOKEN_EXPIRED: '로그인이 만료되었어요. 다시 로그인해주세요.',
   TOKEN_INVALID: '비밀번호를 올바르게 입력해주세요.',
   FORBIDDEN: '접근할 수 없는 행사에요.',
+  PASSWORD_INVALID: '비밀번호를 올바르게 입력해주세요.',
 
   // 사용자에게 뜨면 안되며 프론트 구현 미스인 에러 코드
   MESSAGE_NOT_READABLE: '읽을 수 없는 요청이에요.',


### PR DESCRIPTION
## issue
- close #678 

## 구현 사항

잘못된 비밀번호를 입력하면 `PASSWORD_INVALID`라는 오류 코드를 받게되는데요.
이 `PASSWORD_INVALID`가 프론트엔드에서 관리하는 서버 오류 코드 상수에 존재하지 않았어요.
`알 수 없는 페이지` 는 프론트엔드의 서버 오류 코드 상수에 존재하지 않는 경우 도달하게 되는 페이지입니다.

그래서 `PASSWORD_INVALID`를 서버 오류 코드 상수에 추가해주었어요~!

```jsx
  PASSWORD_INVALID: '비밀번호를 올바르게 입력해주세요.',
```

https://github.com/user-attachments/assets/3b948be6-8edf-48a8-a62a-adc01adc3521
