### PR TITLE
[FE] carousel 에 maxWidth가 적용되지 않아 768 이상 해상도에서 짤리는 문제

### DIFF
--- a/client/src/components/Design/components/Carousel/Carousel.style.ts
+++ b/client/src/components/Design/components/Carousel/Carousel.style.ts
@@ -60,7 +60,7 @@ export const deleteButtonStyle = css`
   right: 1rem;
   padding: 0.5rem;
   opacity: 0.48;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.8);
   border-radius: 50%;
   display: flex;
   justify-content: center;
@@ -70,7 +70,7 @@ export const deleteButtonStyle = css`
 export const indicatorContainerStyle = css`
   position: absolute;
   left: 50%;
-  bottom: 1rem;
+  top: 1rem;
   transform: translateX(-50%);
   display: flex;
   gap: 0.25rem;

--- a/client/src/components/Design/components/Carousel/Carousel.style.ts
+++ b/client/src/components/Design/components/Carousel/Carousel.style.ts
@@ -44,6 +44,7 @@ export const imageCardStyle = ({theme}: ImageCardStyleProps) => css`
   justify-content: center;
   align-items: center;
   clip-path: inset(0 round 1rem);
+  max-width: calc(768px - 4rem);
   background-color: ${theme.colors.gray};
 `;
 


### PR DESCRIPTION
## issue
- close #765

## 구현 목적
- 768px 이상의 해상도에서 carousel이 잘리는 문제가 발생했습니다.
![image](https://github.com/user-attachments/assets/161bfea2-5baf-451f-92c5-876957890af3)

## 구현 사항
- `Carousel` component에서 이미지 카드의 `max-width`를 적용해 줌으로써 해결하였습니다.
