### PR TITLE
[FE] SelectBox 수정 + globalStyle 파란색 하이라이팅 제거

### DIFF
--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -118,6 +118,7 @@ export const GlobalStyle = css`
   #root {
     display: flex;
     justify-content: center;
+    -webkit-tap-highlight-color: transparent;
   }
 
   button {

--- a/client/src/components/Design/components/Select/SelectInput.tsx
+++ b/client/src/components/Design/components/Select/SelectInput.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource @emotion/react */
-import {useState} from 'react';
 
 import {useTheme} from '@components/Design/theme/HDesignProvider';
 
@@ -28,7 +27,7 @@ const SelectInput = ({
   };
 
   return (
-    <Flex flexDirection="column" gap="0.375rem">
+    <Flex flexDirection="column">
       {labelText && (
         <Flex justifyContent="spaceBetween" paddingInline="0.5rem" margin="0 0 0.375rem 0">
           {labelText && (


### PR DESCRIPTION
## issue
- close #743 

## 구현목적

SelectBox의 버그를 수정합니다. 유저가 사용할 때, 큰 불편함은 존재하지 않겠지만 사용성을 조금 더 올리기 위해서 개선을 진행합니다.

## 수정사항

- 클릭 시 파란색 강조되는 현상을 해결해야합니다.
    
    이는 SelectBox 뿐 만아니라 다양한 컴포넌트에서도 발생하고 있는 사항입니다. 따라서 전역 스타일에서 해당 문제를 해결했습니다.
    
    ```tsx
    WebkitTapHighlightColor: 'transparent',
    ```
    
    [[root 속성 (-webkit-tap-highlight-color: transparent;)](https://velog.io/@jongk91/root-%EC%86%8D%EC%84%B1)](https://velog.io/@jongk91/root-속성)
    
- SelectBox 디자인과 불일치한 요소 수정
    
    SelectBox에서 SelectInput의 labelText에 Flex 컴포넌트가 사용되고 있었습니다. 그리고 그 컴포넌트에 gap에 0.375rem이 사용되고 있었습니다. 이미 labelText의 개별 style에 marginBottom을 주고 있었기 때문에 해당 gap은 중복으로 0.375rem을 주고 있었습니다. 
    
    따라서 SelectInput의 Flex 컴포넌트에 적용한 gap을 제거했습니다.