### PR TITLE
[FE] auth 요청 4번 보내는 현상 해결

### DIFF
--- a/client/src/hooks/useAdminPage.ts
+++ b/client/src/hooks/useAdminPage.ts
@@ -11,7 +11,6 @@ import SessionStorage from '@utils/SessionStorage';
 import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 import useRequestGetSteps from './queries/step/useRequestGetSteps';
-import useRequestPostAuthentication from './queries/auth/useRequestPostAuthentication';
 
 const useAdminPage = () => {
   const eventId = getEventIdByUrl();
@@ -20,11 +19,6 @@ const useAdminPage = () => {
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
 
   const {steps} = useRequestGetSteps();
-  const {postAuthenticate} = useRequestPostAuthentication();
-
-  useEffect(() => {
-    postAuthenticate();
-  }, [postAuthenticate]);
 
   // session storage에 배너를 지웠는지 관리
   const storageValue = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId));


### PR DESCRIPTION
## issue
- close #752 

## 구현 사항
### useAdminPage와 AuthGate 두 곳에서 중복적으로 부르는 `postAuthenticate` 제거
AuthGate에서 postAuthenticate 함수를 불러 auth 상태를 업데이트하는데 그 하위 useAdminPage에서 중복적으로 postAuthenticate를 부르고 있었습니다.

그래서 useAdminPage에서 postAuthenticate 함수 호출 구문을 제거했습니다.


### 개선 후 호출 결과
![image](https://github.com/user-attachments/assets/2961c603-fc6a-4874-8a09-e5d727793d7b)


## 🫡 참고사항
