### PR TITLE
[FE] 사진 추가한 후 다시 접속 시 반영이 되지 않는 버그

### DIFF
--- a/client/src/apis/request/images.ts
+++ b/client/src/apis/request/images.ts
@@ -14,7 +14,7 @@ export const requestPostImages = async ({eventId, formData}: WithEventId<Request
   //   baseUrl: BASE_URL.HD,
   //   endpoint: `${ADMIN_API_PREFIX}/${eventId}/images`,
   //   headers: {
-  //     'Content-Type': 'multipart/form-data',
+  //     'Content-Type': '',
   //   },
   //   body: formData,
   // });
@@ -22,14 +22,18 @@ export const requestPostImages = async ({eventId, formData}: WithEventId<Request
   // TODO: (@todari): 기존의 request 방식들은 기본적으로
   // header를 Content-Type : application/json 으로 보내주고 있음
   // multipart/form-data 요청을 보내기 위해선 header Content-Type을 빈 객체로 전달해야 함
-  fetch(`${BASE_URL.HD}${ADMIN_API_PREFIX}/${eventId}/images`, {
-    credentials: 'include',
-    // headers: {
-    //   'Content-Type': 'multipart/form-data',
-    // },
-    method: 'POST',
-    body: formData,
-  });
+  try {
+    await fetch(`${BASE_URL.HD}${ADMIN_API_PREFIX}/${eventId}/image`, {
+      credentials: 'include',
+      // headers: {
+      //   'Content-Type': 'multipart/form-data',
+      // },
+      method: 'POST',
+      body: formData,
+    });
+  } catch (error) {
+    throw error;
+  }
 };
 
 export const requestGetImages = async ({eventId}: WithEventId) => {

--- a/client/src/apis/request/images.ts
+++ b/client/src/apis/request/images.ts
@@ -10,30 +10,7 @@ export interface RequestPostImages {
 }
 
 export const requestPostImages = async ({eventId, formData}: WithEventId<RequestPostImages>) => {
-  // return await requestPostWithoutResponse({
-  //   baseUrl: BASE_URL.HD,
-  //   endpoint: `${ADMIN_API_PREFIX}/${eventId}/images`,
-  //   headers: {
-  //     'Content-Type': '',
-  //   },
-  //   body: formData,
-  // });
-
-  // TODO: (@todari): 기존의 request 방식들은 기본적으로
-  // header를 Content-Type : application/json 으로 보내주고 있음
-  // multipart/form-data 요청을 보내기 위해선 header Content-Type을 빈 객체로 전달해야 함
-  try {
-    await fetch(`${BASE_URL.HD}${ADMIN_API_PREFIX}/${eventId}/image`, {
-      credentials: 'include',
-      // headers: {
-      //   'Content-Type': 'multipart/form-data',
-      // },
-      method: 'POST',
-      body: formData,
-    });
-  } catch (error) {
-    throw error;
-  }
+  await requestPostWithoutResponse({endpoint: `${ADMIN_API_PREFIX}/${eventId}/images`, body: formData});
 };
 
 export const requestGetImages = async ({eventId}: WithEventId) => {

--- a/client/src/hooks/queries/images/useRequestPostImages.ts
+++ b/client/src/hooks/queries/images/useRequestPostImages.ts
@@ -10,14 +10,14 @@ const useRequestPostImages = () => {
   const eventId = getEventIdByUrl();
   const queryClient = useQueryClient();
 
-  const {mutate, ...rest} = useMutation({
+  const {mutateAsync, ...rest} = useMutation({
     mutationFn: ({formData}: RequestPostImages) => requestPostImages({eventId, formData}),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.images]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.images]});
     },
   });
 
-  return {postImages: mutate, ...rest};
+  return {postImages: mutateAsync, ...rest};
 };
 
 export default useRequestPostImages;

--- a/client/src/hooks/useAddImagesPage.ts
+++ b/client/src/hooks/useAddImagesPage.ts
@@ -16,7 +16,7 @@ const useAddImagesPage = () => {
   const [images, setImages] = useState<Array<LoadedImage | AddedImage>>([]);
   const [isPrevImageDeleted, setIsPrevImageDeleted] = useState(false);
   const addedImages = images.filter(image => image instanceof File);
-  const {images: prevImages} = useRequestGetImages();
+  const {images: prevImages, isSuccess} = useRequestGetImages();
   const urls = images.map(image => {
     if (image instanceof File) {
       return URL.createObjectURL(image);
@@ -33,11 +33,18 @@ const useAddImagesPage = () => {
   const {deleteImage} = useRequestDeleteImage();
 
   useEffect(() => {
-    if (!prevImages) return;
+    if (!isSuccess) return;
     setImages([...prevImages]);
-  }, [prevImages]);
+  }, [prevImages, isSuccess]);
+
+  useEffect(() => {
+    console.log(images);
+  }, [images]);
 
   const handleChangeImages = (event: React.ChangeEvent<HTMLInputElement>) => {
+    //TODO: (@Todari): 현재 A 이미지 추가 -> A 이미지 x 버튼 눌러 취소 -> 다시 A 이미지 추가 시 업로드 되지 않음
+    //                 event.target.files가 변경되지 않기 때문에 onChange에 넣은
+    //                 handleChangeImages가 실행되지 않아 일어나는 문제로 추정
     if (event.target.files) {
       const dataTransfer = new DataTransfer();
 
@@ -66,15 +73,16 @@ const useAddImagesPage = () => {
   const canSubmit = addedImages.length !== 0 || isPrevImageDeleted;
 
   const submitImages = async () => {
-    const formData = new FormData();
+    if (addedImages.length !== 0) {
+      const formData = new FormData();
 
-    if (!addedImages) return;
+      for (let i = 0; i < addedImages.length; i++) {
+        formData.append('images', addedImages[i], addedImages[i].name);
+      }
 
-    for (let i = 0; i < addedImages.length; i++) {
-      formData.append('images', addedImages[i], addedImages[i].name);
+      await postImages({formData});
     }
 
-    await postImages({formData});
     navigate(`/event/${eventId}/admin`);
   };
 

--- a/client/src/hooks/useAddImagesPage.ts
+++ b/client/src/hooks/useAddImagesPage.ts
@@ -29,7 +29,7 @@ const useAddImagesPage = () => {
   const navigate = useNavigate();
   const eventId = getEventIdByUrl();
 
-  const {postImages, isPending, isSuccess: isSuccessPostImage} = useRequestPostImages();
+  const {postImages, isPending} = useRequestPostImages();
   const {deleteImage} = useRequestDeleteImage();
 
   useEffect(() => {
@@ -57,13 +57,13 @@ const useAddImagesPage = () => {
       deleteImage({
         imageId: images[index].id,
       });
-      setIsPrevImageDeleted(false);
+      setIsPrevImageDeleted(true);
     } else {
       setImages(prev => prev.filter((_, idx) => idx !== index));
     }
   };
 
-  const canSubmit = !!addedImages || isPrevImageDeleted;
+  const canSubmit = addedImages.length !== 0 || isPrevImageDeleted;
 
   const submitImages = async () => {
     const formData = new FormData();

--- a/client/src/hooks/useAddImagesPage.ts
+++ b/client/src/hooks/useAddImagesPage.ts
@@ -65,7 +65,7 @@ const useAddImagesPage = () => {
 
   const canSubmit = !!addedImages || isPrevImageDeleted;
 
-  const submitImages = () => {
+  const submitImages = async () => {
     const formData = new FormData();
 
     if (!addedImages) return;
@@ -74,7 +74,8 @@ const useAddImagesPage = () => {
       formData.append('images', addedImages[i], addedImages[i].name);
     }
 
-    postImages({formData});
+    await postImages({formData});
+    navigate(`/event/${eventId}/admin`);
   };
 
   useEffect(() => {
@@ -84,11 +85,6 @@ const useAddImagesPage = () => {
       document.body.style.overflowX = 'auto';
     };
   }, []);
-
-  useEffect(() => {
-    if (!isSuccessPostImage) return;
-    navigate(`/event/${eventId}/admin`);
-  }, [isSuccessPostImage]);
 
   return {fileInputRef, handleChangeImages, urls, handleDeleteImage, isPending, canSubmit, submitImages};
 };


### PR DESCRIPTION
## issue
- close #725 

## 구현 사항
### mutateAsync를 사용해서 캐시 데이터가 사라짐을 보장 받은 뒤 navigate를 실행하도록 변경

기존에는 실행된 후 바깥에서 useEffect로 isSuccess를 감지해서 true이면 navigate를 하도록 되어있었습니다.
이를 async를 이용해서 아래 onSuccess가 된 것을 먼저 실행한 후에 navigate를 실행하는 방식으로 변경했습니다.

```ts
const {mutateAsync, ...rest} = useMutation({
  mutationFn: ({formData}: RequestPostImages) => requestPostImages({eventId, formData}),
  onSuccess: () => {
    queryClient.removeQueries({queryKey: [QUERY_KEYS.images]});
  },
});
```

```ts
await postImages({formData});
navigate(`/event/${eventId}/admin`);
```


## 🫡 참고사항
