### PR TITLE
[FE] toast.error, toast.none이어도 모두 toast.confirm으로 출력되는 문제

### DIFF
--- a/client/src/hooks/useToast/toast.ts
+++ b/client/src/hooks/useToast/toast.ts
@@ -1,19 +1,20 @@
 import {ToastMessage, ToastOptions} from 'types/toastType';
+import {ToastType} from '@components/Toast/Toast.type';
 
 import toastEventManager from './toastEventManager';
 import {TOAST_EVENT} from './toastEventManager.type';
 
-const showToast = (message: ToastMessage, options: ToastOptions) => {
-  return toastEventManager.trigger(TOAST_EVENT.show, message, options);
+const showToast = (message: ToastMessage, options: ToastOptions, type?: ToastType) => {
+  return toastEventManager.trigger(TOAST_EVENT.show, message, {...options, type});
 };
 
 // toast('안녕') 처럼도 사용할 수 있도록
 const toast = (message: ToastMessage, options: ToastOptions = {}) => {
-  return showToast(message, options);
+  return showToast(message, options, 'none');
 };
 
-toast.error = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options);
-toast.confirm = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options);
-toast.none = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options);
+toast.error = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options, 'error');
+toast.confirm = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options, 'confirm');
+toast.none = (message: ToastMessage, options: ToastOptions = {}) => showToast(message, options, 'none');
 
 export default toast;

--- a/client/src/hooks/useToast/useToast.tsx
+++ b/client/src/hooks/useToast/useToast.tsx
@@ -8,11 +8,6 @@ import {TOAST_EVENT} from './toastEventManager.type';
 
 const DEFAULT_TIME = 3000;
 
-type Toast = {
-  message: ToastMessage;
-  options: ToastOptions;
-};
-
 export const useToast = () => {
   const [currentToast, setCurrentToast] = useState<ToastArgs | null>(null);
 


### PR DESCRIPTION
## issue
- close #689 

## 구현 목적
pr제목 그대로.. 띄울 토스트의 타입이 error, none이어도 모두 confirm으로 아이콘이 뜨는 문제가 있었습니다.

## 구현 사항
기존에는 toast는 message, options 두 값을 담아 UI 컴포넌트인 Toast 컴포넌트에 전달해주었는데요. 이 options값에 type(confirm인지 error인지 none인지..)이 없었기 때문에 기본 값인 confirm으로 계속 뜨고있었습니다.

따라서 제일 오른쪽에 보이는 것처럼 타입을 인자로 받도록 인터페이스를 열었습니다.
<img width="730" alt="image" src="https://github.com/user-attachments/assets/56a17c16-be49-4967-9b13-9f154ea32d1e">

그리고 아래처럼 options를 원래의 options + type 값이 담기도록 스프레드연산자를 통해 담아 넘겨주었습니다.
```jsx
const showToast = (message: ToastMessage, options: ToastOptions, type?: ToastType) => {
  return toastEventManager.trigger(TOAST_EVENT.show, message, {...options, type});
};
```

ToastContainer.tsx에서 아래와 같이 options를 스프레드해서 넘겨주기 때문에 정상적으로 Toast컴포넌트에 type prop이 전달되어 문제가 해결됩니다.
<img width="797" alt="image" src="https://github.com/user-attachments/assets/9cbd795c-1ba5-412c-aa81-f90e946f0df1">

