### PR TITLE
[FE] react-query 캐싱 적용으로 인해 발생한 버그 해결

### DIFF
--- a/client/src/hooks/queries/bill/useRequestDeleteBill.ts
+++ b/client/src/hooks/queries/bill/useRequestDeleteBill.ts
@@ -17,6 +17,7 @@ const useRequestDeleteBill = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPostBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPostBill.ts
@@ -15,6 +15,7 @@ const useRequestPostBill = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPutBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBill.ts
@@ -17,6 +17,7 @@ const useRequestPutBill = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
@@ -18,6 +18,7 @@ const useRequestPutBillDetails = ({billId}: WithBillId) => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId]});
     },
     // onMutate: async (newMembers: MemberReportInAction[]) => {

--- a/client/src/hooks/queries/event/useRequestPostEvent.ts
+++ b/client/src/hooks/queries/event/useRequestPostEvent.ts
@@ -2,14 +2,12 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {RequestPostEvent, requestPostEvent} from '@apis/request/event';
 
-import QUERY_KEYS from '@constants/queryKeys';
-
 const useRequestPostEvent = () => {
   const queryClient = useQueryClient();
   const {mutate, mutateAsync, ...rest} = useMutation({
     mutationFn: ({eventName, password}: RequestPostEvent) => requestPostEvent({eventName, password}),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.event]});
+      queryClient.removeQueries();
     },
   });
 

--- a/client/src/hooks/queries/event/useRequestPostEvent.ts
+++ b/client/src/hooks/queries/event/useRequestPostEvent.ts
@@ -1,10 +1,16 @@
-import {useMutation} from '@tanstack/react-query';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {RequestPostEvent, requestPostEvent} from '@apis/request/event';
 
+import QUERY_KEYS from '@constants/queryKeys';
+
 const useRequestPostEvent = () => {
+  const queryClient = useQueryClient();
   const {mutate, mutateAsync, ...rest} = useMutation({
     mutationFn: ({eventName, password}: RequestPostEvent) => requestPostEvent({eventName, password}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.event]});
+    },
   });
 
   // 실행 순서를 await으로 보장하기 위해 mutateAsync 사용

--- a/client/src/hooks/queries/member/useRequestDeleteMember.ts
+++ b/client/src/hooks/queries/member/useRequestDeleteMember.ts
@@ -15,6 +15,7 @@ const useRequestDeleteMember = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
     },

--- a/client/src/hooks/queries/member/useRequestPostMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPostMembers.ts
@@ -16,6 +16,7 @@ const useRequestPostMembers = () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       return responseData;
     },
   });

--- a/client/src/hooks/queries/member/useRequestPutMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPutMembers.ts
@@ -15,6 +15,7 @@ const useRequestPutMembers = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
     },


### PR DESCRIPTION
## issue
- close #711 

## 수정 목적

저번 버전에서 gc,stale time을 추가하면서 새로운 행사를 생성해도 이전 행사의 데이터가 캐싱되는 현상이 발생했습니다. 물론 1분이 지나고 새로고침을 하면 사라지긴 합니다. 하지만, 즉각 행사를 생성하는 경우가 발생할 수 있기 때문에 수정을 진행했습니다.

## 수정 사항

**Problem 1**

새로운 지출내역을 생성해도 이전 지출내역의 참여자가 자동으로 추가되지 않는 문제가 발생했습니다.

- 해결
    
    Bill과 Member 에서 patch, post, delete를 요청하는 query hook에 `queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});`를 추가해줬습니다. 
    
    성공적으로 요청이 진행되면 currentMembers를 refetching합니다.
    

**Problem 2**

만들었던 행사가 존재하고 곧 바로 새로운 행사를 생성하면 이전 행사의 데이터가 들어오는 문제가 발생했습니다.

- 해결
    
    새로운 행사를 생성해도 이전의 데이터가 캐싱되어 발생한 문제였기에, 요청이 성공적으로 진행되면 event가 refetching 되도록 했습니다. 
    
    ```tsx
    onSuccess: () => {
      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.event]});
    },
    ```

### +) 쿠키가 토다리 피드백에 남겨줬던 내용을 해당 PR에서 반영했어요!
위에 작성한 Problem2의 내용을 쿠키가 준 피드백 방향으로 수정했습니다~!
removeQueries()와 resetQueries() 중에 어떤 것이 더 적절할까? 테스트를 해봤어요.
removeQueries()는 행사를 생성할 때 queryKey 또한 모두 초기화하고 resetQueries()는 queryKey는 그대로 존재하고 값만 제거하더라구요. 따라서 removeQueries()가 더 적절할 것 같아서 해당 메소드를 사용했습니다!

```tsx
onSuccess: () => {
      queryClient.removeQueries();
    },
```