### PR TITLE
[FE] 송금에서 데스크탑 환경은 복사하기밖에 보이지 않도록 수정

### DIFF
--- a/client/src/components/Design/components/Select/Select.tsx
+++ b/client/src/components/Design/components/Select/Select.tsx
@@ -21,7 +21,7 @@ const Select = <T extends string | number | readonly string[]>({
 
   return (
     <ClickOutsideDetector targetRef={selectRef} onClickOutside={() => setIsOpen(false)}>
-      <fieldset css={selectStyle}>
+      <fieldset ref={selectRef} css={selectStyle}>
         <SelectInput
           labelText={labelText}
           placeholder={placeholder ?? ''}
@@ -31,7 +31,7 @@ const Select = <T extends string | number | readonly string[]>({
           setHasFocus={setIsOpen}
         />
         {options.length > 0 && (
-          <ul ref={selectRef} css={optionListStyle(theme, isOpen)}>
+          <ul css={optionListStyle(theme, isOpen)}>
             <Flex flexDirection="column" gap="0.5rem">
               {options.map((option, index) => (
                 <li key={`${option}-${index}`}>

--- a/client/src/components/Design/components/Select/useSelect.ts
+++ b/client/src/components/Design/components/Select/useSelect.ts
@@ -9,7 +9,7 @@ const useSelect = <T extends string | number | readonly string[]>({defaultValue,
   const [isOpen, setIsOpen] = useState(false);
   const [value, setValue] = useState(defaultValue);
 
-  const selectRef = useRef<HTMLUListElement>(null);
+  const selectRef = useRef<HTMLFieldSetElement>(null);
 
   const handleSelect = (option: T) => {
     setValue(option);

--- a/client/src/hooks/useSendPage.ts
+++ b/client/src/hooks/useSendPage.ts
@@ -1,6 +1,8 @@
 import {useLocation} from 'react-router-dom';
 import {useEffect, useState} from 'react';
 
+import {isMobileDevice} from '@utils/detectDevice';
+
 import {SendInfo} from './useReportsPage';
 import toast from './useToast/toast';
 import useAmplitude from './useAmplitude';
@@ -9,13 +11,14 @@ export type SendMethod = '복사하기' | '토스' | '카카오페이';
 export type OnSend = () => void | Promise<void>;
 
 const useSendPage = () => {
-  const [sendMethod, setSendMethod] = useState<SendMethod>('토스');
+  const isMobile = isMobileDevice();
+  const options: SendMethod[] = isMobile ? ['토스', '카카오페이', '복사하기'] : ['복사하기'];
+  const defaultValue: SendMethod = isMobile ? '토스' : '복사하기';
+
+  const [sendMethod, setSendMethod] = useState<SendMethod>(defaultValue);
   const state = useLocation().state as SendInfo;
 
   const {trackSendMoney} = useAmplitude();
-
-  const options: SendMethod[] = ['토스', '카카오페이', '복사하기'];
-  const defaultValue: SendMethod = '토스';
 
   const onSelect = (option: SendMethod) => {
     setSendMethod(option);


### PR DESCRIPTION
## issue
- close #734 

## 구현 사항
### 데스크탑에서는 토스밖에 보이지 않도록 설정
데스크탑 환경에선 선택지를 복사하기 밖에 보이지 않도록 설정했습니다.
모바일 환경에선 3가지가 다 보이게 했어요.

![image](https://github.com/user-attachments/assets/43d8fe0c-15c3-4c61-b25d-6b693c49a690)
![image](https://github.com/user-attachments/assets/bfde1ce7-77da-4540-9c96-f57fa5ea80b2)


### Select box 열렸다가 닫히는 문제 해결
현재는 목록이 열려있을 때 select box를 클릭했을 때 목록이 열렸다가 닫히는 현상이 있었습니다.
이를 수정했어요

![image](https://github.com/user-attachments/assets/ddcfebc4-9dba-4b42-8c0e-1d96344a6926)


## 🫡 참고사항
