### PR TITLE
[FE] 에러 페이지 구현

### DIFF
--- a/client/src/components/AppErrorBoundary/ErrorCatcher.test.tsx
+++ b/client/src/components/AppErrorBoundary/ErrorCatcher.test.tsx
@@ -86,7 +86,7 @@ describe('ErrorCatcher', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('알 수 없는 오류입니다.')).toBeInTheDocument();
+      expect(screen.getByText('알 수 없는 오류가 발생했습니다.')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/ErrorPage/ErrorPage.tsx
+++ b/client/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,13 +1,27 @@
-import Top from '@components/Design/components/Top/Top';
+import Image from '@components/Design/components/Image/Image';
 
-import {MainLayout} from '@HDesign/index';
+import {Flex, MainLayout, Text} from '@HDesign/index';
+
+import getImageUrl from '@utils/getImageUrl';
 
 const ErrorPage = () => {
   return (
     <MainLayout>
-      <Top>
-        <Top.Line text="알 수 없는 오류입니다." emphasize={['알 수 없는 오류입니다.']} />
-      </Top>
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        flexDirection="column"
+        gap="1rem"
+        height="80vh"
+        css={{alignContent: 'center'}}
+      >
+        <Image src={getImageUrl('cryingDog', 'webp')} width="160px" />
+        <Text size="subTitle">알 수 없는 오류가 발생했습니다.</Text>
+        <Text size="body" css={{textAlign: 'center'}}>
+          계속 발생한다면 잠시 후 다시 시도해주세요. <br />
+          인터넷 연결 상태가 좋지 않으면 발생할 수 있습니다.
+        </Text>
+      </Flex>
     </MainLayout>
   );
 };

--- a/client/src/pages/ErrorPage/ErrorPage.tsx
+++ b/client/src/pages/ErrorPage/ErrorPage.tsx
@@ -15,7 +15,7 @@ const ErrorPage = () => {
         height="80vh"
         css={{alignContent: 'center'}}
       >
-        <Image src={getImageUrl('cryingDog', 'webp')} width="160px" />
+        <Image src={getImageUrl('cryingDog', 'webp')} fallbackSrc={getImageUrl('cryingDog', 'png')} width="160px" />
         <Text size="subTitle">알 수 없는 오류가 발생했습니다.</Text>
         <Text size="body" css={{textAlign: 'center'}}>
           계속 발생한다면 잠시 후 다시 시도해주세요. <br />


### PR DESCRIPTION
## issue
- close #807 

## 구현 목적
현재 UnpredictableErrorBoundary에서 에러가 잡혔을 경우 '에러가 발생했습니다.'라는 텍스트만 뜹니다.

그래서 에러 페이지를 꾸며보았습니다.

## 구현 사항
에러 페이지를 구현합니다.

<img width="364" alt="image" src="https://github.com/user-attachments/assets/3b634af1-2add-44f3-a0be-c3f9ec2c4ac1">
