### PR TITLE
[FE] 접근성 개선 : 지출내역 추가 Flow의 Top

### DIFF
--- a/client/src/components/Design/components/Top/Line.tsx
+++ b/client/src/components/Design/components/Top/Line.tsx
@@ -31,6 +31,7 @@ export default function Line({text, emphasize = []}: Props) {
             size="subTitle"
             textColor={emphasize.includes(text) ? 'black' : 'gray'}
             style={{whiteSpace: 'pre'}}
+            aria-hidden={true}
           >
             {`${text}`}
           </Text>

--- a/client/src/components/Design/components/Top/Top.tsx
+++ b/client/src/components/Design/components/Top/Top.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import {css} from '@emotion/react';
-import {useEffect, useState} from 'react';
 import React from 'react';
 
 import Line from './Line';
@@ -10,17 +9,12 @@ Top.Line = Line;
 Top.EditableLine = EditableLine;
 
 export default function Top({children}: React.PropsWithChildren) {
-  const [childrenTexts, setChildrenTexts] = useState<string[]>([]);
-
-  useEffect(() => {
-    const collectedTexts: string[] = [];
-    React.Children.forEach(children, child => {
-      if (React.isValidElement(child) && child.type === Top.Line) {
-        collectedTexts.push(child.props.text);
-      }
-    });
-    setChildrenTexts(collectedTexts);
-  }, [children]);
+  const childrenTexts: string[] = [];
+  React.Children.forEach(children, child => {
+    if (React.isValidElement(child) && child.type === Top.Line) {
+      childrenTexts.push(child.props.text);
+    }
+  });
 
   return (
     <div

--- a/client/src/components/Design/components/Top/Top.tsx
+++ b/client/src/components/Design/components/Top/Top.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import {css} from '@emotion/react';
+import {useEffect, useState} from 'react';
+import React from 'react';
 
 import Line from './Line';
 import EditableLine from './EditableLine';
@@ -8,12 +10,26 @@ Top.Line = Line;
 Top.EditableLine = EditableLine;
 
 export default function Top({children}: React.PropsWithChildren) {
+  const [childrenTexts, setChildrenTexts] = useState<string[]>([]);
+
+  useEffect(() => {
+    const collectedTexts: string[] = [];
+    React.Children.forEach(children, child => {
+      if (React.isValidElement(child) && child.type === Top.Line) {
+        collectedTexts.push(child.props.text);
+      }
+    });
+    setChildrenTexts(collectedTexts);
+  }, [children]);
+
   return (
     <div
       css={css`
         display: flex;
         flex-direction: column;
       `}
+      aria-label={childrenTexts.join(' ')}
+      tabIndex={0}
     >
       {children}
     </div>


### PR DESCRIPTION
## issue
- close #757 

## 구현 목적

핵심 flow인 지출내역 생성에서 스크린리더를 사용하는 유저는 header를 제외하고는 가장 먼저 Top을 듣게 될 것입니다. Top 컴포넌트는 해당 페이지에 대한 설명을 담은 컴포넌트로, 스크린리더 사용자는 해당 페이지에서 어떤 것을 입력해야 하는지 듣게 됩니다.

그런데, 기존의 Top 컴포넌트의 text는 끊어서 읽혔습니다. 이런 점은 스크린리더 사용자에게 혼동과 불편함을 주게 될 것입니다. 따라서, Top 컴포넌트를 스크린리더가 읽혔을 때 내용이 한번에 읽히도록 수정합니다.

## 개선 전/후 영상
🔇 영상 속 스크린리더기는 음성을 사용하지 않습니다! 
💬 영상 하단에 스크린리더 자막으로 확인해주세요!
- 개선 전
- 
   https://github.com/user-attachments/assets/91ee2e08-7fae-4bac-9ef1-1a0d20e4d7de

- 개선 후

   https://github.com/user-attachments/assets/432d4034-c5bb-4682-b5ba-24a2e8b303ad

## 구현 방법

```tsx
const [childrenTexts, setChildrenTexts] = useState<string[]>([]);

  useEffect(() => {
    const collectedTexts: string[] = [];
    React.Children.forEach(children, child => {
      if (React.isValidElement(child) && child.type === Top.Line) {
        collectedTexts.push(child.props.text);
      }
    });
    setChildrenTexts(collectedTexts);
  }, [children]);

  return (
    <div
      css={css`
        display: flex;
        flex-direction: column;
      `}
      aria-label={childrenTexts.join(' ')}
      tabIndex={0}
    >
      {children}
    </div>
  );
```

- childrenTexts 상태 생성
- Top 컴포넌트의 children(즉, Line 컴포넌트)를 map합니다.
    
    이때,  children의 props가 text인 값을 collectedTexts에 저장합니다.
    이 collectedTexts의 값을 setChildrenTexts를 통해 상태를 업데이트 합니다.
    
- Top 컴포넌트의 aria-label로 childrenTexts를 넣습니다.
    
    이때, childrenTexts를 배열이라 join을 사용하여 하나의 문자열로 만듭니다.
    
- tabIndex의 값을 0을 주어, Top 컴포넌트만 상위로 읽히도록 합니다.

```tsx
export default function Line({text, emphasize = []}: Props) {
  // ...
  
  {elements.map((text, index) => {
    return (
      <Text
        key={`${text}-${index}`}
        size="subTitle"
        textColor={emphasize.includes(text) ? 'black' : 'gray'}
        style={{whiteSpace: 'pre'}}
        aria-hidden={true}
      >
        {`${text}`}
      </Text>
    );
  })}
}
```

- 이때, Line 컴포넌트에 aria-hidden=true를 추가합니다.
    
    Top 컴포넌트 이후에 Line 컴포넌트가 같이 스크린리더로 읽히기 때문입니다.
