### PR TITLE
[FE] 전체 참여자 관리 : 참여자 이름 정렬 

### DIFF
--- a/client/src/hooks/queries/report/useRequestGetReports.ts
+++ b/client/src/hooks/queries/report/useRequestGetReports.ts
@@ -15,8 +15,10 @@ const useRequestGetReports = ({...props}: WithErrorHandlingStrategy | null = {})
     queryFn: () => requestGetReports({eventId, ...props}),
   });
 
+  const sortedMemberNameReports = data?.reports.sort((a, b) => a.memberName.localeCompare(b.memberName));
+
   return {
-    reports: data?.reports ?? [],
+    reports: sortedMemberNameReports ?? [],
     ...rest,
   };
 };

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -28,9 +28,7 @@ const useEventMember = (): ReturnUseEventMember => {
   const [deleteMembers, setDeleteMembers] = useState<number[]>([]);
 
   useEffect(() => {
-    const sortedMemberNameReports = initialReports.sort((a, b) => a.memberName.localeCompare(b.memberName));
-
-    setReports(sortedMemberNameReports);
+    setReports(initialReports);
   }, [initialReports]);
 
   const canSubmit = useMemo(() => {

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -28,7 +28,9 @@ const useEventMember = (): ReturnUseEventMember => {
   const [deleteMembers, setDeleteMembers] = useState<number[]>([]);
 
   useEffect(() => {
-    setReports(initialReports);
+    const sortedMemberNameReports = initialReports.sort((a, b) => a.memberName.localeCompare(b.memberName));
+
+    setReports(sortedMemberNameReports);
   }, [initialReports]);
 
   const canSubmit = useMemo(() => {


### PR DESCRIPTION
## issue
- close #823

## 구현 목적

기존에는 전체 참여자 관리 페이지에서 참여자의 정렬이 이뤄지지 않고 있습니다. 이런 방식은 참여자가 많아질 경우, 관리자가 참여자를 찾는 것에 불편함을 줍니다. 참여자의 상태를 관리하기 위해 관리자가 참여자의 이름을 찾는 과정에서 참여자 이름에 규칙이 존재하지 않기 때문에 어느 위치에 존재하는지 찾기가 어려워지기 때문입니다.

따라서, 참여자의 이름을 사용자 브라우저의 언어 설정에 맞게 (ㄱ-ㅎ,a-z / 한글 언어 설정 기준) 순으로 정렬하는 기능을 추가했습니다.

## 구현 방법

sort 메서드를 활용하여 initialReports를 이름을 기준으로 정렬했습니다.

useEventMember hook은 기존에 서버로부터 reports 데이터 값을 받아오면 useEffect를 사용하여 initalReports의 값이 변화가 생기면 reports 클라이언트 값을 바꾸도록 했습니다. 이 과정에서 reports에 값을 set을 통해 변경하기 전, initalReports를 이름을 기준으로 정렬하는 과정을 추가했습니다.

```tsx
useEffect(() => {
  const sortedMemberNameReports = initialReports.sort((a, b) => a.memberName.localeCompare(b.memberName));

  setReports(sortedMemberNameReports);
}, [initialReports]);
```

sort 메소드를 활용하여 정렬했습니다. 이때, 두개의 요소 a와 b를 비교하는 콜백함수를 받습니다.

- `(a, b) => a.memberName.localeCompare(b.memberName, 'en')`
    
    `localeCompare` 메서드는 두 문자열을 비교하여 정렬 순서를 결정합니다. 문자열을 사전적으로 비교하며, 언어 및 지역 설정을 기준으로 비교합니다.
    
    `a.memberName`과 `b.memberName`을 비교하며, 이때, 지역 설정은 브라우저 설정에 맞게 정렬되도록 했습니다. 따로 코드에 ‘ko’를 추가하여 지역설정을 해줄 경우 무조건적으로 참여자 이름 정렬이 한글-영어 순으로 적용됩니다. ‘en’으로 설정할 경우 영어-한글 순으로 정렬됩니다.
    그러나, 지역설정을 아무것도(위 코드처럼) 하지 않았다면, 유저가 사용하는 브라우저의 언어 설정에 맞게 이름이 정렬됩니다.
    

## 결과

현재 api가 변동되어 실제로 반영된 화면은 없습니다.. 추후 추가하도록 하겠습니다!

## 논의하고 싶은 점
이름 정렬을 사용자 브라우저 설정에 맞춰주는 것이 아니라 강제적으로 'ko'로 할지 고민되었습니다! 여러분은 어떻게 생각하시는지 궁금합니다~
