### PR TITLE
[FE] 이벤트 페이지 api 호출 개선

### DIFF
--- a/client/src/components/Loader/EventLoader.tsx
+++ b/client/src/components/Loader/EventLoader.tsx
@@ -1,0 +1,45 @@
+import {useQueries} from '@tanstack/react-query';
+import {useEffect} from 'react';
+
+import {requestGetEvent} from '@apis/request/event';
+import {requestGetReports} from '@apis/request/report';
+import {requestGetSteps} from '@apis/request/step';
+import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
+
+import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
+
+import getEventIdByUrl from '@utils/getEventIdByUrl';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+const EventLoader = ({children, ...props}: React.PropsWithChildren<WithErrorHandlingStrategy | null> = {}) => {
+  const eventId = getEventIdByUrl();
+
+  const queries = useQueries({
+    queries: [
+      {queryKey: [QUERY_KEYS.event], queryFn: () => requestGetEvent({eventId, ...props})},
+      {
+        queryKey: [QUERY_KEYS.reports],
+        queryFn: () => requestGetReports({eventId, ...props}),
+      },
+      {
+        queryKey: [QUERY_KEYS.steps],
+        queryFn: () => requestGetSteps({eventId, ...props}),
+      },
+    ],
+  });
+
+  const {updateTotalExpenseAmount} = useTotalExpenseAmountStore();
+
+  useEffect(() => {
+    if (queries[2].isSuccess && queries[2].data) {
+      updateTotalExpenseAmount(queries[2].data);
+    }
+  }, [queries[2].data, queries[2].isSuccess, updateTotalExpenseAmount]);
+
+  const isLoading = queries.some(query => query.isLoading === true);
+
+  return !isLoading && children;
+};
+
+export default EventLoader;

--- a/client/src/components/Loader/EventLoader.tsx
+++ b/client/src/components/Loader/EventLoader.tsx
@@ -1,12 +1,9 @@
 import {useQueries} from '@tanstack/react-query';
-import {useEffect} from 'react';
 
 import {requestGetEvent} from '@apis/request/event';
 import {requestGetReports} from '@apis/request/report';
 import {requestGetSteps} from '@apis/request/step';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
-
-import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
@@ -28,14 +25,6 @@ const EventLoader = ({children, ...props}: React.PropsWithChildren<WithErrorHand
       },
     ],
   });
-
-  const {updateTotalExpenseAmount} = useTotalExpenseAmountStore();
-
-  useEffect(() => {
-    if (queries[2].isSuccess && queries[2].data) {
-      updateTotalExpenseAmount(queries[2].data);
-    }
-  }, [queries[2].data, queries[2].isSuccess, updateTotalExpenseAmount]);
 
   const isLoading = queries.some(query => query.isLoading === true);
 

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -3,6 +3,7 @@ import {lazy, Suspense} from 'react';
 
 import ErrorPage from '@pages/ErrorPage/ErrorPage';
 import EventLoginPage from '@pages/EventPage/AdminPage/EventLoginPage';
+import EventLoader from '@components/Loader/EventLoader';
 
 import {EventPage} from '@pages/EventPage';
 
@@ -40,9 +41,16 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTER_URLS.event,
-        element: <EventPage />,
+        element: (
+          <EventLoader>
+            <EventPage />
+          </EventLoader>
+        ),
         children: [
-          {path: ROUTER_URLS.eventManage, element: <AdminPage />},
+          {
+            path: ROUTER_URLS.eventManage,
+            element: <AdminPage />,
+          },
           {path: ROUTER_URLS.home, element: <HomePage />},
           {
             path: ROUTER_URLS.eventLogin,


### PR DESCRIPTION
## issue
- close #683 

## 구현 근거
아래 영상을 보면 행사 이름 레이아웃이 먼저 보이고 행사 이름이 채워진 후 아래 step 들이 보이게 됩니다.
사용자에게 깜빡거리는 안 좋은 경험을 주게 됩니다.

https://github.com/user-attachments/assets/8e916e2c-a851-4ea0-9ec7-111dc1843dbb

이런 현상을 해결하기 위해선 컴포넌트를 랜더링 하기 전에 필요한 데이터를 전부 불러온 뒤에 컴포넌트를 랜더링하면 되지 않을까 해서 적용해봤습니다.


### 고민점
1. react-router loader 도입에 대한 고민
처음에는 react-router의 loader 기능을 활용해서 컴포넌트가 랜더링 되기 전 데이터를 load 한 뒤 랜더링을 하려고 했습니다.
우리는 서버 상태를 react-query로 관리하며 react-query와 loader를 같이 사용하기 위해선 router에서 query client가 필요해집니다. 하지만 router는 jsx element를 반환하는 컴포넌트가 아니기때문에 hook을 사용할 수 없습니다.

즉 useQueryClient를 사용해서 queryClient를 받아올 수 없기 때문에 지금 작성된 구조로는 loader를 도입하는데 어려움이 있다고 생각했어요

2. 컴포넌트를 감싸는 Loader
그렇다면 react-router의 loder와 비슷하게 구현해보면 되지 않을까 해서 컴포넌트를 감싸는 로더를 만들어봤어요

```tsx
<EventLoader>
  <EventPageLayout />
</EventLoader>
```

위 구조와 같이 Loader를 만들어줍니다.
그리고 Loader 안에서 react-query를 사용해서 api 호출을 해줍니다.
이 때 이벤트에 필요한 세 가지 정보, (Event, Report, Step)를 useQueries를 이용해 병렬적으로 불러오도록 변경했습니다.
병렬적으로 불렀을 때의 장점은 한 페이지에 필요한 정보를 한 번에 실행시키기 위함입니다. 

```ts
 const queries = useQueries({
    queries: [
      {queryKey: [QUERY_KEYS.event], queryFn: () => requestGetEvent({eventId, ...props})},
      {
        queryKey: [QUERY_KEYS.reports],
        queryFn: () => requestGetReports({eventId, ...props}),
      },
      {
        queryKey: [QUERY_KEYS.steps],
        queryFn: () => requestGetSteps({eventId, ...props}),
      },
    ],
  });
```

```ts
const isLoading = queries.some(query => query.isLoading === true);
return !isLoading && children;
```

그리고 로딩이 아닐 경우에 children을 랜더링하도록 설정해서 데이터가 로딩 중일 때는 컴포넌트가 랜더링되지 않고 로딩이 끝난 후 데이터가 준비가 됐을 때 children이 보이도록 했습니다.


### 개선 결과
https://github.com/user-attachments/assets/717d28c2-4ba5-4197-9b46-8fae4b957fe3


### 더 개선해야 할 점
로더를 통해 데이터를 미리 가져오지만 staleTime이 설정되지 않아 데이터를 불러오자마자 stale 처리되어 하위에서 다시 데이터가 fetch 됩니다. 이 부분은 조금 아쉬워요



## 🫡 참고사항
