### PR TITLE
[FE] 접근성 : 넘버 키패드 스크린리더 개선

### DIFF
--- a/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
@@ -34,7 +34,9 @@ export function Keypad({value, ...restButtonProps}: KeypadProps) {
         }
       `}
     >
-      <Text size="title">{value}</Text>
+      <Text size="title" aria-hidden>
+        {value}
+      </Text>
     </button>
   );
 }

--- a/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
@@ -5,7 +5,7 @@ import {setDarker, setLighter} from '@components/Design/utils/colors';
 
 import {Text, useTheme} from '@components/Design';
 
-type KeypadProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+type KeypadProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'> & {
   value: string;
 };
 

--- a/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
@@ -5,18 +5,16 @@ import {setDarker, setLighter} from '@components/Design/utils/colors';
 
 import {Text, useTheme} from '@components/Design';
 
-interface Props {
+type KeypadProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   value: string;
-  ariaLabel?: string;
-  onClick: () => void;
-  disabled?: boolean;
-}
+};
 
-export function Keypad({value, ariaLabel, onClick, disabled = false}: Props) {
+export function Keypad({value, ...restButtonProps}: KeypadProps) {
   const {theme} = useTheme();
+
   return (
     <button
-      aria-label={ariaLabel}
+      {...restButtonProps}
       css={css`
         display: flex;
         justify-content: center;
@@ -35,8 +33,6 @@ export function Keypad({value, ariaLabel, onClick, disabled = false}: Props) {
           }
         }
       `}
-      onClick={onClick}
-      disabled={disabled}
     >
       <Text size="title">{value}</Text>
     </button>

--- a/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
@@ -7,16 +7,16 @@ import {Text, useTheme} from '@components/Design';
 
 interface Props {
   value: string;
-  label: string;
+  ariaLabel?: string;
   onClick: () => void;
   disabled?: boolean;
 }
 
-export function Keypad({value, label, onClick, disabled = false}: Props) {
+export function Keypad({value, ariaLabel, onClick, disabled = false}: Props) {
   const {theme} = useTheme();
   return (
     <button
-      aria-label={label}
+      aria-label={ariaLabel}
       css={css`
         display: flex;
         justify-content: center;

--- a/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/Keypad.tsx
@@ -7,14 +7,16 @@ import {Text, useTheme} from '@components/Design';
 
 interface Props {
   value: string;
+  label: string;
   onClick: () => void;
   disabled?: boolean;
 }
 
-export function Keypad({value, onClick, disabled = false}: Props) {
+export function Keypad({value, label, onClick, disabled = false}: Props) {
   const {theme} = useTheme();
   return (
     <button
+      aria-label={label}
       css={css`
         display: flex;
         justify-content: center;

--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
@@ -64,11 +64,11 @@ export default function NumberKeyboard({type, maxNumber, initialValue, onChange}
           </Button>
         </div>
       )}
-      {(type === 'amount' ? amountKeypads : numberKeypads).map(({keypad, label}) => (
+      {(type === 'amount' ? amountKeypads : numberKeypads).map(({keypad, ariaLabel}) => (
         <Keypad
           key={keypad}
           value={keypad}
-          label={label}
+          ariaLabel={ariaLabel}
           disabled={keypad === ''}
           onClick={keypad === '<-' ? onClickDelete : () => onClickKeypad(keypad)}
         />

--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
@@ -7,9 +7,7 @@ import {Button} from '@components/Design';
 
 import {Keypad} from './Keypad';
 import useNumberKeyboard from './useNumberKeyboard';
-import {amountKeypads, numberKeypads} from './keypads';
-
-export type KeyboardType = 'number' | 'string' | 'amount';
+import {KeyboardType, makeKeypads} from './keypads';
 
 export interface NumberKeyboardProps {
   type: KeyboardType;
@@ -64,7 +62,7 @@ export default function NumberKeyboard({type, maxNumber, initialValue, onChange}
           </Button>
         </div>
       )}
-      {(type === 'amount' ? amountKeypads : numberKeypads).map(({keypad, ariaLabel}) => (
+      {makeKeypads(type).map(({keypad, ariaLabel}) => (
         <Keypad
           key={keypad}
           value={keypad}

--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
@@ -7,6 +7,7 @@ import {Button} from '@components/Design';
 
 import {Keypad} from './Keypad';
 import useNumberKeyboard from './useNumberKeyboard';
+import {amountKeypads, numberKeypads} from './keypads';
 
 export type KeyboardType = 'number' | 'string' | 'amount';
 
@@ -19,8 +20,6 @@ export interface NumberKeyboardProps {
 
 export default function NumberKeyboard({type, maxNumber, initialValue, onChange}: NumberKeyboardProps) {
   const {theme} = useTheme();
-  const amountKeypads = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '00', '0', '<-'];
-  const numberKeypads = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', '<-'];
 
   const {onClickKeypad, onClickDelete, onClickDeleteAll, onClickAddAmount} = useNumberKeyboard({
     type,
@@ -65,12 +64,13 @@ export default function NumberKeyboard({type, maxNumber, initialValue, onChange}
           </Button>
         </div>
       )}
-      {(type === 'amount' ? amountKeypads : numberKeypads).map(el => (
+      {(type === 'amount' ? amountKeypads : numberKeypads).map(({keypad, label}) => (
         <Keypad
-          key={el}
-          value={el}
-          disabled={el === ''}
-          onClick={el === '<-' ? onClickDelete : () => onClickKeypad(el)}
+          key={keypad}
+          value={keypad}
+          label={label}
+          disabled={keypad === ''}
+          onClick={keypad === '<-' ? onClickDelete : () => onClickKeypad(keypad)}
         />
       ))}
     </div>

--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboard.tsx
@@ -68,7 +68,7 @@ export default function NumberKeyboard({type, maxNumber, initialValue, onChange}
         <Keypad
           key={keypad}
           value={keypad}
-          ariaLabel={ariaLabel}
+          aria-label={ariaLabel}
           disabled={keypad === ''}
           onClick={keypad === '<-' ? onClickDelete : () => onClickKeypad(keypad)}
         />

--- a/client/src/components/Design/components/NumberKeyboard/keypads.ts
+++ b/client/src/components/Design/components/NumberKeyboard/keypads.ts
@@ -1,105 +1,105 @@
 type Keypad = {
   keypad: string;
-  label: string;
+  ariaLabel: string;
 };
 
 export const amountKeypads: Keypad[] = [
   {
     keypad: '1',
-    label: '1',
+    ariaLabel: '1',
   },
   {
     keypad: '2',
-    label: '2',
+    ariaLabel: '2',
   },
   {
     keypad: '3',
-    label: '3',
+    ariaLabel: '3',
   },
   {
     keypad: '4',
-    label: '4',
+    ariaLabel: '4',
   },
   {
     keypad: '5',
-    label: '5',
+    ariaLabel: '5',
   },
   {
     keypad: '6',
-    label: '6',
+    ariaLabel: '6',
   },
   {
     keypad: '7',
-    label: '7',
+    ariaLabel: '7',
   },
   {
     keypad: '8',
-    label: '8',
+    ariaLabel: '8',
   },
   {
     keypad: '9',
-    label: '9',
+    ariaLabel: '9',
   },
   {
     keypad: '00',
-    label: '0 2개 버튼',
+    ariaLabel: '0 2개 버튼',
   },
   {
     keypad: '0',
-    label: '0',
+    ariaLabel: '0',
   },
   {
     keypad: '<-',
-    label: '직전 입력 지우기',
+    ariaLabel: '직전 입력 지우기',
   },
 ];
 export const numberKeypads: Keypad[] = [
   {
     keypad: '1',
-    label: '1',
+    ariaLabel: '1',
   },
   {
     keypad: '2',
-    label: '2',
+    ariaLabel: '2',
   },
   {
     keypad: '3',
-    label: '3',
+    ariaLabel: '3',
   },
   {
     keypad: '4',
-    label: '4',
+    ariaLabel: '4',
   },
   {
     keypad: '5',
-    label: '5',
+    ariaLabel: '5',
   },
   {
     keypad: '6',
-    label: '6',
+    ariaLabel: '6',
   },
   {
     keypad: '7',
-    label: '7',
+    ariaLabel: '7',
   },
   {
     keypad: '8',
-    label: '8',
+    ariaLabel: '8',
   },
   {
     keypad: '9',
-    label: '9',
+    ariaLabel: '9',
   },
   {
     keypad: '',
-    label: '',
+    ariaLabel: '',
   },
   {
     keypad: '0',
-    label: '0',
+    ariaLabel: '0',
   },
   {
     keypad: '<-',
-    label: '직전 입력 지우기',
+    ariaLabel: '직전 입력 지우기',
   },
 ];

--- a/client/src/components/Design/components/NumberKeyboard/keypads.ts
+++ b/client/src/components/Design/components/NumberKeyboard/keypads.ts
@@ -50,7 +50,7 @@ export const amountKeypads: Keypad[] = [
   },
   {
     keypad: '<-',
-    ariaLabel: '직전 입력 지우기',
+    ariaLabel: '마지막 숫자 지우기',
   },
 ];
 export const numberKeypads: Keypad[] = [
@@ -100,6 +100,6 @@ export const numberKeypads: Keypad[] = [
   },
   {
     keypad: '<-',
-    ariaLabel: '직전 입력 지우기',
+    ariaLabel: '마지막 숫자 지우기',
   },
 ];

--- a/client/src/components/Design/components/NumberKeyboard/keypads.ts
+++ b/client/src/components/Design/components/NumberKeyboard/keypads.ts
@@ -1,0 +1,105 @@
+type Keypad = {
+  keypad: string;
+  label: string;
+};
+
+export const amountKeypads: Keypad[] = [
+  {
+    keypad: '1',
+    label: '1',
+  },
+  {
+    keypad: '2',
+    label: '2',
+  },
+  {
+    keypad: '3',
+    label: '3',
+  },
+  {
+    keypad: '4',
+    label: '4',
+  },
+  {
+    keypad: '5',
+    label: '5',
+  },
+  {
+    keypad: '6',
+    label: '6',
+  },
+  {
+    keypad: '7',
+    label: '7',
+  },
+  {
+    keypad: '8',
+    label: '8',
+  },
+  {
+    keypad: '9',
+    label: '9',
+  },
+  {
+    keypad: '00',
+    label: '0 2개 버튼',
+  },
+  {
+    keypad: '0',
+    label: '0',
+  },
+  {
+    keypad: '<-',
+    label: '직전 입력 지우기',
+  },
+];
+export const numberKeypads: Keypad[] = [
+  {
+    keypad: '1',
+    label: '1',
+  },
+  {
+    keypad: '2',
+    label: '2',
+  },
+  {
+    keypad: '3',
+    label: '3',
+  },
+  {
+    keypad: '4',
+    label: '4',
+  },
+  {
+    keypad: '5',
+    label: '5',
+  },
+  {
+    keypad: '6',
+    label: '6',
+  },
+  {
+    keypad: '7',
+    label: '7',
+  },
+  {
+    keypad: '8',
+    label: '8',
+  },
+  {
+    keypad: '9',
+    label: '9',
+  },
+  {
+    keypad: '',
+    label: '',
+  },
+  {
+    keypad: '0',
+    label: '0',
+  },
+  {
+    keypad: '<-',
+    label: '직전 입력 지우기',
+  },
+];

--- a/client/src/components/Design/components/NumberKeyboard/keypads.ts
+++ b/client/src/components/Design/components/NumberKeyboard/keypads.ts
@@ -1,105 +1,29 @@
+export type KeyboardType = 'number' | 'string' | 'amount';
+
 type Keypad = {
   keypad: string;
   ariaLabel: string;
 };
 
-export const amountKeypads: Keypad[] = [
-  {
-    keypad: '1',
-    ariaLabel: '1',
-  },
-  {
-    keypad: '2',
-    ariaLabel: '2',
-  },
-  {
-    keypad: '3',
-    ariaLabel: '3',
-  },
-  {
-    keypad: '4',
-    ariaLabel: '4',
-  },
-  {
-    keypad: '5',
-    ariaLabel: '5',
-  },
-  {
-    keypad: '6',
-    ariaLabel: '6',
-  },
-  {
-    keypad: '7',
-    ariaLabel: '7',
-  },
-  {
-    keypad: '8',
-    ariaLabel: '8',
-  },
-  {
-    keypad: '9',
-    ariaLabel: '9',
-  },
-  {
-    keypad: '00',
-    ariaLabel: '0 2개 버튼',
-  },
-  {
-    keypad: '0',
-    ariaLabel: '0',
-  },
-  {
+export const makeKeypads = (type: KeyboardType): Keypad[] => {
+  const keypads: Keypad[] = [];
+
+  // 1~9는 동일
+  keypads.push(...new Array(9).fill(0).map((_, index) => ({keypad: String(index + 1), ariaLabel: String(index + 1)})));
+
+  // amount는 00버튼 나머지는 숨기기
+  if (type === 'amount') {
+    keypads.push({keypad: '00', ariaLabel: '0 2개 버튼'});
+  } else {
+    keypads.push({keypad: '', ariaLabel: ''});
+  }
+
+  // 나머지 0과 지우기 버튼
+  keypads.push({keypad: '0', ariaLabel: '0'});
+  keypads.push({
     keypad: '<-',
     ariaLabel: '마지막 숫자 지우기',
-  },
-];
-export const numberKeypads: Keypad[] = [
-  {
-    keypad: '1',
-    ariaLabel: '1',
-  },
-  {
-    keypad: '2',
-    ariaLabel: '2',
-  },
-  {
-    keypad: '3',
-    ariaLabel: '3',
-  },
-  {
-    keypad: '4',
-    ariaLabel: '4',
-  },
-  {
-    keypad: '5',
-    ariaLabel: '5',
-  },
-  {
-    keypad: '6',
-    ariaLabel: '6',
-  },
-  {
-    keypad: '7',
-    ariaLabel: '7',
-  },
-  {
-    keypad: '8',
-    ariaLabel: '8',
-  },
-  {
-    keypad: '9',
-    ariaLabel: '9',
-  },
-  {
-    keypad: '',
-    ariaLabel: '',
-  },
-  {
-    keypad: '0',
-    ariaLabel: '0',
-  },
-  {
-    keypad: '<-',
-    ariaLabel: '마지막 숫자 지우기',
-  },
-];
+  });
+
+  return keypads;
+};


### PR DESCRIPTION
## issue
- close #748 

## 개선 전 영상

https://github.com/user-attachments/assets/ad6c0c18-5e4e-49ae-85ca-9ea6bd57014b


현재는 위 영상에서 00 버튼을 '공' 버튼이라고 읽습니다.
실제로 0이 두 개이고 이 버튼을 클릭하면 1원에서 100원이 되지만 0이라고 읽힌다면 스크린리더로 서비스를 이용하는 사용자에게 불편한 경험을 줄 수 있습니다.

그래서 넘버 키패드 00을 `'0' 2개 버튼`으로 읽도록 개선해야합니다.

추가로 지우기 버튼도 `다음보다 작음`이라고 읽고 있습니다. 이를 `금액 지우기, 버튼`으로 읽어야 스크린리더 사용자가 헷갈리지 않고 이용할 수 있습니다.


## 구현 사항
## keypad에 label 속성 추가
기존에는 amountKeypads 배열이 이렇게 선언되어 있었습니다.

```ts
const amountKeypads = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '00', '0', '<-'];
```

여기에 스크린 리더가 읽어야 할 label 속성을 추가했습니다.
```ts
  {
    keypad: '1',
    label: '1',
  },
```

스크린 리더가 읽는 값과 화면에 표시되는 값을 다르게 설정하는 방식으로 구현했습니다.
그래서 00은 `0 2개 버튼`, <-는 `직전 입력 지우기`로 설정했어요.


## 개선 후 영상
https://github.com/user-attachments/assets/1c4e51ff-44f7-40ee-b887-b35e2e9c43fa



## 🫡 참고사항
### 스토리북에서 html lang = ko로 변경하는 방법

접근성 개선 결과를 확인하고 싶을 때 `npm run storybook`를 사용해 본인의 기기로 http://~~~:6006으로 확인을 주로 할 것이라 예상돼요. 이 때 스토리북의 preview 페이지는 우리가 설정한 index.html이 아니라 기본 lang 값이 en으로 설정돼있습니다. 그래서 스크린 리더가 한글을 읽을 때 굴려서 발음하게 됩니다.

레퍼런스를 찾아봤고 previewHead, preview-head.html을 작성하면 된다는 글이 있어 적용해봤지만 적용이 되지 않더라구요.
그래서 이를 변경하기 위해선 개선한 컴포넌트에 아래 두 문장 임의로 넣어서 테스트를 한 후 지워주면 됩니다.

```ts
const html = document.querySelector('html');
html?.setAttribute('lang', 'ko');
```
