### PR TITLE
[FE] 폰트를 프리로드 하도록 수정

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,7 +34,12 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
-    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet" />
+    <link
+      rel="preload"
+      as="style"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+      onload="this.rel='stylesheet'"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## issue
- close #798 

## 구현 사항
폰트가 프리로드되지 않아 render-blocking 요소로 측정되고 있었습니다.
<img width="544" alt="image" src="https://github.com/user-attachments/assets/22c999c0-6af7-49ac-9366-0329bbe21ed6">

그래서 프리로드하도록 개선했습니다.
