### PR TITLE
[FE] 랜딩페이지 스크롤 오류 해결

### DIFF
--- a/client/src/hooks/useMainPageYScroll.ts
+++ b/client/src/hooks/useMainPageYScroll.ts
@@ -4,6 +4,14 @@ const useMainPageYScroll = () => {
   const featureSectionRef = useRef<HTMLDivElement>(null);
   const threshold = window.innerHeight * 2;
   const translateX = useRef(0);
+  const animationFrameId = useRef<number | null>(null);
+
+  const updateTransform = () => {
+    const newTransform = `translateX(calc(200vw - ${translateX.current}px))`;
+    if (featureSectionRef.current) {
+      featureSectionRef.current.style.transform = newTransform;
+    }
+  };
 
   useEffect(() => {
     const handleScroll = () => {
@@ -28,14 +36,22 @@ const useMainPageYScroll = () => {
           featureSectionRef.current.style.position = 'static';
           featureSectionRef.current.style.top = '';
         }
-        const newTransform = `translateX(calc(200vw - ${translateX.current}px))`;
-        featureSectionRef.current.style.transform = newTransform;
+
+        if (animationFrameId.current) {
+          cancelAnimationFrame(animationFrameId.current);
+        }
+        animationFrameId.current = requestAnimationFrame(updateTransform);
       }
     };
 
     window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [featureSectionRef, window.innerHeight, window.innerWidth, window.scrollY]);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (animationFrameId.current) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
+    };
+  }, [featureSectionRef]);
 
   return {featureSectionRef};
 };

--- a/client/src/hooks/useMainPageYScroll.ts
+++ b/client/src/hooks/useMainPageYScroll.ts
@@ -2,32 +2,37 @@ import {useEffect, useRef} from 'react';
 
 const useMainPageYScroll = () => {
   const featureSectionRef = useRef<HTMLDivElement>(null);
+  const threshold = window.innerHeight * 2;
   const translateX = useRef(0);
 
   useEffect(() => {
     const handleScroll = () => {
       if (featureSectionRef.current) {
-        const featureSectionTop = featureSectionRef.current.offsetTop;
         const scrollY = window.scrollY;
+        console.log(scrollY);
 
-        if (scrollY >= featureSectionTop && translateX.current < window.innerWidth * 4) {
-          window.scrollTo(0, featureSectionTop);
-          translateX.current += scrollY - featureSectionTop;
-          const newTransform = `translateX(calc(200vw - ${translateX.current > 0 ? translateX.current : 0}px))`;
-          featureSectionRef.current.style.transform = newTransform;
-        }
-        if (scrollY <= featureSectionTop && translateX.current > 0) {
-          window.scrollTo(0, featureSectionTop);
-          translateX.current += scrollY - featureSectionTop;
-          const newTransform = `translateX(calc(200vw - ${translateX.current < window.innerWidth * 4 ? translateX.current : window.innerWidth * 4}px))`;
-          featureSectionRef.current.style.transform = newTransform;
+        if (scrollY >= threshold && scrollY < threshold + window.innerHeight * 5) {
+          featureSectionRef.current.style.position = 'fixed';
+          featureSectionRef.current.style.top = '0';
+          featureSectionRef.current.style.marginTop = '0';
+          if (scrollY < threshold + window.innerHeight * 4) {
+            translateX.current = (scrollY - threshold) * (window.innerWidth / window.innerHeight);
+            const newTransform = `translateX(calc(200vw - ${translateX.current}px))`;
+            featureSectionRef.current.style.transform = newTransform;
+          } else {
+            featureSectionRef.current.style.opacity = `${(window.innerHeight * 7 - scrollY) / window.innerHeight}`;
+          }
+        } else {
+          featureSectionRef.current.style.position = 'static';
+          featureSectionRef.current.style.margin = '';
+          featureSectionRef.current.style.top = '';
         }
       }
     };
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [featureSectionRef, window.innerHeight, window.innerWidth, window.scrollY]);
 
   return {featureSectionRef};
 };

--- a/client/src/hooks/useMainPageYScroll.ts
+++ b/client/src/hooks/useMainPageYScroll.ts
@@ -9,24 +9,27 @@ const useMainPageYScroll = () => {
     const handleScroll = () => {
       if (featureSectionRef.current) {
         const scrollY = window.scrollY;
-        console.log(scrollY);
 
         if (scrollY >= threshold && scrollY < threshold + window.innerHeight * 5) {
           featureSectionRef.current.style.position = 'fixed';
           featureSectionRef.current.style.top = '0';
-          featureSectionRef.current.style.marginTop = '0';
           if (scrollY < threshold + window.innerHeight * 4) {
             translateX.current = (scrollY - threshold) * (window.innerWidth / window.innerHeight);
-            const newTransform = `translateX(calc(200vw - ${translateX.current}px))`;
-            featureSectionRef.current.style.transform = newTransform;
           } else {
             featureSectionRef.current.style.opacity = `${(window.innerHeight * 7 - scrollY) / window.innerHeight}`;
           }
         } else {
+          if (scrollY < threshold) {
+            translateX.current = 0;
+          } else {
+            translateX.current = 4 * window.innerWidth;
+          }
+          featureSectionRef.current.style.opacity = '1';
           featureSectionRef.current.style.position = 'static';
-          featureSectionRef.current.style.margin = '';
           featureSectionRef.current.style.top = '';
         }
+        const newTransform = `translateX(calc(200vw - ${translateX.current}px))`;
+        featureSectionRef.current.style.transform = newTransform;
       }
     };
 

--- a/client/src/hooks/useMainSectionBackgroundScroll.ts
+++ b/client/src/hooks/useMainSectionBackgroundScroll.ts
@@ -20,7 +20,7 @@ const useMainSectionBackgroundScroll = (trackStartCreateEvent: () => void) => {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [window.scrollY, window.innerHeight]);
 
   return {isVisible, handleClick};
 };

--- a/client/src/pages/MainPage/MainPage.style.ts
+++ b/client/src/pages/MainPage/MainPage.style.ts
@@ -3,7 +3,7 @@ import {css} from '@emotion/react';
 export const mainContainer = css({
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'center',
+  justifyContent: 'start',
   alignItems: 'center',
-  width: '100%',
+  height: '850vh',
 });

--- a/client/src/pages/MainPage/MainPage.style.ts
+++ b/client/src/pages/MainPage/MainPage.style.ts
@@ -6,4 +6,5 @@ export const mainContainer = css({
   justifyContent: 'start',
   alignItems: 'center',
   height: '850vh',
+  overflowX: 'hidden',
 });

--- a/client/src/pages/MainPage/Section/CreatorSection/Avatar.tsx
+++ b/client/src/pages/MainPage/Section/CreatorSection/Avatar.tsx
@@ -1,9 +1,10 @@
-import {Text} from '@components/Design';
-
-import {avatarImageStyle, avatarStyle} from './Avatar.style';
 import Image from '@components/Design/components/Image/Image';
 
+import {Text} from '@components/Design';
+
 import getImageUrl from '@utils/getImageUrl';
+
+import {avatarImageStyle, avatarStyle} from './Avatar.style';
 
 interface Props {
   imagePath: string;

--- a/client/src/pages/MainPage/Section/CreatorSection/Avatar.tsx
+++ b/client/src/pages/MainPage/Section/CreatorSection/Avatar.tsx
@@ -1,6 +1,9 @@
 import {Text} from '@components/Design';
 
 import {avatarImageStyle, avatarStyle} from './Avatar.style';
+import Image from '@components/Design/components/Image/Image';
+
+import getImageUrl from '@utils/getImageUrl';
 
 interface Props {
   imagePath: string;
@@ -11,7 +14,7 @@ interface Props {
 const Avatar = ({imagePath, name, navigateUrl}: Props) => {
   return (
     <a href={navigateUrl} target="_blank" css={avatarStyle}>
-      <img src={`${process.env.IMAGE_URL}/${imagePath}.png`} css={avatarImageStyle} />
+      <Image src={getImageUrl(imagePath, 'webp')} fallbackSrc={getImageUrl(imagePath, 'png')} css={avatarImageStyle} />
       <Text size="bodyBold" textColor="white" responsive={true}>
         {name}
       </Text>

--- a/client/src/pages/MainPage/Section/CreatorSection/CreatorSection.style.ts
+++ b/client/src/pages/MainPage/Section/CreatorSection/CreatorSection.style.ts
@@ -8,8 +8,9 @@ export const sectionStyle = css({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  backgroundColor: '#000000 ',
+  backgroundColor: '#000000',
   gap: '2rem',
+  marginTop: 'auto',
 });
 
 export const partStyle = css({

--- a/client/src/pages/MainPage/Section/FeatureSection/FeatureSection.tsx
+++ b/client/src/pages/MainPage/Section/FeatureSection/FeatureSection.tsx
@@ -1,5 +1,5 @@
 import {css} from '@emotion/react';
-import {forwardRef, useEffect, useRef} from 'react';
+import {useRef} from 'react';
 
 import useMainPageYScroll from '@hooks/useMainPageYScroll';
 

--- a/client/src/pages/MainPage/Section/FeatureSection/FeatureSection.tsx
+++ b/client/src/pages/MainPage/Section/FeatureSection/FeatureSection.tsx
@@ -1,5 +1,5 @@
 import {css} from '@emotion/react';
-import {useRef} from 'react';
+import {forwardRef, useEffect, useRef} from 'react';
 
 import useMainPageYScroll from '@hooks/useMainPageYScroll';
 
@@ -17,10 +17,11 @@ const FeatureSection = () => {
     <div
       ref={featureSectionRef}
       css={css({
+        position: 'static',
         display: 'flex',
         transform: 'translateX(200vw)',
-        overflowY: 'hidden',
         background: 'linear-gradient(to right, #FFA5B8 0%, #DFC1FF 50%, #C1CFFF 100%)',
+        height: '100vh',
       })}
     >
       <SimpleShare />


### PR DESCRIPTION
## issue
- close #796 

## 구현 목적
- 현재 모바일 환경이나 일부 데스크탑 환경에서 가로 스크롤이 제대로 되지 않는 오류가 있어 이를 해결합니다.

## 구현 사항
현재 가로 스크롤이 작동하는 과정은 아래와 같습니다.

1. 스크롤이 featureSection에 도달한다.
2. featureSection 영역부터, 종방향 스크롤을 하면 이를 featureSection 위치로 다시 종방향 스크롤시킨다
3. 종방향 스크롤을 한 만큼, featureSection을 translateX 시킨다.
4. translateX가 최대치에 도달하면, 다시 종방향 스크롤을 가능하게 한다.

이 과정에서, 종방향 스크롤을 강제로 못하게 원 위치로 되돌리는 방식이다 보니, 스크롤이 계속 유지되는 모바일 환경의 touch 이벤트에서는 제대로 작동하지 않는 것이 문제가 되었습니다.
또한, 스크롤 자체를 다시 원위치로 되돌이는 것이다 보니, 중간 중간 스크롤이 꿀렁거리는 오류가 있었습니다.
이를 해결하기 위해 작동 방식을 아래와 같이 변경하였습니다.

1. 스크롤이 featureSection에 도달한다.
2. featureSection의 position을 fixed로 변경한다.
3. featureSection이 fixed인 상태로 스크롤 되는 만큼 페이지에 여백을 만들어 둔다.
4. 여백 내부에서 종방향 스크롤을 한 만큼, featureSection을 translateX 시킨다.
5. 여백이 끝에 도달할 때, opacity를 이용해 featureSection을 없애준다.

따라서, 스크롤은 실제로 이루어지고, default Event를 강제로 조작하지 않으므로 많은 환경에서 동일하게 작동할 것으로 기대됩니다.