### PR TITLE
[BE] 이벤트당 이미지 업로드 수량 제한

### DIFF
--- a/server/src/main/java/server/haengdong/application/EventImageFacadeService.java
+++ b/server/src/main/java/server/haengdong/application/EventImageFacadeService.java
@@ -1,0 +1,25 @@
+package server.haengdong.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class EventImageFacadeService {
+
+    private final EventService eventService;
+    private final ImageService imageService;
+
+    public void uploadImages(String token, List<MultipartFile> images) {
+        eventService.validateImageCount(token, images.size());
+        List<String> imageNames = imageService.uploadImages(images);
+        eventService.saveImages(token, imageNames);
+    }
+
+    public void deleteImage(String token, Long imageId) {
+        String imageName = eventService.deleteImage(token, imageId);
+        imageService.deleteImage(imageName);
+    }
+}

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -31,6 +31,8 @@ import server.haengdong.exception.HaengdongException;
 @Service
 public class EventService {
 
+    private static final int MAX_IMAGE_COUNT = 10;
+
     private final EventRepository eventRepository;
     private final EventTokenProvider eventTokenProvider;
     private final BillRepository billRepository;
@@ -136,5 +138,15 @@ public class EventService {
         }
         eventImageRepository.delete(eventImage);
         return eventImage.getName();
+    }
+
+    public void validateImageCount(String token, int uploadImageCount) {
+        Event event = getEvent(token);
+        Long imageCount = eventImageRepository.countByEvent(event);
+        Long totalImageCount = imageCount + uploadImageCount;
+
+        if (totalImageCount > MAX_IMAGE_COUNT) {
+            throw new HaengdongException(HaengdongErrorCode.IMAGE_COUNT_INVALID, totalImageCount);
+        }
     }
 }

--- a/server/src/main/java/server/haengdong/application/EventService.java
+++ b/server/src/main/java/server/haengdong/application/EventService.java
@@ -5,6 +5,7 @@ import java.util.Map.Entry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import server.haengdong.application.request.EventAppRequest;
 import server.haengdong.application.request.EventLoginAppRequest;

--- a/server/src/main/java/server/haengdong/domain/event/EventImageRepository.java
+++ b/server/src/main/java/server/haengdong/domain/event/EventImageRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface EventImageRepository extends JpaRepository<EventImage, Long> {
 
     List<EventImage> findAllByEvent(Event event);
+
+    Long countByEvent(Event event);
 }

--- a/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
+++ b/server/src/main/java/server/haengdong/exception/HaengdongErrorCode.java
@@ -31,6 +31,7 @@ public enum HaengdongErrorCode {
     DIFFERENT_STEP_MEMBERS("참여자 목록이 일치하지 않습니다."),
 
     IMAGE_NOT_FOUND("존재하지 않는 이미지 입니다."),
+    IMAGE_COUNT_INVALID("이미지 수량은 %d개 까지 업로드할 수 있습니다."),
 
     /* Authentication */
 

--- a/server/src/main/java/server/haengdong/presentation/admin/AdminEventController.java
+++ b/server/src/main/java/server/haengdong/presentation/admin/AdminEventController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import server.haengdong.application.EventImageFacadeService;
 import server.haengdong.application.EventService;
 import server.haengdong.application.ImageService;
 import server.haengdong.application.response.ImageNameAppResponse;
@@ -24,7 +25,7 @@ import server.haengdong.presentation.request.EventUpdateRequest;
 public class AdminEventController {
 
     private final EventService eventService;
-    private final ImageService imageUploadService;
+    private final EventImageFacadeService eventImageFacadeService;
 
     @PostMapping("/api/admin/events/{eventId}/auth")
     public ResponseEntity<Void> authenticate() {
@@ -46,8 +47,7 @@ public class AdminEventController {
             @PathVariable("eventId") String token,
             @RequestPart("images") List<MultipartFile> images
     ) {
-        List<String> imageNames = imageUploadService.uploadImages(images);
-        eventService.saveImages(token, imageNames);
+        eventImageFacadeService.uploadImages(token, images);
 
         return ResponseEntity.ok().build();
     }
@@ -57,8 +57,7 @@ public class AdminEventController {
             @PathVariable("eventId") String token,
             @PathVariable("imageId") Long imageId
     ) {
-        String imageName = eventService.deleteImage(token, imageId);
-        imageUploadService.deleteImage(imageName);
+        eventImageFacadeService.deleteImage(token, imageId);
 
         return ResponseEntity.ok().build();
     }

--- a/server/src/test/java/server/haengdong/application/EventServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/EventServiceTest.java
@@ -2,6 +2,7 @@ package server.haengdong.application;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -28,6 +29,7 @@ import server.haengdong.domain.member.MemberRepository;
 import server.haengdong.domain.event.Event;
 import server.haengdong.domain.event.EventRepository;
 import server.haengdong.domain.event.EventTokenProvider;
+import server.haengdong.exception.HaengdongException;
 import server.haengdong.support.fixture.Fixture;
 
 class EventServiceTest extends ServiceTestSupport {
@@ -227,5 +229,18 @@ class EventServiceTest extends ServiceTestSupport {
 
         assertThat(eventImageRepository.findById(eventImage.getId()))
                 .isEmpty();
+    }
+
+    @DisplayName("행사 1개당 이미지는 10개까지 업로드 가능하다.")
+    @Test
+    void validateImageCount() {
+        Event event = Fixture.EVENT1;
+        eventRepository.save(event);
+        List<String> imageNames = List.of("image1.jpg", "image2.jpg");
+        String token = event.getToken();
+        eventService.saveImages(token, imageNames);
+
+        assertThatThrownBy(() -> eventService.validateImageCount(token, 9))
+                .isInstanceOf(HaengdongException.class);
     }
 }

--- a/server/src/test/java/server/haengdong/application/ImageServiceTest.java
+++ b/server/src/test/java/server/haengdong/application/ImageServiceTest.java
@@ -1,0 +1,48 @@
+package server.haengdong.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.given;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import server.haengdong.exception.HaengdongException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+
+class ImageServiceTest extends ServiceTestSupport {
+
+    @Autowired
+    private ImageService imageService;
+
+    @MockBean
+    private S3Client s3Client;
+
+    @DisplayName("이미지 업로드 도중 실패하면 예외가 커스텀 예외가 발생한다.")
+    @Test
+    void uploadImages() {
+        MultipartFile multipartFile1 = new MockMultipartFile("file1", "test1.txt", "text/plain", "hello1".getBytes());
+        MultipartFile multipartFile2 = new MockMultipartFile("file2", "test2.txt", "text/plain", "hello2".getBytes());
+        MultipartFile multipartFile3 = new MockMultipartFile("file3", "test3.txt", "text/plain", "hello3".getBytes());
+        MultipartFile multipartFile4 = new MockMultipartFile("file4", "test4.txt", "text/plain", "hello4".getBytes());
+        MultipartFile multipartFile5 = new MockMultipartFile("file5", "test5.txt", "text/plain", "hello5".getBytes());
+
+        doThrow(new RuntimeException("S3 upload failed"))
+                .when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+        assertThatThrownBy(() -> imageService.uploadImages(List.of(multipartFile1, multipartFile2, multipartFile3, multipartFile4, multipartFile5)))
+                .isInstanceOf(HaengdongException.class);
+    }
+}

--- a/server/src/test/java/server/haengdong/docs/AdminEventControllerDocsTest.java
+++ b/server/src/test/java/server/haengdong/docs/AdminEventControllerDocsTest.java
@@ -26,19 +26,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
+import server.haengdong.application.EventImageFacadeService;
 import server.haengdong.application.EventService;
-import server.haengdong.application.ImageService;
 import server.haengdong.presentation.admin.AdminEventController;
 import server.haengdong.presentation.request.EventUpdateRequest;
 
 class AdminEventControllerDocsTest extends RestDocsSupport {
 
     private final EventService eventService = mock(EventService.class);
-    private final ImageService imageUploadService = mock(ImageService.class);
+    private final EventImageFacadeService eventImageFacadeService = mock(EventImageFacadeService.class);
 
     @Override
     protected Object initController() {
-        return new AdminEventController(eventService, imageUploadService);
+        return new AdminEventController(eventService, eventImageFacadeService);
     }
 
     @DisplayName("행사 어드민 권한을 확인한다.")

--- a/server/src/test/java/server/haengdong/presentation/ControllerTestSupport.java
+++ b/server/src/test/java/server/haengdong/presentation/ControllerTestSupport.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import server.haengdong.application.AuthService;
 import server.haengdong.application.BillService;
+import server.haengdong.application.EventImageFacadeService;
 import server.haengdong.application.EventService;
 import server.haengdong.application.ImageService;
 import server.haengdong.application.MemberService;
@@ -49,5 +50,5 @@ public abstract class ControllerTestSupport {
     protected BillService billService;
 
     @MockBean
-    protected ImageService imageUploadService;
+    protected EventImageFacadeService eventImageFacadeService;
 }


### PR DESCRIPTION
## issue
- close #814

## 구현 사항

이벤트 1개에 업로드할 수 있는 이미지 수량을 10개로 제한합니다.

flow : validateImageCount -> uploadImages-> saveImages

비지니스 플로우가 Controller에 노출되어 파사드 패턴을 도입했습니다.

## 추가 논의 사항
현재 flow가 validateImageCount -> uploadImages-> saveImages 인데
eventService에서 validateImageCount와 saveImages로 별도의 메소드로 분리되어 
외부에서 인지했을 때 saveImages전에 validate가 필요한지 인지하기 어려울 것 같습니다.

그래서 다른 방법으로 
1. validateAndsaveImages -> uploadImages를 실시하고 업로드 실패시 데이터베이스만 deleteImages를 하는 방법
2. uploadImages -> validateAndsaveImages를 실시하고 업로드 실패시 deleteImages API를 날리는 방법
이 있는데 어떻게 생각하시나요?

