### PR TITLE
[FE] 로그인 구축으로 인한 인증 전략 변경

### DIFF
--- a/client/src/apis/request/auth.ts
+++ b/client/src/apis/request/auth.ts
@@ -37,6 +37,7 @@ export const requestGetKakaoLogin = async (code: string) => {
   await requestGetWithoutResponse({
     baseUrl: BASE_URL.HD,
     endpoint: `/api/login/kakao?code=${code}&redirect_uri=${getKakaoRedirectUrl()}`,
+    errorHandlingStrategy: 'errorBoundary',
   });
 
   return null;

--- a/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
+++ b/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
@@ -36,7 +36,11 @@ const ErrorCatcher = ({children}: React.PropsWithChildren) => {
     });
 
     // 로그인 처리
-    if (error.errorCode === 'TOKEN_NOT_FOUND') {
+    if (
+      error.errorCode === 'TOKEN_NOT_FOUND' &&
+      !window.location.pathname.includes('/guest/login') &&
+      !window.location.pathname.includes('/member/login')
+    ) {
       const createdByGuest = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.createdByGuest);
       SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
 

--- a/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
+++ b/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
@@ -38,7 +38,7 @@ const ErrorCatcher = ({children}: React.PropsWithChildren) => {
     // 로그인 처리
     if (error.errorCode === 'TOKEN_NOT_FOUND') {
       const createdByGuest = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.createdByGuest);
-      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.href);
+      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
 
       const currentPath = window.location.pathname;
 

--- a/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
+++ b/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import {useNavigate} from 'react-router-dom';
 
 import toast from '@hooks/useToast/toast';
 
@@ -7,10 +6,8 @@ import {useAppErrorStore} from '@store/appErrorStore';
 
 import {captureError} from '@utils/captureError';
 import isRequestError from '@utils/isRequestError';
-import SessionStorage from '@utils/SessionStorage';
 
 import {SERVER_ERROR_MESSAGES} from '@constants/errorMessage';
-import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 const isPredictableError = (error: Error) => {
   if (isRequestError(error)) if (error.errorCode === 'INTERNAL_SERVER_ERROR') return false;
@@ -20,7 +17,6 @@ const isPredictableError = (error: Error) => {
 
 const ErrorCatcher = ({children}: React.PropsWithChildren) => {
   const {appError: error} = useAppErrorStore();
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (!error) return;
@@ -34,25 +30,7 @@ const ErrorCatcher = ({children}: React.PropsWithChildren) => {
       position: 'bottom',
       bottom: '8rem',
     });
-
-    // 로그인 처리
-    if (
-      error.errorCode === 'TOKEN_NOT_FOUND' &&
-      !window.location.pathname.includes('/guest/login') &&
-      !window.location.pathname.includes('/member/login')
-    ) {
-      const createdByGuest = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.createdByGuest);
-      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
-
-      const currentPath = window.location.pathname;
-
-      if (createdByGuest) {
-        navigate(`${currentPath}/guest/login`);
-      } else {
-        navigate(`${currentPath}/member/login`);
-      }
-    }
-  }, [error, navigate]);
+  }, [error]);
 
   return children;
 };

--- a/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
+++ b/client/src/components/AppErrorBoundary/ErrorCatcher.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
 
 import toast from '@hooks/useToast/toast';
 
@@ -6,8 +7,10 @@ import {useAppErrorStore} from '@store/appErrorStore';
 
 import {captureError} from '@utils/captureError';
 import isRequestError from '@utils/isRequestError';
+import SessionStorage from '@utils/SessionStorage';
 
 import {SERVER_ERROR_MESSAGES} from '@constants/errorMessage';
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 const isPredictableError = (error: Error) => {
   if (isRequestError(error)) if (error.errorCode === 'INTERNAL_SERVER_ERROR') return false;
@@ -17,6 +20,7 @@ const isPredictableError = (error: Error) => {
 
 const ErrorCatcher = ({children}: React.PropsWithChildren) => {
   const {appError: error} = useAppErrorStore();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!error) return;
@@ -30,7 +34,21 @@ const ErrorCatcher = ({children}: React.PropsWithChildren) => {
       position: 'bottom',
       bottom: '8rem',
     });
-  }, [error]);
+
+    // 로그인 처리
+    if (error.errorCode === 'TOKEN_NOT_FOUND') {
+      const createdByGuest = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.createdByGuest);
+      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.href);
+
+      const currentPath = window.location.pathname;
+
+      if (createdByGuest) {
+        navigate(`${currentPath}/guest/login`);
+      } else {
+        navigate(`${currentPath}/member/login`);
+      }
+    }
+  }, [error, navigate]);
 
   return children;
 };

--- a/client/src/components/Design/components/TopNav/NavItem.tsx
+++ b/client/src/components/Design/components/TopNav/NavItem.tsx
@@ -3,7 +3,7 @@ import type {NavItemProps} from './NavItem.type';
 
 import {useLocation, useNavigate} from 'react-router-dom';
 
-import getDeletedLastPath from '@utils/getDeletedLastPath';
+import getEventBaseUrl from '@utils/getEventBaseUrl';
 
 import TextButton from '../TextButton/TextButton';
 
@@ -28,7 +28,7 @@ const NavItem = ({displayName, routePath, onHandleRouteInFunnel, noEmphasis = fa
         navigate(-1);
         break;
       default:
-        navigate(`${getDeletedLastPath(location.pathname)}${routePath}`);
+        navigate(`/${getEventBaseUrl(location.pathname)}${routePath}`);
         break;
     }
   };

--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -17,4 +17,7 @@ export const ROUTER_URLS = {
   qrCode: `${EVENT_WITH_EVENT_ID}/qrcode`,
   event: EVENT,
   login: '/login',
+  guestEventLogin: `${EVENT_WITH_EVENT_ID}/admin/guest/login`,
+  memberEventLogin: `${EVENT_WITH_EVENT_ID}/admin/member/login`,
+  kakaoLoginRedirectUri: process.env.KAKAO_REDIRECT_URI,
 };

--- a/client/src/constants/sessionStorageKeys.ts
+++ b/client/src/constants/sessionStorageKeys.ts
@@ -1,6 +1,8 @@
 const SESSION_STORAGE_KEYS = {
   closeAccountBannerByEventToken: (eventToken: string) => `closeAccountBanner-${eventToken}`,
   closeDepositStateBannerByEventToken: (eventToken: string) => `closeDepositStateBanner-${eventToken}`,
+  createdByGuest: 'createdByGuest',
+  previousUrlForLogin: 'previousUrlForLogin',
 } as const;
 
 export default SESSION_STORAGE_KEYS;

--- a/client/src/hooks/createEvent/useCreateGuestEventData.tsx
+++ b/client/src/hooks/createEvent/useCreateGuestEventData.tsx
@@ -1,12 +1,12 @@
 import {useState} from 'react';
 
 import useSetEventNameStep from './useSetEventNameStep';
-import {useSetNickNameStep} from './useSetNicknameStep';
+import {useSetNicknameStep} from './useSetNicknameStep';
 
 // 행사 생성 페이지에서 여러 스텝에 걸쳐 사용되는 상태를 선언해 내려주는 용도의 훅입니다.
 const useCreateGuestEventData = () => {
   const eventNameProps = useSetEventNameStep();
-  const nickNameProps = useSetNickNameStep();
+  const nickNameProps = useSetNicknameStep();
   const [eventToken, setEventToken] = useState('');
 
   return {

--- a/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
+++ b/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
@@ -20,20 +20,23 @@ const useRequestPostAuthentication = () => {
 
   const {createdByGuest} = useRequestGetEvent();
 
+  const isSecondEncounteredOnError = () => {
+    return window.location.pathname.includes('/guest/login') || window.location.pathname.includes('/member/login');
+  };
+
   const {mutate, ...rest} = useMutation({
     mutationFn: () => requestPostAuthentication({eventId}),
     onSuccess: () => updateAuth(true),
     onError: () => {
-      if (!window.location.pathname.includes('/guest/login') && !window.location.pathname.includes('/member/login')) {
-        SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
+      if (isSecondEncounteredOnError()) return;
+      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
 
-        const eventToken = getEventIdByUrl();
+      const eventToken = getEventIdByUrl();
 
-        if (createdByGuest) {
-          navigate(ROUTER_URLS.guestEventLogin.replace(':eventId', eventToken));
-        } else {
-          navigate(ROUTER_URLS.memberEventLogin.replace(':eventId', eventToken));
-        }
+      if (createdByGuest) {
+        navigate(ROUTER_URLS.guestEventLogin.replace(':eventId', eventToken));
+      } else {
+        navigate(ROUTER_URLS.memberEventLogin.replace(':eventId', eventToken));
       }
     },
   });

--- a/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
+++ b/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
@@ -9,6 +9,7 @@ import getEventIdByUrl from '@utils/getEventIdByUrl';
 import SessionStorage from '@utils/SessionStorage';
 
 import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
+import {ROUTER_URLS} from '@constants/routerUrls';
 
 import useRequestGetEvent from '../event/useRequestGetEvent';
 
@@ -26,12 +27,12 @@ const useRequestPostAuthentication = () => {
       if (!window.location.pathname.includes('/guest/login') && !window.location.pathname.includes('/member/login')) {
         SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);
 
-        const currentPath = window.location.pathname;
+        const eventToken = getEventIdByUrl();
 
         if (createdByGuest) {
-          navigate(`${currentPath}/guest/login`);
+          navigate(ROUTER_URLS.guestEventLogin.replace(':eventId', eventToken));
         } else {
-          navigate(`${currentPath}/member/login`);
+          navigate(ROUTER_URLS.memberEventLogin.replace(':eventId', eventToken));
         }
       }
     },

--- a/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
+++ b/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
@@ -5,14 +5,24 @@ import {requestPostAuthentication} from '@apis/request/auth';
 import {useAuthStore} from '@store/authStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
+import SessionStorage from '@utils/SessionStorage';
+
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
+
+import useRequestGetEvent from '../event/useRequestGetEvent';
 
 const useRequestPostAuthentication = () => {
   const eventId = getEventIdByUrl();
   const {updateAuth} = useAuthStore();
 
+  const {createdByGuest} = useRequestGetEvent();
+
   const {mutate, ...rest} = useMutation({
     mutationFn: () => requestPostAuthentication({eventId}),
     onSuccess: () => updateAuth(true),
+    onMutate: () => {
+      SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.createdByGuest, createdByGuest);
+    },
   });
 
   return {

--- a/client/src/hooks/queries/auth/useRequestPostLogin.ts
+++ b/client/src/hooks/queries/auth/useRequestPostLogin.ts
@@ -1,18 +1,30 @@
 import {useMutation} from '@tanstack/react-query';
+import {useNavigate} from 'react-router-dom';
 
 import {RequestPostToken, requestPostToken} from '@apis/request/auth';
 
 import {useAuthStore} from '@store/authStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
+import SessionStorage from '@utils/SessionStorage';
+
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 const useRequestPostLogin = () => {
   const eventId = getEventIdByUrl();
   const {updateAuth} = useAuthStore();
+  const navigate = useNavigate();
 
   const {mutate, ...rest} = useMutation({
     mutationFn: ({password}: RequestPostToken) => requestPostToken({eventId, password}),
-    onSuccess: () => updateAuth(true),
+    onSuccess: () => {
+      const previousUrlForLogin = SessionStorage.get<string>(SESSION_STORAGE_KEYS.previousUrlForLogin);
+      if (previousUrlForLogin) {
+        SessionStorage.remove(SESSION_STORAGE_KEYS.previousUrlForLogin);
+        navigate(previousUrlForLogin, {replace: true});
+      }
+      updateAuth(true);
+    },
   });
 
   return {postLogin: mutate, ...rest};

--- a/client/src/hooks/queries/event/useRequestGetEvent.ts
+++ b/client/src/hooks/queries/event/useRequestGetEvent.ts
@@ -19,6 +19,7 @@ const useRequestGetEvent = ({...props}: WithErrorHandlingStrategy | null = {}) =
     eventName: data?.eventName ?? '',
     bankName: data?.bankName ?? '',
     accountNumber: data?.accountNumber ?? '',
+    createdByGuest: data?.createdByGuest ?? true,
     ...rest,
   };
 };

--- a/client/src/hooks/queries/event/useRequestGetEvent.ts
+++ b/client/src/hooks/queries/event/useRequestGetEvent.ts
@@ -1,4 +1,4 @@
-import {useQuery} from '@tanstack/react-query';
+import {useSuspenseQuery} from '@tanstack/react-query';
 
 import {requestGetEvent} from '@apis/request/event';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
@@ -10,16 +10,16 @@ import QUERY_KEYS from '@constants/queryKeys';
 const useRequestGetEvent = ({...props}: WithErrorHandlingStrategy | null = {}) => {
   const eventId = getEventIdByUrl();
 
-  const {data, ...rest} = useQuery({
+  const {data, ...rest} = useSuspenseQuery({
     queryKey: [QUERY_KEYS.event],
     queryFn: () => requestGetEvent({eventId, ...props}),
   });
 
   return {
-    eventName: data?.eventName ?? '',
-    bankName: data?.bankName ?? '',
-    accountNumber: data?.accountNumber ?? '',
-    createdByGuest: data?.createdByGuest ?? true,
+    eventName: data?.eventName,
+    bankName: data?.bankName,
+    accountNumber: data?.accountNumber,
+    createdByGuest: data?.createdByGuest,
     ...rest,
   };
 };

--- a/client/src/hooks/queries/event/useRequestGetEvent.ts
+++ b/client/src/hooks/queries/event/useRequestGetEvent.ts
@@ -16,10 +16,10 @@ const useRequestGetEvent = ({...props}: WithErrorHandlingStrategy | null = {}) =
   });
 
   return {
-    eventName: data?.eventName,
-    bankName: data?.bankName,
-    accountNumber: data?.accountNumber,
-    createdByGuest: data?.createdByGuest,
+    eventName: data.eventName,
+    bankName: data.bankName,
+    accountNumber: data.accountNumber,
+    createdByGuest: data.createdByGuest,
     ...rest,
   };
 };

--- a/client/src/hooks/useAmplitude.ts
+++ b/client/src/hooks/useAmplitude.ts
@@ -1,4 +1,4 @@
-import {EventName} from 'types/createEvent';
+import {EventName} from 'types/serviceType';
 
 import {useAmplitudeStore} from '@store/amplitudeStore';
 

--- a/client/src/hooks/useEventPageLayout.ts
+++ b/client/src/hooks/useEventPageLayout.ts
@@ -9,7 +9,7 @@ import useRequestGetSteps from './queries/step/useRequestGetSteps';
 
 const useEventPageLayout = () => {
   const eventId = getEventIdByUrl();
-  const {eventName, bankName, accountNumber} = useRequestGetEvent();
+  const {eventName, bankName, accountNumber, createdByGuest} = useRequestGetEvent();
   const {isAdmin} = useAuthStore();
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
   const {members} = useRequestGetAllMembers();
@@ -20,6 +20,7 @@ const useEventPageLayout = () => {
     eventName,
     bankName,
     accountNumber,
+    createdByGuest,
   };
 
   const eventSummary = {

--- a/client/src/hooks/useLoginPage.ts
+++ b/client/src/hooks/useLoginPage.ts
@@ -30,7 +30,7 @@ const useLoginPage = () => {
 
   const goNonLoginCreateEvent = () => {
     trackStartCreateEvent({login: false});
-    navigate(ROUTER_URLS.createEvent);
+    navigate(ROUTER_URLS.createGuestEvent);
   };
 
   useEffect(() => {
@@ -45,7 +45,7 @@ const useLoginPage = () => {
 
         // 추후에 업데이트 하는 로직 필요
         trackStartCreateEvent({login: true});
-        navigate(ROUTER_URLS.createEvent);
+        navigate(ROUTER_URLS.createMemberEvent);
       }
     };
 

--- a/client/src/hooks/useLoginPage.ts
+++ b/client/src/hooks/useLoginPage.ts
@@ -19,7 +19,7 @@ const useLoginPage = () => {
     const queryResult = await requestGetClientId();
     const clientId = queryResult.data?.clientId;
 
-    if (typeof previousUrl !== 'undefined') {
+    if (typeof previousUrl === 'string') {
       SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, previousUrl);
     }
 

--- a/client/src/hooks/useLoginPage.ts
+++ b/client/src/hooks/useLoginPage.ts
@@ -1,28 +1,27 @@
-import {useEffect} from 'react';
-import {useLocation, useNavigate} from 'react-router-dom';
-
-import {useAuthStore} from '@store/authStore';
+import {useNavigate} from 'react-router-dom';
 
 import getKakaoRedirectUrl from '@utils/getKakaoRedirectUrl';
+import SessionStorage from '@utils/SessionStorage';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 
 import useRequestGetKakaoClientId from './queries/auth/useRequestGetKakaoClientId';
 import useAmplitude from './useAmplitude';
-import useRequestGetKakaoLogin from './queries/auth/useRequestGetKakaoLogin';
 
 const useLoginPage = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const {trackStartCreateEvent} = useAmplitude();
-  const {updateAuth} = useAuthStore();
-  const {requestGetKakaoLogin} = useRequestGetKakaoLogin();
 
   const {requestGetClientId} = useRequestGetKakaoClientId();
 
-  const goKakaoLogin = async () => {
+  const goKakaoLogin = async (previousUrl?: string) => {
     const queryResult = await requestGetClientId();
     const clientId = queryResult.data?.clientId;
+
+    if (typeof previousUrl !== 'undefined') {
+      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, previousUrl);
+    }
 
     const link = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${getKakaoRedirectUrl()}&response_type=code`;
     window.location.href = link;
@@ -32,25 +31,6 @@ const useLoginPage = () => {
     trackStartCreateEvent({login: false});
     navigate(ROUTER_URLS.createGuestEvent);
   };
-
-  useEffect(() => {
-    if (location.search === '') return;
-
-    const code = new URLSearchParams(location.search).get('code');
-
-    const kakaoLogin = async () => {
-      if (code) {
-        await requestGetKakaoLogin();
-        updateAuth(true);
-
-        // 추후에 업데이트 하는 로직 필요
-        trackStartCreateEvent({login: true});
-        navigate(ROUTER_URLS.createMemberEvent);
-      }
-    };
-
-    kakaoLogin();
-  }, [location.search]);
 
   return {goKakaoLogin, goNonLoginCreateEvent};
 };

--- a/client/src/hooks/useReportsPage.ts
+++ b/client/src/hooks/useReportsPage.ts
@@ -3,7 +3,7 @@ import {useLocation, useNavigate, useOutletContext} from 'react-router-dom';
 
 import {EventPageContextProps} from '@pages/EventPage/EventPageLayout';
 
-import getDeletedLastPath from '@utils/getDeletedLastPath';
+import getEventBaseUrl from '@utils/getEventBaseUrl';
 
 import {useSearchReports} from './useSearchReports';
 import toast from './useToast/toast';
@@ -37,7 +37,7 @@ const useReportsPage = () => {
       eventToken,
     };
 
-    navigate(`${getDeletedLastPath(location.pathname)}/${memberId}/send`, {state: sendInfo});
+    navigate(`/${getEventBaseUrl(location.pathname)}/${memberId}/send`, {state: sendInfo});
   };
 
   const onCopy = async (amount: number) => {

--- a/client/src/mocks/handlers/authHandlers.ts
+++ b/client/src/mocks/handlers/authHandlers.ts
@@ -9,7 +9,14 @@ import {MOCK_API_PREFIX} from '@mocks/mockEndpointPrefix';
 export const authHandler = [
   // POST /api/eventId/auth (requestPostAuthentication)
   http.post(`${MOCK_API_PREFIX}${ADMIN_API_PREFIX}/:eventId/auth`, () => {
-    return new HttpResponse(null, {status: 200});
+    // return new HttpResponse(null, {status: 200});
+    return HttpResponse.json(
+      {
+        errorCode: 'TOKEN_NOT_FOUND',
+        message: '토큰이 존재하지 않습니다.',
+      },
+      {status: 401},
+    );
   }),
 
   http.get(`${MOCK_API_PREFIX}/api/login/kakao`, () => {

--- a/client/src/mocks/sharedState.ts
+++ b/client/src/mocks/sharedState.ts
@@ -2,6 +2,7 @@ export let eventData = {
   eventName: '행동대장 야유회',
   bankName: '',
   accountNumber: '000000-01-121212',
+  createdByGuest: true,
 };
 
 export let memberData = {

--- a/client/src/pages/AccountPage/Account.tsx
+++ b/client/src/pages/AccountPage/Account.tsx
@@ -7,7 +7,7 @@ import useAccount from '@hooks/useAccount';
 
 import {FixedButton, Flex, FunnelLayout, Input, MainLayout, Top, TopNav} from '@components/Design';
 
-import getDeletedLastPath from '@utils/getDeletedLastPath';
+import getEventBaseUrl from '@utils/getEventBaseUrl';
 
 const Account = () => {
   const navigate = useNavigate();
@@ -28,7 +28,7 @@ const Account = () => {
 
   const enrollAccountAndNavigateAdmin = async () => {
     await enrollAccount();
-    navigate(getDeletedLastPath(location.pathname));
+    navigate(`/${getEventBaseUrl(location.pathname)}/admin`);
   };
 
   return (

--- a/client/src/pages/CreateEventPage/CreateGuestEventPage/CreateGuestEventFunnel.tsx
+++ b/client/src/pages/CreateEventPage/CreateGuestEventPage/CreateGuestEventFunnel.tsx
@@ -51,7 +51,7 @@ const CreateGuestEventFunnel = () => {
         <Funnel.Step name="eventPassword">
           <SetEventPasswordStep
             moveToNextStep={moveToNextStep}
-            nickname={nickNameProps.nickName}
+            nickname={nickNameProps.nickname}
             eventName={eventNameProps.eventName}
             setEventToken={setEventToken}
           />

--- a/client/src/pages/EventPage/AuthGate/index.tsx
+++ b/client/src/pages/EventPage/AuthGate/index.tsx
@@ -2,23 +2,12 @@ import {useEffect} from 'react';
 
 import useRequestPostAuthentication from '@hooks/queries/auth/useRequestPostAuthentication';
 
-import {useAuthStore} from '@store/authStore';
-
-type AuthGateProps = React.PropsWithChildren & {
-  fallback: React.ReactNode;
-};
-
-const AuthGate = ({children, fallback}: AuthGateProps) => {
-  const {isError, postAuthenticate} = useRequestPostAuthentication();
-  const {isAdmin} = useAuthStore();
+const AuthGate = ({children}: React.PropsWithChildren) => {
+  const {postAuthenticate} = useRequestPostAuthentication();
 
   useEffect(() => {
     postAuthenticate();
   }, [postAuthenticate]);
-
-  if (isError && !isAdmin) {
-    return fallback;
-  }
 
   return children;
 };

--- a/client/src/pages/EventPage/EventPageFallback/Login/GusetEventLogin.tsx
+++ b/client/src/pages/EventPage/EventPageFallback/Login/GusetEventLogin.tsx
@@ -1,25 +1,16 @@
-import {css} from '@emotion/react';
-
 import Top from '@components/Design/components/Top/Top';
 
 import useEventLogin from '@hooks/useEventLogin';
 
-import {FixedButton, Input} from '@HDesign/index';
+import {FixedButton, FunnelLayout, Input} from '@HDesign/index';
 
 import RULE from '@constants/rule';
 
-const EventLoginPage = () => {
+const GuestEventLogin = () => {
   const {password, errorMessage, handleChange, canSubmit, submitPassword} = useEventLogin();
 
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        padding: 1rem;
-      `}
-    >
+    <FunnelLayout>
       <Top>
         <Top.Line
           text={`행사 생성 시 설정한 ${RULE.maxEventPasswordLength}자리`}
@@ -41,8 +32,8 @@ const EventLoginPage = () => {
         ></Input>
         <FixedButton disabled={!canSubmit}>관리 페이지로</FixedButton>
       </form>
-    </div>
+    </FunnelLayout>
   );
 };
 
-export default EventLoginPage;
+export default GuestEventLogin;

--- a/client/src/pages/EventPage/EventPageFallback/Login/MemberEventLogin.tsx
+++ b/client/src/pages/EventPage/EventPageFallback/Login/MemberEventLogin.tsx
@@ -14,7 +14,7 @@ const MemberEventLogin = () => {
     <FunnelLayout>
       <Top>
         <Top.Line text={`행사 관리 접근을 위해`} />
-        <Top.Line text="카카오 계정 로그인을 해주세요." emphasize={['카카오 계정 로그인을 해주세요.']} />
+        <Top.Line text="카카오 계정 로그인을 해주세요." emphasize={['카카오 계정 로그인']} />
       </Top>
       <Button variants="kakao" size="large" onClick={() => goKakaoLogin(previousUrl)}>
         <Flex alignItems="center" gap="0.625rem">

--- a/client/src/pages/EventPage/EventPageFallback/Login/MemberEventLogin.tsx
+++ b/client/src/pages/EventPage/EventPageFallback/Login/MemberEventLogin.tsx
@@ -1,0 +1,29 @@
+import Top from '@components/Design/components/Top/Top';
+
+import useLoginPage from '@hooks/useLoginPage';
+
+import {Button, Flex, FunnelLayout, Icon} from '@HDesign/index';
+
+import getEventBaseUrl from '@utils/getEventBaseUrl';
+
+const MemberEventLogin = () => {
+  const {goKakaoLogin} = useLoginPage();
+  const previousUrl = `${getEventBaseUrl(window.location.pathname)}/admin`;
+
+  return (
+    <FunnelLayout>
+      <Top>
+        <Top.Line text={`행사 관리 접근을 위해`} />
+        <Top.Line text="카카오 계정 로그인을 해주세요." emphasize={['카카오 계정 로그인을 해주세요.']} />
+      </Top>
+      <Button variants="kakao" size="large" onClick={() => goKakaoLogin(previousUrl)}>
+        <Flex alignItems="center" gap="0.625rem">
+          <Icon iconType="kakao" />
+          카카오 로그인
+        </Flex>
+      </Button>
+    </FunnelLayout>
+  );
+};
+
+export default MemberEventLogin;

--- a/client/src/pages/LoginPage/LoginFailFallback.tsx
+++ b/client/src/pages/LoginPage/LoginFailFallback.tsx
@@ -1,0 +1,35 @@
+import {useNavigate} from 'react-router-dom';
+
+import Image from '@components/Design/components/Image/Image';
+
+import {Button, FunnelLayout, MainLayout, Text, Top} from '@components/Design';
+
+import getImageUrl from '@utils/getImageUrl';
+
+const LoginFailFallback = () => {
+  const navigate = useNavigate();
+
+  const goLandingPage = () => {
+    navigate('/');
+  };
+
+  return (
+    <MainLayout backgroundColor="white">
+      <FunnelLayout>
+        <Text size="title" textColor="onTertiary">
+          로그인 실패
+        </Text>
+        <Top>
+          <Top.Line text="로그인에 실패했습니다" />
+          <Top.Line text="반복된다면 메일로 문의해주세요" />
+        </Top>
+        <Image src={getImageUrl('cryingDog', 'webp')} fallbackSrc={getImageUrl('cryingDog', 'png')} width={200} />
+        <Button variants="secondary" size="large" onClick={goLandingPage}>
+          홈으로 돌아가기
+        </Button>
+      </FunnelLayout>
+    </MainLayout>
+  );
+};
+
+export default LoginFailFallback;

--- a/client/src/pages/LoginPage/LoginRedirectPage.tsx
+++ b/client/src/pages/LoginPage/LoginRedirectPage.tsx
@@ -32,6 +32,8 @@ const LoginRedirectPage = () => {
       if (!code) return;
 
       await requestGetKakaoLogin();
+      SessionStorage.remove(SESSION_STORAGE_KEYS.previousUrlForLogin);
+
       updateAuth(true);
       trackStartCreateEvent({login: true});
 

--- a/client/src/pages/LoginPage/LoginRedirectPage.tsx
+++ b/client/src/pages/LoginPage/LoginRedirectPage.tsx
@@ -31,7 +31,7 @@ const LoginRedirectPage = () => {
     const kakaoLogin = async () => {
       if (!code) return;
 
-      await requestGetKakaoLogin();
+      await requestGetKakaoLogin({throwOnError: true});
       SessionStorage.remove(SESSION_STORAGE_KEYS.previousUrlForLogin);
 
       updateAuth(true);

--- a/client/src/pages/LoginPage/LoginRedirectPage.tsx
+++ b/client/src/pages/LoginPage/LoginRedirectPage.tsx
@@ -1,0 +1,64 @@
+import {useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import Image from '@components/Design/components/Image/Image';
+import useRequestGetKakaoLogin from '@hooks/queries/auth/useRequestGetKakaoLogin';
+
+import useAmplitude from '@hooks/useAmplitude';
+
+import {useAuthStore} from '@store/authStore';
+
+import {FunnelLayout, MainLayout, Text, Top} from '@components/Design';
+
+import getImageUrl from '@utils/getImageUrl';
+import SessionStorage from '@utils/SessionStorage';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
+import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
+
+const LoginRedirectPage = () => {
+  const navigate = useNavigate();
+  const {requestGetKakaoLogin} = useRequestGetKakaoLogin();
+  const {updateAuth} = useAuthStore();
+  const {trackStartCreateEvent} = useAmplitude();
+
+  useEffect(() => {
+    if (location.search === '') return;
+
+    const code = new URLSearchParams(location.search).get('code');
+    const previousUrlForLogin = SessionStorage.get<string>(SESSION_STORAGE_KEYS.previousUrlForLogin);
+
+    const kakaoLogin = async () => {
+      if (!code) return;
+
+      await requestGetKakaoLogin();
+      updateAuth(true);
+      trackStartCreateEvent({login: true});
+
+      if (previousUrlForLogin) {
+        navigate(previousUrlForLogin, {replace: true});
+      } else {
+        navigate(ROUTER_URLS.createMemberEvent);
+      }
+    };
+
+    kakaoLogin();
+  }, [location.search]);
+
+  return (
+    <MainLayout backgroundColor="white">
+      <FunnelLayout>
+        <Text size="title" textColor="onTertiary">
+          로그인 중
+        </Text>
+        <Top>
+          <Top.Line text="로그인이 완료될 때까지" />
+          <Top.Line text="잠시만 기다려주세요" />
+        </Top>
+        <Image src={getImageUrl('runningDog', 'webp')} fallbackSrc={getImageUrl('runningDog', 'png')} width={300} />
+      </FunnelLayout>
+    </MainLayout>
+  );
+};
+
+export default LoginRedirectPage;

--- a/client/src/pages/LoginPage/index.tsx
+++ b/client/src/pages/LoginPage/index.tsx
@@ -29,7 +29,7 @@ const LoginPage = () => {
             </Text>
           </Flex>
           <Flex flexDirection="column" gap="1rem" width="100%" padding="0 2rem" paddingInline="auto">
-            <Button variants="kakao" size="large" onClick={goKakaoLogin}>
+            <Button variants="kakao" size="large" onClick={() => goKakaoLogin()}>
               <Flex alignItems="center" gap="0.625rem">
                 <Icon iconType="kakao" />
                 카카오 로그인

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -30,6 +30,7 @@ const AddImagesPage = lazy(() => import('@pages/AddImagesPage/AddImagesPage'));
 const EssentialQueryApp = lazy(() => import('./EssentialQueryApp'));
 const QRCodePage = lazy(() => import('@pages/QRCodePage/QRCodePage'));
 const LoginPage = lazy(() => import('@pages/LoginPage'));
+const LoginRedirectPage = lazy(() => import('@pages/LoginPage/LoginRedirectPage'));
 
 const router = createBrowserRouter([
   {
@@ -59,6 +60,10 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.login,
             element: <LoginPage />,
+          },
+          {
+            path: ROUTER_URLS.kakaoLoginRedirectUri,
+            element: <LoginRedirectPage />,
           },
           {
             path: ROUTER_URLS.event,

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -7,11 +7,13 @@ import App from './App';
 
 const ErrorPage = lazy(() => import('@pages/ErrorPage/ErrorPage'));
 const SendErrorPage = lazy(() => import('@pages/ErrorPage/SendErrorPage'));
-const EventLoginPage = lazy(() => import('@pages/EventPage/AdminPage/EventLoginPage'));
 const CreateGuestEventFunnel = lazy(() => import('@pages/CreateEventPage/CreateGuestEventPage/CreateGuestEventFunnel'));
 const CreateMemberEventFunnel = lazy(
   () => import('@pages/CreateEventPage/CreateMemberEventPage/CreateMemberEventFunnel'),
 );
+const GuestEventLogin = lazy(() => import('@pages/EventPage/EventPageFallback/Login/GusetEventLogin'));
+const MemberEventLogin = lazy(() => import('@pages/EventPage/EventPageFallback/Login/MemberEventLogin'));
+
 const EventLoader = lazy(() => import('@components/Loader/EventLoader'));
 const AuthGate = lazy(() => import('@pages/EventPage/AuthGate'));
 const EventPage = lazy(() => import('@pages/EventPage/EventPageLayout'));
@@ -69,7 +71,7 @@ const router = createBrowserRouter([
               {
                 path: ROUTER_URLS.eventManage,
                 element: (
-                  <AuthGate fallback={<EventLoginPage />}>
+                  <AuthGate>
                     <AdminPage />
                   </AuthGate>
                 ),
@@ -77,6 +79,14 @@ const router = createBrowserRouter([
               {
                 path: ROUTER_URLS.home,
                 element: <HomePage />,
+              },
+              {
+                path: ROUTER_URLS.guestEventLogin,
+                element: <GuestEventLogin />,
+              },
+              {
+                path: ROUTER_URLS.memberEventLogin,
+                element: <MemberEventLogin />,
               },
             ],
           },

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -31,6 +31,7 @@ const EssentialQueryApp = lazy(() => import('./EssentialQueryApp'));
 const QRCodePage = lazy(() => import('@pages/QRCodePage/QRCodePage'));
 const LoginPage = lazy(() => import('@pages/LoginPage'));
 const LoginRedirectPage = lazy(() => import('@pages/LoginPage/LoginRedirectPage'));
+const LoginFailFallback = lazy(() => import('@pages/LoginPage/LoginFailFallback'));
 
 const router = createBrowserRouter([
   {
@@ -64,6 +65,7 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.kakaoLoginRedirectUri,
             element: <LoginRedirectPage />,
+            errorElement: <LoginFailFallback />,
           },
           {
             path: ROUTER_URLS.event,

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -63,6 +63,7 @@ export interface Event {
   eventName: EventName;
   bankName: string;
   accountNumber: string;
+  createdByGuest: boolean;
 }
 
 export interface Report {

--- a/client/src/utils/SessionStorage.ts
+++ b/client/src/utils/SessionStorage.ts
@@ -14,6 +14,10 @@ const SessionStorage = {
     const element = JSON.stringify(data);
     sessionStorage.setItem(key, element);
   },
+
+  remove: (key: string) => {
+    sessionStorage.removeItem(key);
+  },
 };
 
 export default SessionStorage;

--- a/client/src/utils/getDeletedLastPath.ts
+++ b/client/src/utils/getDeletedLastPath.ts
@@ -1,7 +1,0 @@
-const getDeletedLastPath = (url: string) => {
-  const urlParts = url.split('/');
-  urlParts.pop();
-  return urlParts.join('/');
-};
-
-export default getDeletedLastPath;

--- a/client/src/utils/getEventBaseUrl.ts
+++ b/client/src/utils/getEventBaseUrl.ts
@@ -1,0 +1,8 @@
+const getEventBaseUrl = (url: string) => {
+  const urlParts = url.split('/');
+  const baseUrl = urlParts[1] + '/' + urlParts[2];
+
+  return baseUrl;
+};
+
+export default getEventBaseUrl;


### PR DESCRIPTION
## issue
- close #836 

**[블로그](https://jinokim.tistory.com/47)에서도 아래 내용을 확인할 수 있습니다.**

### 기존 인증 전략
<img src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbcibAR%2FbtsKSigLukh%2FXKDMkCo5QwNemIUTW9oIqk%2Fimg.png" />

먼저 유저가 관리 페이지에 진입하게 되면 PostAuthenticate 함수 호출을 하게 됩니다. 이는 백엔드로 "내가 이 행사의 접근 권한이 있나요?"를 물어보는 기능으로 백엔드에서 쿠키를 확인한 후 결과를 알려주게 됩니다. 쿠키가 있다면 행사의 주최자가 맞으므로 관리 페이지에 정상 진입하게 되고, 쿠키가 없거나 변조된 값이면 주최자가 아니기 때문에 관리 페이지 대신 비회원 로그인 페이지로 가도록 하며, 비밀번호 4자리를 입력하고 로그인을 해야 주최자로 승인 받게 됩니다.

행사마다 회원 소유가 없으며 비밀번호를 정상적으로 입력하는 유저는 모두 주최자로 인정받을 수 있기 때문에 단순한 플로우를 구축할 수 있었고 프론트엔드에서 인증 절차를 복잡하게 가져가지 않았습니다.

### 로그인 기능으로 추가된 인증 요구사항
하지만 이제 회원가입이 생겨 행사의 소유자가 생기고 로그인 한 유저는 비밀번호 4자리를 입력하지 않으므로 위 전략대로 가져갈 수가 없습니다. 행사 주최자가 비밀번호 없이 행사를 만들었는데 관리 페이지 접근 시 비밀번호 입력 화면을 보여주면 안 되기 때문입니다. 그리고 로그인으로 카카오 OAuth를 사용하게 되어 서비스를 이탈했다가 돌아와야하는 요구사항도 생겼습니다. 그래서 관리 페이지에서 카카오 로그인으로 이동한 뒤 관리 페이지로 다시 돌아갈 수 있는 기능도 추가 되어야 합니다. 요구사항을 짧게 정리해보면

1. 행사 소유자에 따른 로그인 기능 분리 (비밀번호 / 카카오)
2. 인증 실패 후 로그인을 성공했을 때 관리 페이지로 바로 접속할 수 있는 기능


### 변경된 인증 전략
![image](https://github.com/user-attachments/assets/f196d037-5578-4f29-a0bc-e3c8b3c31728)

동일하게 먼저 유저가 관리 페이지에 진입합니다. 이 때 원래는 바로 PostAuthenticate 함수를 호출하여 백엔드에게 인증을 요청했지만 이제는 행사의 소유자를 먼저 알아야하므로 행사 정보 조회 API를 먼저 불러옵니다. 그리고 PostAuthenticate 함수를 호출하여 백엔드에게 인증을 요청한 후에 ~~바로 세션스토리지에 행사 소유자 정보를 저장합니다.~~ 만약 쿠키가 있어서 정상적으로 인증이 완료되면 관리 페이지로 정상 진입하게 됩니다. 그러나 쿠키가 없거나 변조되어 정상적으로 인증이 완료되지 않은 경우에 아래 흐름을 따릅니다.

먼저 현재 URL을 세션스토리지에 저장합니다. 즉 관리 페이지 URL이 세션스토리지에 저장됩니다. 그리고 아까 세션스토리지에 저장한 행사 소유자 정보를 가져와서 회원 / 비회원 생성을 구분하게 됩니다. 회원이 생성한 행사라면 카카오 로그인 페이지로, 비회원이 생성한 행사라면 기존의 비회원 로그인(비밀번호 입력) 페이지로 이동하게 됩니다. 각자의 방법으로 로그인을 성공했다면 이전에 세션스토리지에 저장해 둔 URL로 이동시키게 되면 관리 페이지에 접속하여 인증에 실패한 유저가 다시 관리 페이지로 자동으로 돌아올 수 있게 됩니다.

### 변경된 인증 전략을 코드로 살펴보기 

1. 행사 정보 조회 API 호출

```tsx
// query hooks
const useRequestGetEvent = ({...props}: WithErrorHandlingStrategy | null = {}) => {
  const eventId = getEventIdByUrl();

  const {data, ...rest} = useSuspenseQuery({
    queryKey: [QUERY_KEYS.event],
    queryFn: () => requestGetEvent({eventId, ...props}),
  });

  return {
    eventName: data.eventName,
    bankName: data.bankName,
    accountNumber: data.accountNumber,
    createdByGuest: data.createdByGuest,
    ...rest,
  };
};

export default useRequestGetEvent;
```

백엔드에서 행사 소유자 정보인 createdByGuest를 추가해줘서 이를 반영해줬습니다. 그리고 변경된 코드가 하나 더 있는데 바로 useQuery에서 useSuspenseQuery로의 변경입니다. 행동대장에서는 GET 메서드 호출을 할 때 useQuery를 사용해왔습니다. 제가 생각한 그 이유는 GET 메서드를 호출하는 동안 대체로 보여줄 로딩과 스켈레톤을 만들지 않았으며 반드시 값이 보장되어야하는 요구사항이 없었기 때문에 SuspenseQuery를 사용해야하는 근거가 없었다고 생각합니다. 하지만 이 기능을 구현하며 두 번째의 이유가 생겼습니다. 인증에 실패한 사용자가 로그인을 하는 과정에서 행사 소유자 정보를 보장받을 수 없다면 회원으로 생성된 행사에서 비회원 로그인 방식을 보여줄 수 있게 되는 최악의 경우가 발생할 수 있습니다. 그래서 값이 보장되어야하는 이유가 생겼고 useSuspenseQuery를 사용해서 값을 보장할 수 있도록 변경해줬습니다.

여기서 SuspenseQuery를 사용하는 주의점으로 SuspenseQuery를 호출하는 부모 컴포넌트에 Suspense로 감싸줘야하는 규칙이 있지만 행동대장에서 이미 Lazy import를 하며 Suspense를 라우트 최상단에 감싸주고 있기 때문에 따로 처리를 해주지 않았습니다. 추후에 로딩 화면이 필요하다는 요구사항이 들어오면 이벤트 페이지를 감싸는 Suspense를 추가해줄 수 있을 것 같습니다.


2. 백엔드로 인증 요청하는 PostAuthenticate
```tsx
const useRequestPostAuthentication = () => {
  const eventId = getEventIdByUrl();
  const {updateAuth} = useAuthStore();

  const {createdByGuest} = useRequestGetEvent();

  const {mutate, ...rest} = useMutation({
    mutationFn: () => requestPostAuthentication({eventId}),
    onSuccess: () => updateAuth(true),
    onMutate: () => {
      SessionStorage.set<boolean>(SESSION_STORAGE_KEYS.createdByGuest, createdByGuest);
    },
  });

  return {
    postAuthenticate: mutate,
    ...rest,
  };
};
```

여기서 postAuthenticate 함수 호출로 mutate가 실행되어 백엔드로 인증을 요청하게 됩니다. 여기서 추가된 것은 onMutate 콜백입니다. mutate가 실행될 때, 즉 백엔드로 인증 요청을 할 때 세션스토리지에 행사 소유자 정보를 저장하게 되며 이는 추후에 로그인에 실패할 때 사용하게 됩니다.



3. 에러를 잡아주는 ErrorCatcher에서 401 에러에 대한 대응 추가
```tsx
const ErrorCatcher = ({children}: React.PropsWithChildren) => {
  const {appError: error} = useAppErrorStore();
  const navigate = useNavigate();
   
  useEffect(() => {
    ...
    if (
      error.errorCode === 'TOKEN_NOT_FOUND' &&
      !window.location.pathname.includes('/guest/login') &&
      !window.location.pathname.includes('/member/login')
    ) {
      const createdByGuest = SessionStorage.get<boolean>(SESSION_STORAGE_KEYS.createdByGuest);
      SessionStorage.set<string>(SESSION_STORAGE_KEYS.previousUrlForLogin, window.location.pathname);

      const currentPath = window.location.pathname;

      if (createdByGuest) {
        navigate(`${currentPath}/guest/login`);
      } else {
        navigate(`${currentPath}/member/login`);
      }
    }
  }, [error, navigate]);
  
  return children;
};

export default ErrorCatcher;
```

로그인에 실패하게 되면 백엔드에서 인증 에러인 401 TOKEN_NOT_FOUND 에러를 발생시킵니다 그러면 ErrorCatcher에서 useEffect 구문에 의해 에러 변경이 감지되면 기존의 에러 처리를 한 후에 if문을 실행하게 됩니다.

TOKEN_NOT_FOUND 에러가 발생한 경우에 세션스토리지에서 행사 소유자 정보를 먼저 가져옵니다. 여기서 행사 소유자 정보에 따라 카카오 / 비밀번호 페이지로 이동하기 때문입다. 그리고 바로 다시 세션스토리지에 현재 url path 정보를 저장해주는데 이는 나중에 로그인에 성공했을 때 사용하기 위해 저장해둡니다.

createByGuest가 true라면 비회원이 만든 행사이므로 비회원 로그인 페이지로 라우트 시키고 false일 때는 회원이 만든 행사이므로 카카오 로그인 페이지로 라우트 시킵니다.

여기서 처음 if문이 복잡한 이유는 React.StrictMode 때문입니다. StrictMode에서는 useEffect를 두 번 씩 실행시키기 때문에 navigate도 역시 두 번 실행되어 url이 https://~~~/admin/guest/login/guest/login이 되기 때문이며 두 번 째 Effect가 실행될 때 navigate가 실행되지 않기 위한 가드 역할을 해줍니다.


4. 비회원 로그인 후 관리 페이지로 이동하기
```tsx
const useRequestPostLogin = () => {
  const eventId = getEventIdByUrl();
  const {updateAuth} = useAuthStore();
  const navigate = useNavigate();

  const {mutate, ...rest} = useMutation({
    mutationFn: ({password}: RequestPostToken) => requestPostToken({eventId, password}),
    onSuccess: () => {
      const previousUrlForLogin = SessionStorage.get<string>(SESSION_STORAGE_KEYS.previousUrlForLogin);
      if (previousUrlForLogin) {
        SessionStorage.remove(SESSION_STORAGE_KEYS.previousUrlForLogin);
        navigate(previousUrlForLogin, {replace: true});
      }
      updateAuth(true);
    },
  });

  return {postLogin: mutate, ...rest};
};

export default useRequestPostLogin;
```

여기서 비회원 로그인 api가 호출되고 요청에 성공할 때 기능이 추가되었습니다. 먼저 이전 단계에서 저장한 이전 페이지 정보를 세션스토리지에서 가져옵니다. 그리고 이전 페이지 정보가 있다면 그 페이지로 이동시켜주고 세션스토리지에서 이전 페이지 정보를 지워줍니다. 여기서 navigate 옵션으로 replace: true를 준 이유는 로그인에 성공했으니깐 페이지를 대체해버리기 위함입니다.


5. 회원 로그인 후 관리 페이지로 이동하기
```tsx
const LoginRedirectPage = () => {
  useEffect(() => {
    if (location.search === '') return;

    const code = new URLSearchParams(location.search).get('code');
    const previousUrlForLogin = SessionStorage.get<string>(SESSION_STORAGE_KEYS.previousUrlForLogin);

    const kakaoLogin = async () => {
      if (!code) return;

      await requestGetKakaoLogin();
      updateAuth(true);
      trackStartCreateEvent({login: true});

      if (previousUrlForLogin) {
        navigate(previousUrlForLogin, {replace: true});
      } else {
        navigate(ROUTER_URLS.createMemberEvent);
      }
    };

    kakaoLogin();
  }, [location.search]);
  
  return (
  ...
  )
}

export default LoginRedirectPage;
```

카카오 OAuth 서비스에 등록해 둔 Redirect Uri에 해당하는 컴포넌트입니다. 카카오 OAuth에서 유저가 아이디와 비밀번호를 입력하게 되면 인가코드(code)라는 것을 주게 되는데 우리는 이 code를 백엔드에 전달하여 카카오 로그인을 하게 됩니다. 여기서도 우선 이전 페이지 정보를 세션스토리지에서 가져오게 됩니다. 여기는 분기가 조금 다른 것이 카카오 로그인을 관리 페이지에서도 하지만 서비스를 처음 시작할 때도 사용하기 때문에 조건을 나누어 처리를 해줬습니다. 동일하게 로그인에 성공하게 되면 이전 페이지 정보를 확인하고 정보가 있다면 이전 페이지(관리 페이지)로 이동합니다. 이전 페이지 정보가 없다면 회원 행사 생성으로 이동하게 됩니다.


여기까지 블로그에 기록한 내용입니다. 추가로 이 아래는 기타로 변경된 사항을 적어보려합니다.


### 카카오 Redirect Uri 변경
카카오 Redirect Uri를 변경했습니다. 그 이유는 처음 플로우에서 로그인만 생각했었는데 관리 페이지에서 인증에 실패하여 카카오 로그인을 요구할 때 동일한 UI를 사용하면 안 될 것 같아 관리 페이지 카카오 로그인과, 서비스 시작 로그인을 분리해서 만들어줬습니다. 그래서 Redirect Uri도 한 페이지에 의존하지 않고 다른 컴포넌트를 만들어 분리했습니다.


### TopNav navigate 로직 수정
이전에는 마지막 path만 지우고 추가해줬는데 이제는 /admin/guest/login 과 같이 sub path가 길어지게 되어 이런 경우에 정상적으로 처리해줄 수 없었습니다. 그래서 유틸 함수 getDeletedLastPath를 getEventBaseUrl이라는 함수로 변경하고 event/eventId까지 얻어와서 그 뒤에 상황에 맞게 붙여주는 기능으로 변경했습니다.


### 추가한 화면들
![image](https://github.com/user-attachments/assets/4d2b6eba-fcd6-4b68-8c7f-17a80b0497de)


### 추가 변경사항
createdByGuest 값을 굳이 세션스토리지에 저장하지 않고 useRequestPostAuthentication에서 책임을 지는 방식으로 변경했습니다. ErrorCatcher에 특정 에러에 대한 navigate 책임까지 넣기에 과한 책임을 진다고 생각했으며 인증을 책임지는 함수에서 이를 책임지도록 변경하는 것이 더 적절하다고 생각하여 변경했습니다. 

변경사항 : createdByGuest를 세션스토리지에 저장하여 ErrorCatcher에서 사용한다 -> createdByGuest를 호출하여 postAuthenticate 함수 내 onError 콜백 안에서 navigate를 책임진다.

#### 카카오 로그인 실패 시 실패 화면 보여주는 기능 추가
카카오 로그인에 실패했을 때도 로그인 후 화면으로 이동하는 버그가 있었습니다. 이에 카카오 로그인에 실패했을 때 fallback을 보여줄 수 있도록 설정했습니다.

+ 과정
1. errorBoundary 설정
웨디의 에러처리에서 `errorStrategy: errorBoundary` 설정을 해주어 요청에서 에러가 났을 때 에러 바운더리가 보여지도록 설정했습니다.

```ts
await requestGetWithoutResponse({
    baseUrl: BASE_URL.HD,
    endpoint: `/api/login/kakao?code=${code}&redirect_uri=${getKakaoRedirectUrl()}`,
    errorHandlingStrategy: 'errorBoundary',
  });
```

2. throwOnError 설정 
useQuery의 refetchFuntion: requestGetKakaoLogin 함수 옵션에 throwOnError: true 설정을 추가해줬습니다. 이는 추후에 설명할 router의 errorElement를 사용하기 위함입니다.

```ts
await requestGetKakaoLogin({throwOnError: true});
```

3. Router의 ErrorElement 설정
LoginRedirectPage에서 throwOnError 옵션으로 인해 에러가 발생하면 router 설정의 errorElement가 보여지게 됩니다. 
router의 ErrorBoundary 역할이라고 생각하시면 될 것 같아요!!

```tsx
  path: ROUTER_URLS.kakaoLoginRedirectUri,
  element: <LoginRedirectPage />,
  errorElement: <LoginFailFallback />,
```

4. 로그인 실패 영상

https://github.com/user-attachments/assets/9eae30e4-e34a-4a02-849b-4757ae5b58c4



## 중점적으로 리뷰받고 싶은 부분(선택)
인증 과정에 대해서 리뷰 부탁 드려요!! 더 간편한 방식이 있을지 궁금합니다!


## 🫡 참고사항


