### PR TITLE
[FE] 이미지 추가 및 조회 기능에서 발생하는 버그

### DIFF
--- a/client/src/hooks/useAddImagesPage.ts
+++ b/client/src/hooks/useAddImagesPage.ts
@@ -34,30 +34,12 @@ const useAddImagesPage = () => {
 
   useEffect(() => {
     if (!isSuccess) return;
-    setImages([...prevImages]);
-  }, [prevImages, isSuccess]);
-
-  useEffect(() => {
-    console.log(images);
-  }, [images]);
+    setImages([...prevImages, ...addedImages]);
+  }, [isSuccess, prevImages]);
 
   const handleChangeImages = (event: React.ChangeEvent<HTMLInputElement>) => {
-    //TODO: (@Todari): 현재 A 이미지 추가 -> A 이미지 x 버튼 눌러 취소 -> 다시 A 이미지 추가 시 업로드 되지 않음
-    //                 event.target.files가 변경되지 않기 때문에 onChange에 넣은
-    //                 handleChangeImages가 실행되지 않아 일어나는 문제로 추정
-    if (event.target.files) {
-      const dataTransfer = new DataTransfer();
-
-      if (addedImages) {
-        Array.from(addedImages).forEach(image => dataTransfer.items.add(image));
-      }
-
-      Array.from(event.target.files).forEach(image => dataTransfer.items.add(image));
-
-      setImages([...prevImages, ...dataTransfer.files]);
-    }
+    setImages(prev => [...prev, ...(event.target.files ? Array.from(event.target.files) : [])]);
   };
-
   const handleDeleteImage = (index: number) => {
     if ('url' in images[index]) {
       //TODO: (@Todari): 추후 낙관적 업데이트 적용
@@ -67,6 +49,9 @@ const useAddImagesPage = () => {
       setIsPrevImageDeleted(true);
     } else {
       setImages(prev => prev.filter((_, idx) => idx !== index));
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     }
   };
 

--- a/client/src/pages/AddImagesPage/AddImagesPage.tsx
+++ b/client/src/pages/AddImagesPage/AddImagesPage.tsx
@@ -35,7 +35,7 @@ const AddImagesPage = () => {
           onChange={handleChangeImages}
           style={{display: 'none'}}
         />
-        <Button variants="primary" onClick={() => fileInputRef.current?.click()}>
+        <Button variants="tertiary" onClick={() => fileInputRef.current?.click()}>
           사진 추가하기
         </Button>
       </div>

--- a/client/src/pages/EventPage/HomePage/HomePage.tsx
+++ b/client/src/pages/EventPage/HomePage/HomePage.tsx
@@ -29,9 +29,11 @@ const HomePage = () => {
         title={eventName}
         amount={totalExpenseAmount}
         icon={
-          <button>
-            <Icon iconType="photoButton" onClick={() => navigate(`/event/${eventId}/images`)} />
-          </button>
+          images.length !== 0 && (
+            <button>
+              <Icon iconType="photoButton" onClick={() => navigate(`/event/${eventId}/images`)} />
+            </button>
+          )
         }
       />
       <Tabs>


### PR DESCRIPTION
## issue
- close #736

## 구현 목적
- 이미지 추가 페이지에서 A사진 등록 -> A 사진 등록 해제 -> 다시 A 사진 등록 과정이 안되는 문제가 있습니다.

https://github.com/user-attachments/assets/fa45b1dc-d50f-477f-b8bb-3e7fc014a310

- 이미 추가했던 사진이 있고, 이후에 사진들을 등록한 뒤 이미 추가한 사진을 삭제할 때, 등록한 이미지들이 사라지는 문제가 있습니다.

https://github.com/user-attachments/assets/57a349ba-8321-4504-ba72-1769d61975dd

- 등록된 사진이 없을 때, 홈에서 사진 조회 페이지에 들어갈 수 있는 문제가 있습니다.

https://github.com/user-attachments/assets/25fa1872-02dc-4880-a001-6d7bc2fb51f7

## 구현 사항
1. **이미지 추가 페이지에서 A사진 등록 -> A 사진 등록 해제 -> 다시 A 사진 등록 과정이 안되는 문제**

두 사진이 같은 경우, file input의 `onChange`가 작동하지 않아서 `handleChangeImage`가 제대로 트리거되지 않는 문제입니다.
```tsx
      if (fileInputRef.current) {
        fileInputRef.current.value = '';
      }
```
`handleDeleteImage`를 실행할 경우, inputRef의 value를 초기화 함으로써 handleChange가 항상 작동하도록 변경하였습니다.

- **이미 추가했던 사진이 있고, 이후에 사진들을 등록한 뒤 이미 추가한 사진을 삭제할 때, 등록한 이미지들이 사라지는 문제**
```tsx
  useEffect(() => {
    if (!isSuccess) return;
    setImages([...prevImages]);
  }, [prevImages, isSuccess]);
```
기존 코드에서, `deleteImage` API가 실행되어 `prevImages`가 변경되면 image를 `prevImages`로만 덮어씌워져 `addedImages` 가 사라지는 문제였습니다.

```tsx
  useEffect(() => {
    if (!isSuccess) return;
    setImages([...prevImages, ...addedImages]);
  }, [isSuccess, prevImages]);
```
`addImages` 또한 함께 반영될 수 있도록 코드를 변경하였습니다.

- **등록된 사진이 없을 때, 홈에서 사진 조회 페이지에 들어갈 수 있는 오류**
```tsx
icon={
          images.length !== 0 && (
            <button>
              <Icon iconType="photoButton" onClick={() => navigate(`/event/${eventId}/images`)} />
            </button>
          )
        }
```

images.length가 0이 아닐때만 버튼이 보이도록 변경하였습니다.