### PR TITLE
[BE] 이미지 병렬 업로드 기능 추가

### DIFF
--- a/server/src/main/java/server/haengdong/application/ImageService.java
+++ b/server/src/main/java/server/haengdong/application/ImageService.java
@@ -39,7 +39,7 @@ public class ImageService {
                 .map(image -> CompletableFuture.supplyAsync(() -> uploadImage(image), executorService))
                 .toList();
 
-        CompletableFuture<List<String>> result = CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
+        CompletableFuture<List<String>> result = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                 .thenApply(v -> futures.stream()
                         .map(this::getFuture)
                         .toList());

--- a/server/src/main/java/server/haengdong/config/S3Config.java
+++ b/server/src/main/java/server/haengdong/config/S3Config.java
@@ -1,5 +1,7 @@
 package server.haengdong.config;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
@@ -8,10 +10,17 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
+    private static final int THREAD_POOL_SIZE = 10;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.AP_NORTHEAST_2)
                 .build();
+    }
+
+    @Bean
+    public ExecutorService executorService() {
+        return Executors.newFixedThreadPool(THREAD_POOL_SIZE);
     }
 }

--- a/server/src/main/java/server/haengdong/exception/HaengdongException.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongException.java
@@ -16,4 +16,9 @@ public class HaengdongException extends RuntimeException {
         super(String.format(errorCode.getMessage(), args));
         this.errorCode = errorCode;
     }
+
+    public HaengdongException(HaengdongErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }


### PR DESCRIPTION
## issue
- close #813

## 구현 사항
여러 이미지를 순차적으로 업로드하던 기능을 병렬로 업로드할 수 있게 변경합니다.

[10MB 이미지 10개]
순차 업로드 : 5.5s
병렬 업로드 : 2.1s

로 응답시간을 개선했습니다.

추가로 S3Client 호출 시에 발생하는 예외를 추적할 수 있도록 HaengdongException 생성자에 Throwable 을 추가했습니다.