### PR TITLE
[FE] eventName에 따라 og태그가 변경되도록 수정

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
 
     <title>행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스</title>
 
-    <meta name="description" content="모임에서 발생한 비용을 손쉽게 정산하고 간편하게 송금할 수 있는 행동대장" />
+    <meta name="description" content="행동대장으로 모임에서 발생한 비용을 손쉽게 정산하고 간편하게 송금해요" />
     <meta
       name="keywords"
       content="행동대장, 행대동장, 행댕이, 흔듯, 행사, 정산, 모임, 송금, 더치페이, 더치페이 서비스, 더치페이 앱, 간편 정산, 간편한 정산, 쉬운 정산, 정산 앱, 정산 서비스, 엔빵, 엔빵계산기, 엔빵 앱, 엔빵 서비스, 우아한테크코스, 우테코, 우테코 프로젝트, 우테코 6기, 우아한테크코스 6기"
@@ -13,10 +13,7 @@
 
     <meta property="og:url" content="https://haengdong.pro/" />
     <meta property="og:title" content="행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스" />
-    <meta
-      property="og:description"
-      content="모임에서 발생한 비용을 실시간으로 기록하고 정산하여 더치페이 결과를 간편하게 송금할 수 있는 행동대장"
-    />
+    <meta property="og:description" content="행동대장으로 모임에서 발생한 비용을 손쉽게 정산하고 간편하게 송금해요" />
     <meta property="og:type" content="website" />
     <meta
       property="og:image"

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -12,6 +12,7 @@ import {DesktopShareEventButton, MobileShareEventButton} from '@components/Share
 import {Flex, Icon, IconButton, MainLayout, TopNav} from '@HDesign/index';
 
 import {isMobileDevice} from '@utils/detectDevice';
+import {updateMetaTag} from '@utils/udpateMetaTag';
 
 export type EventPageContextProps = Event & {
   isAdmin: boolean;
@@ -39,6 +40,8 @@ const EventPageLayout = () => {
     trackShareEvent({...eventSummary, shareMethod: 'kakao'});
     kakaoShare();
   };
+
+  updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);
 
   return (
     <MainLayout backgroundColor="gray">

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -43,9 +43,11 @@ const EventPageLayout = () => {
   };
 
   useEffect(() => {
+    console.log('mount');
     updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);
 
     return () => {
+      console.log('unmount');
       updateMetaTag('og:title', '행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스');
     };
   }, []);

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -1,6 +1,7 @@
 import type {Event} from 'types/serviceType';
 
 import {Outlet} from 'react-router-dom';
+import {useEffect} from 'react';
 
 import useEventPageLayout from '@hooks/useEventPageLayout';
 import useShareEvent from '@hooks/useShareEvent';
@@ -13,7 +14,6 @@ import {Flex, Icon, IconButton, MainLayout, TopNav} from '@HDesign/index';
 
 import {isMobileDevice} from '@utils/detectDevice';
 import {updateMetaTag} from '@utils/udpateMetaTag';
-import {useEffect} from 'react';
 
 export type EventPageContextProps = Event & {
   isAdmin: boolean;

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -13,6 +13,7 @@ import {Flex, Icon, IconButton, MainLayout, TopNav} from '@HDesign/index';
 
 import {isMobileDevice} from '@utils/detectDevice';
 import {updateMetaTag} from '@utils/udpateMetaTag';
+import {useEffect} from 'react';
 
 export type EventPageContextProps = Event & {
   isAdmin: boolean;
@@ -41,7 +42,13 @@ const EventPageLayout = () => {
     kakaoShare();
   };
 
-  updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);
+  useEffect(() => {
+    updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);
+
+    return () => {
+      updateMetaTag('og:title', '행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스');
+    };
+  }, []);
 
   return (
     <MainLayout backgroundColor="gray">


### PR DESCRIPTION
## issue
- close #738

## 구현 목적
![image](https://github.com/user-attachments/assets/2263b726-334e-4b0c-b125-27cda65e53f9)

정산 시 og 태그들이 동일하게 나타나는데, 이곳에 행사에 대한 개요를 담으면 좋을 것 같다고 생각했습니다.
따라서 `eventLayoutPage`가 포함된 페이지에서는 행사 이름을 포함하는 og:title로 변경하여 썸네일을 보고도 행사의 이름을 알 수 있게 변경합니다.

## 구현 사항
```tsx
// EventPageLayout.tsx
// ...
  useEffect(() => {
    updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);

    return () => {
      updateMetaTag('og:title', '행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스');
    };
  }, []);
// ...
```
`EventPageLayout`이 마운트 될 때, og:title 태그를 변경하도록 적용하였습니다.

아래 동영상에서, 우측의 meta tag가 변경되는 것을 확인할 수 있습니다.

https://github.com/user-attachments/assets/3b94474c-2a6f-4f6d-bd75-ccbe161227e7

