### PR TITLE
[FE] 첫 지출내역 추가 시, 입금 상태 관리 Banner 띄우기

### DIFF
--- a/client/src/constants/sessionStorageKeys.ts
+++ b/client/src/constants/sessionStorageKeys.ts
@@ -1,5 +1,6 @@
 const SESSION_STORAGE_KEYS = {
   closeAccountBannerByEventToken: (eventToken: string) => `closeAccountBanner-${eventToken}`,
+  closeDepositStateBannerByEventToken: (eventToken: string) => `closeDepositStateBanner-${eventToken}`,
 } as const;
 
 export default SESSION_STORAGE_KEYS;

--- a/client/src/hooks/useAdminPage.ts
+++ b/client/src/hooks/useAdminPage.ts
@@ -6,12 +6,10 @@ import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
 import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
-import SessionStorage from '@utils/SessionStorage';
-
-import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 import useRequestGetSteps from './queries/step/useRequestGetSteps';
 import useRequestPostAuthentication from './queries/auth/useRequestPostAuthentication';
+import useBanner from './useBanner';
 
 const useAdminPage = () => {
   const eventId = getEventIdByUrl();
@@ -22,45 +20,16 @@ const useAdminPage = () => {
   const {steps} = useRequestGetSteps();
   const {postAuthenticate} = useRequestPostAuthentication();
 
+  const {isShowAccountBanner, onDeleteAccount, isShowDepositStateBanner, onDeleteDepositState} = useBanner({
+    eventId,
+    bankName,
+    accountNumber,
+    steps,
+  });
+
   useEffect(() => {
     postAuthenticate();
   }, [postAuthenticate]);
-
-  // session storage에 계좌번호 입력 배너를 지웠는지 관리
-  const storageAccountValue = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId));
-  const isClosedAccount = storageAccountValue !== null && storageAccountValue === true;
-
-  const isEmptyAccount = bankName === '' || accountNumber === '';
-  const [isShowAccountBanner, setIsShowAccountBanner] = useState<boolean>(isEmptyAccount && !isClosedAccount);
-
-  useEffect(() => {
-    setIsShowAccountBanner(isEmptyAccount && !isClosedAccount);
-  }, [bankName, accountNumber, isShowAccountBanner]);
-
-  const onDeleteAccount = () => {
-    setIsShowAccountBanner(false);
-    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId), true);
-  };
-
-  // session storage에 입금 상태관리 배너를 지웠는지 관리
-  const storageDepositStateValue = SessionStorage.get<boolean>(
-    SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId),
-  );
-  const isClosedDepositState = storageDepositStateValue != null && storageDepositStateValue;
-
-  const isExistStepsAndAccount = steps.length && !isEmptyAccount;
-  const [isShowDepositStateBanner, setIsShowDepositStateBanner] = useState<boolean>(
-    !!isExistStepsAndAccount && !isClosedDepositState,
-  );
-
-  useEffect(() => {
-    setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
-  }, [isShowDepositStateBanner, steps, bankName, accountNumber]);
-
-  const onDeleteDepositState = () => {
-    setIsShowDepositStateBanner(false);
-    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId), true);
-  };
 
   return {
     eventId,

--- a/client/src/hooks/useAdminPage.ts
+++ b/client/src/hooks/useAdminPage.ts
@@ -26,19 +26,40 @@ const useAdminPage = () => {
     postAuthenticate();
   }, [postAuthenticate]);
 
-  // session storage에 배너를 지웠는지 관리
-  const storageValue = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId));
-  const isClosed = storageValue !== null && storageValue === true;
+  // session storage에 계좌번호 입력 배너를 지웠는지 관리
+  const storageAccountValue = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId));
+  const isClosedAccount = storageAccountValue !== null && storageAccountValue === true;
 
-  const [isShowBanner, setIsShowBanner] = useState<boolean>((bankName === '' || accountNumber === '') && !isClosed);
+  const isEmptyAccount = bankName === '' || accountNumber === '';
+  const [isShowAccountBanner, setIsShowAccountBanner] = useState<boolean>(isEmptyAccount && !isClosedAccount);
 
   useEffect(() => {
-    setIsShowBanner((bankName === '' || accountNumber === '') && !isClosed);
-  }, [bankName, accountNumber, isShowBanner]);
+    setIsShowAccountBanner(isEmptyAccount && !isClosedAccount);
+  }, [bankName, accountNumber, isShowAccountBanner]);
 
-  const onDelete = () => {
-    setIsShowBanner(false);
+  const onDeleteAccount = () => {
+    setIsShowAccountBanner(false);
     SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId), true);
+  };
+
+  // session storage에 입금 상태관리 배너를 지웠는지 관리
+  const storageDepositStateValue = SessionStorage.get<boolean>(
+    SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId),
+  );
+  const isClosedDepositState = storageDepositStateValue != null && storageDepositStateValue;
+
+  const isExistStepsAndAccount = steps.length && !isEmptyAccount;
+  const [isShowDepositStateBanner, setIsShowDepositStateBanner] = useState<boolean>(
+    !!isExistStepsAndAccount && !isClosedDepositState,
+  );
+
+  useEffect(() => {
+    setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
+  }, [isShowDepositStateBanner, steps]);
+
+  const onDeleteDepositState = () => {
+    setIsShowDepositStateBanner(false);
+    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId), true);
   };
 
   return {
@@ -46,9 +67,11 @@ const useAdminPage = () => {
     isAdmin,
     eventName,
     totalExpenseAmount,
-    isShowBanner,
-    onDelete,
+    isShowAccountBanner,
+    onDeleteAccount,
     steps,
+    isShowDepositStateBanner,
+    onDeleteDepositState,
   };
 };
 

--- a/client/src/hooks/useAdminPage.ts
+++ b/client/src/hooks/useAdminPage.ts
@@ -55,7 +55,7 @@ const useAdminPage = () => {
 
   useEffect(() => {
     setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
-  }, [isShowDepositStateBanner, steps]);
+  }, [isShowDepositStateBanner, steps, bankName, accountNumber]);
 
   const onDeleteDepositState = () => {
     setIsShowDepositStateBanner(false);

--- a/client/src/hooks/useBanner.ts
+++ b/client/src/hooks/useBanner.ts
@@ -1,0 +1,61 @@
+import {useEffect, useState} from 'react';
+
+import {Step} from 'types/serviceType';
+
+import SessionStorage from '@utils/SessionStorage';
+
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
+
+interface Props {
+  eventId: string;
+  bankName: string;
+  accountNumber: string;
+  steps: Step[];
+}
+
+const useBanner = ({eventId, bankName, accountNumber, steps}: Props) => {
+  // session storage에 계좌번호 입력 배너를 지웠는지 관리
+  const storageAccountValue = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId));
+  const isClosedAccount = storageAccountValue !== null && storageAccountValue === true;
+
+  const isEmptyAccount = bankName === '' || accountNumber === '';
+  const [isShowAccountBanner, setIsShowAccountBanner] = useState<boolean>(isEmptyAccount && !isClosedAccount);
+
+  useEffect(() => {
+    setIsShowAccountBanner(isEmptyAccount && !isClosedAccount);
+  }, [bankName, accountNumber, isShowAccountBanner]);
+
+  const onDeleteAccount = () => {
+    setIsShowAccountBanner(false);
+    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeAccountBannerByEventToken(eventId), true);
+  };
+
+  // session storage에 입금 상태관리 배너를 지웠는지 관리
+  const storageDepositStateValue = SessionStorage.get<boolean>(
+    SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId),
+  );
+  const isClosedDepositState = storageDepositStateValue != null && storageDepositStateValue;
+
+  const isExistStepsAndAccount = steps.length && !isEmptyAccount;
+  const [isShowDepositStateBanner, setIsShowDepositStateBanner] = useState<boolean>(
+    !!isExistStepsAndAccount && !isClosedDepositState,
+  );
+
+  useEffect(() => {
+    setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
+  }, [isShowDepositStateBanner, steps, bankName, accountNumber]);
+
+  const onDeleteDepositState = () => {
+    setIsShowDepositStateBanner(false);
+    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId), true);
+  };
+
+  return {
+    isShowAccountBanner,
+    onDeleteAccount,
+    isShowDepositStateBanner,
+    onDeleteDepositState,
+  };
+};
+
+export default useBanner;

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -70,7 +70,7 @@ const AdminPage = () => {
           onClick={navigateEventMemberManage}
           onDelete={onDeleteDepositState}
           title="참여자 입금상태를 관리할 수 있어요"
-          description="어떤 참여자가 입금을 완료했는지 관리해 보세요"
+          description="어떤 참여자가 입금을 완료했는지 기록해 보세요"
           buttonText="관리하기"
         />
       )}

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -67,7 +67,7 @@ const AdminPage = () => {
       )}
       {isShowDepositStateBanner && (
         <Banner
-          onClick={navigateAccountInputPage}
+          onClick={navigateEventMemberManage}
           onDelete={onDeleteDepositState}
           title="참여자 입금상태를 관리할 수 있어요"
           description="어떤 참여자가 입금을 완료했는지 관리해봐요"

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -70,7 +70,7 @@ const AdminPage = () => {
           onClick={navigateEventMemberManage}
           onDelete={onDeleteDepositState}
           title="참여자 입금상태를 관리할 수 있어요"
-          description="어떤 참여자가 입금을 완료했는지 관리해봐요"
+          description="어떤 참여자가 입금을 완료했는지 관리해 보세요"
           buttonText="관리하기"
         />
       )}

--- a/client/src/pages/EventPage/AdminPage/AdminPage.tsx
+++ b/client/src/pages/EventPage/AdminPage/AdminPage.tsx
@@ -14,7 +14,17 @@ const AdminPage = () => {
   const navigate = useNavigate();
   const {trackAddBillStart} = useAmplitude();
 
-  const {eventId, isAdmin, eventName, totalExpenseAmount, isShowBanner, onDelete, steps} = useAdminPage();
+  const {
+    eventId,
+    isAdmin,
+    eventName,
+    totalExpenseAmount,
+    isShowAccountBanner,
+    onDeleteAccount,
+    steps,
+    isShowDepositStateBanner,
+    onDeleteDepositState,
+  } = useAdminPage();
 
   const navigateAccountInputPage = () => {
     navigate(`/event/${eventId}/admin/edit`);
@@ -46,13 +56,22 @@ const AdminPage = () => {
           </Dropdown>
         }
       />
-      {isShowBanner && (
+      {isShowAccountBanner && (
         <Banner
           onClick={navigateAccountInputPage}
-          onDelete={onDelete}
+          onDelete={onDeleteAccount}
           title="계좌번호가 등록되지 않았어요"
           description="계좌번호를 입력해야 참여자가 편하게 송금할 수 있어요"
           buttonText="등록하기"
+        />
+      )}
+      {isShowDepositStateBanner && (
+        <Banner
+          onClick={navigateAccountInputPage}
+          onDelete={onDeleteDepositState}
+          title="참여자 입금상태를 관리할 수 있어요"
+          description="어떤 참여자가 입금을 완료했는지 관리해봐요"
+          buttonText="관리하기"
         />
       )}
       {steps.length > 0 && <StepList data={steps ?? []} isAdmin={isAdmin} />}

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -43,11 +43,9 @@ const EventPageLayout = () => {
   };
 
   useEffect(() => {
-    console.log('mount');
     updateMetaTag('og:title', `행동대장이 "${eventSummary.eventName}"에 대한 정산을 요청했어요`);
 
     return () => {
-      console.log('unmount');
       updateMetaTag('og:title', '행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스');
     };
   }, []);


### PR DESCRIPTION
## issue
- close #729 

## 구현 목적

현재 유저가 입금 상태를 관리할 수 있는 기능을 인지할 방법이 존재하지 않습니다.
그렇기 때문에 유저가 지출내역을 생성했다면, 입금 상태를 관리하는 기능을 인지할 수 있도록 Banner를 활용하여 알려줍니다.

## 구현 내용

### 구현된 화면
<img width="410" alt="스크린샷 2024-10-16 16 07 41" src="https://github.com/user-attachments/assets/8e1b07c5-dfe4-41a4-9ea8-4bb1bb2747d1">

### 입금 상태 관리 Banner 띄우기

참여자 입금 상태 Banner를 띄우는 조건은 다음과 같습니다.

- 계좌번호를 등록 할 것
- 최소 1개의 지출내역이 존재할 것
- sessionStorage에 `*closeDepositStateBanner-*${*eventToken*}` key가 존재하지 않고 그 값이 false일 경우

참여자 입금 상태 Banner가 닫히는 조건은 단 하나입니다.

- Banner의 X 버튼을 클릭했을 때

닫히는 조건을 더 추가할까 고민했습니다만, 일단은 x 버튼을 클릭해야만 닫히도록 했습니다. 현 상황에서는 Banner는 최대 1개만 띄워지기 때문입니다.

Banner는 총 2개가 존재하지만 해당 입금상태 Banner는 계좌번호가 존재해야 띄워집니다. 계좌번호 Banne는 계좌번호가 입력되면 사라지기 때문에 2개의 Banner가 동시에 띄워질 일은 발생하지 않습니다. 따라서 입금 상태 Banner에 따로 닫히는 조건을 추가하지는 않았습니다. (만약, 사진 첨부 Banner를 띄우게 된다면 추가로 고려하면 될 것 같습니다.)

### 입금 상태 관리 Banner 구현

쿠키가 Banner를 너무 잘 만들어줘서.. 쿠키가 작성한 코드를 바탕으로 구현했습니다.

```tsx
// constants/sessionStorageKeys.ts

const SESSION_STORAGE_KEYS = {
  // ...
  closeDepositStateBannerByEventToken: (eventToken: string) => `closeDepositStateBanner-${eventToken}`,
} as const;
```

- `closeDepositStateBannerByEventToken`
    
    sessionStorage의 key로 `closeDepositStateBanner-${eventToken}`를 생성했습니다.
    

```tsx
//useAdminPage.ts

// ...

// session storage에 입금 상태관리 배너를 지웠는지 관리
  const storageDepositStateValue = SessionStorage.get<boolean>(
    SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId),
  );
  const isClosedDepositState = storageDepositStateValue != null && storageDepositStateValue;

  const isExistStepsAndAccount = steps.length && !isEmptyAccount;
  const [isShowDepositStateBanner, setIsShowDepositStateBanner] = useState<boolean>(
    !!isExistStepsAndAccount && !isClosedDepositState,
  );

  useEffect(() => {
    setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
  }, [isShowDepositStateBanner, steps, bankName, accountNumber]);

  const onDeleteDepositState = () => {
    setIsShowDepositStateBanner(false);
    SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.closeDepositStateBannerByEventToken(eventId), true);
  };
```

- `storageDepositStateValue`
    
    `closeDepositStateBanner-${eventToken}` key의 값을 sessionStorage에서 가져옵니다.
    
- `isClosedDepositState`
    
    `closeDepositStateBanner-${eventToken}`의 값이 true인지 false인지 저장합니다. 
    만약, 값이 true라면 입금 상태 배너는 닫힌 것입니다. 
    
- `isExistStepsAndAccount`
    
    steps(지출내역)와 account(계좌번호)가 존재하는지 확인합니다.
    
- `isShowDepositStateBanner`
    
    isExistStepsAndAccount가 true이고 isClosedDepositState의 값이 false라면 isShowDepositStateBanner 상태 값은 true입니다.
    isShowDepositStateBanner가 true라는 것은 입금상태 배너가 보인다는 의미입니다. 만약, false라면 배너는 보이지 않습니다.
    

<details>
<summary> <h2>🚀 트러블슈팅</h2> </summary>
<div markdown="1">

### 문제 발생 상황

행사 생성 → 지출 내역 생성 → 계좌번호 입력 → 계좌번호 입력 → adminPage로 이동 → DepositStateBanner 존재 X

해당 flow에서는 DepositStateBanner가 띄워지지 않는 문제가 발생했습니다.

### 문제 해결

isShowDepositStateBanner의 상태를 변경시키는 useEffect의 의존성 값에 bankName과 accountNumber를 넣어주지 않아서 발생한 문제였습니다. 두 값이 의존성에 존재하지 않아 계좌번호를 입력하였음에도 DepositStateBanner의 상태가 변경되지 않은 것이었습니다.

따라서 bankName과 accountNumber를 의존성에 추가하였습니다.

- 변경 전
    
    ```tsx
     useEffect(() => {
        setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
      }, [isShowDepositStateBanner, steps]);
    ```
    
- 변경 후
    
    ```tsx
     useEffect(() => {
        setIsShowDepositStateBanner(!!isExistStepsAndAccount && !isClosedDepositState);
      }, [isShowDepositStateBanner, steps, bankName, accountNumber]);
    ```


</div>
</details>

```tsx
 // AdminPage.tsx
 
 {isShowDepositStateBanner && (
  <Banner
    onClick={navigateEventMemberManage}
    onDelete={onDeleteDepositState}
    title="참여자 입금상태를 관리할 수 있어요"
    description="어떤 참여자가 입금을 완료했는지 관리해 보세요"
    buttonText="관리하기"
  />
)}
```

isShowDepositStateBanner의 값이 true이면 위 Banner 컴포넌트를 띄웁니다.
관리하기 버튼을 클릭하면 `전체 참여자 관리 페이지`로 이동합니다. x 버튼을 클릭하면 버튼이 닫힙니다.

## 논의하고 싶은 부분(선택)
Banner의 description과 title이 적절한지 확인 부탁드립니다!

## 참고사항
불필요하게 console이 찍히는 것을 확인하여 해당 코드를 삭제했습니다.
`EventPageLayout.tsx`에서 mount와 unmount에 관하여 console를 출력하고 있었습니다.
