### PR TITLE
[FE] 상세 지출 수정에서 가상 키보드가 선택 영역을 가리는 문제 해결

### DIFF
--- a/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
+++ b/client/src/components/Design/components/NumberKeyboard/NumberKeyboardBottomSheet.tsx
@@ -1,6 +1,6 @@
 import {css} from '@emotion/react';
 import {createPortal} from 'react-dom';
-import {useEffect, useRef} from 'react';
+import {forwardRef, useEffect, useRef} from 'react';
 
 import {useTheme} from '@components/Design/theme/HDesignProvider';
 
@@ -14,9 +14,12 @@ interface Props extends NumberKeyboardProps {
   onClose: () => void;
 }
 
-const NumberKeyboardBottomSheet = ({isOpened, onClose, ...props}: Props) => {
+const NumberKeyboardBottomSheet = forwardRef<HTMLDivElement, Props>(({isOpened, onClose, ...props}, ref) => {
   const {theme} = useTheme();
-  const {bottomSheetRef} = useNumberKeyboardBottomSheet({isOpened});
+  const {bottomSheetRef} = useNumberKeyboardBottomSheet({
+    isOpened,
+    bottomSheetRef: ref as React.RefObject<HTMLDivElement>,
+  });
 
   return createPortal(
     <div
@@ -45,6 +48,6 @@ const NumberKeyboardBottomSheet = ({isOpened, onClose, ...props}: Props) => {
     </div>,
     document.body,
   );
-};
+});
 
 export default NumberKeyboardBottomSheet;

--- a/client/src/components/Design/components/NumberKeyboard/useNumberKeyboardBottomSheet.ts
+++ b/client/src/components/Design/components/NumberKeyboard/useNumberKeyboardBottomSheet.ts
@@ -1,12 +1,11 @@
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 
 interface Props {
   isOpened: boolean;
+  bottomSheetRef: React.RefObject<HTMLDivElement>;
 }
 
-const useNumberKeyboardBottomSheet = ({isOpened}: Props) => {
-  const bottomSheetRef = useRef<HTMLDivElement>(null);
-
+const useNumberKeyboardBottomSheet = ({isOpened, bottomSheetRef}: Props) => {
   useEffect(() => {
     const bottomSheet = bottomSheetRef.current;
     if (!bottomSheet) return;

--- a/client/src/hooks/useEditBillKeyboardAction.ts
+++ b/client/src/hooks/useEditBillKeyboardAction.ts
@@ -16,7 +16,7 @@ interface Props {
 const useEditBillKeyboardAction = ({newBill, billDetails, newBillDetails}: Props) => {
   const [keyboardTargetId, setKeyboardTargetId] = useState<null | number>(null);
   const billDetailsRef = useRef<HTMLDivElement>(null);
-  const {handleScrollToFocus} = useEditBillPageScroll();
+  const {keyboardRef, handleScrollToFocus} = useEditBillPageScroll();
 
   const handleClickBillDetailInput = (id: number) => {
     setKeyboardTargetId(id);
@@ -33,6 +33,7 @@ const useEditBillKeyboardAction = ({newBill, billDetails, newBillDetails}: Props
     newBill.price.toLocaleString('ko-kr');
 
   return {
+    keyboardRef,
     handleClickBillDetailInput,
     billDetailsRef,
     keyboardMaxPrice,

--- a/client/src/hooks/useEditBillPage.ts
+++ b/client/src/hooks/useEditBillPage.ts
@@ -23,6 +23,7 @@ const useEditBillPage = () => {
   });
 
   const {
+    keyboardRef,
     keyboardTargetId,
     setKeyboardTargetId,
     keyboardMaxPrice,
@@ -43,6 +44,7 @@ const useEditBillPage = () => {
     handleClickUpdate,
     isPendingUpdate,
     canSubmit,
+    keyboardRef,
     keyboardInitialValue,
     keyboardMaxPrice,
     keyboardTargetId,

--- a/client/src/hooks/useEditBillPageScroll.ts
+++ b/client/src/hooks/useEditBillPageScroll.ts
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
 
 interface Props {
   id: number;
@@ -6,19 +6,19 @@ interface Props {
 }
 
 const useEditBillPageScroll = () => {
+  const keyboardRef = useRef<HTMLDivElement>(null);
+
   const handleScrollToFocus = useCallback(({id, billDetailsRef}: Props) => {
     setTimeout(() => {
       if (billDetailsRef.current) {
         const selectedItem = billDetailsRef.current.querySelector(`[data-id="${id}"]`) as HTMLElement;
-        if (selectedItem) {
-          const screenHeight = window.screen.height;
-          const keyboardHeight = 416;
+        if (selectedItem && keyboardRef.current) {
           const itemTop = selectedItem.offsetTop;
           const itemHeight = selectedItem.offsetHeight;
           const itemBottom = itemTop + itemHeight;
-          const visibleY = screenHeight - keyboardHeight;
+          const keyboardTop = keyboardRef.current.offsetTop;
 
-          const targetScrollTop = itemBottom < visibleY ? 0 : itemTop - (visibleY - itemHeight) / 2;
+          const targetScrollTop = itemBottom < keyboardTop ? 0 : itemTop - (keyboardTop - itemHeight) / 2;
 
           window.scrollTo({
             top: targetScrollTop,
@@ -29,7 +29,7 @@ const useEditBillPageScroll = () => {
     }, 100);
   }, []);
 
-  return {handleScrollToFocus};
+  return {keyboardRef, handleScrollToFocus};
 };
 
 export default useEditBillPageScroll;

--- a/client/src/pages/EditBillPage/EditBillPage.tsx
+++ b/client/src/pages/EditBillPage/EditBillPage.tsx
@@ -22,6 +22,7 @@ const EditBillPage = () => {
     handleClickUpdate,
     isPendingUpdate,
     canSubmit,
+    keyboardRef,
     keyboardInitialValue,
     keyboardMaxPrice,
     keyboardTargetId,
@@ -78,6 +79,7 @@ const EditBillPage = () => {
         수정완료
       </FixedButton>
       <NumberKeyboardBottomSheet
+        ref={keyboardRef}
         type="amount"
         maxNumber={keyboardMaxPrice}
         initialValue={keyboardInitialValue}


### PR DESCRIPTION
## issue
- close #744 

## 구현 목적
- 기존에 모바일 환경에서, 상세 지출 내역 아이템 선택 시, 특정 높이에서 가상 키보드가 선택 영역을 가리는 문제가 존재했습니다.
- 사용자 경험 향상을 위해서 이 문제를 해결합니다.

https://github.com/user-attachments/assets/7763a90b-c5eb-4154-a4e8-c04b4699c2fb

## 구현 사항
- 기존에는 키보드의 height만을 고려해서 코드를 작성하였기 때문에, 브라우저 특성으로 인한 `window.innerHeight`를 별도로 고려하지 않아 브라우저 환경 별 위와 같은 문제가 발생했습니다.
- 이를 해결하기 위해 keyboardHeight만을 고려하는 것이 아닌, 브라우저 환경에 따라 변경되는 `offsetTop`을 이용하여 기준점을 설정하도록 변경하였습니다.