### PR TITLE
[FE] 마이페이지 화면 퍼블리싱

### DIFF
--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -17,4 +17,5 @@ export const ROUTER_URLS = {
   qrCode: `${EVENT_WITH_EVENT_ID}/qrcode`,
   event: EVENT,
   login: '/login',
+  myPage: '/mypage',
 };

--- a/client/src/pages/MyPage/Container.tsx
+++ b/client/src/pages/MyPage/Container.tsx
@@ -1,0 +1,20 @@
+import {Flex} from '@components/Design';
+
+type ContainerProps = React.PropsWithChildren;
+
+const Container = ({children}: ContainerProps) => {
+  return (
+    <Flex
+      flexDirection="column"
+      width="100%"
+      gap="0.5rem"
+      backgroundColor="white"
+      padding="1rem"
+      css={{borderRadius: '0.75rem'}}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+export default Container;

--- a/client/src/pages/MyPage/MyPage.style.ts
+++ b/client/src/pages/MyPage/MyPage.style.ts
@@ -1,0 +1,12 @@
+import {css} from '@emotion/react';
+
+import {Theme} from '@components/Design/theme/theme.type';
+
+export const mockImageStyle = (theme: Theme) =>
+  css({
+    width: '3rem',
+    height: '3rem',
+
+    borderRadius: '50%',
+    backgroundColor: theme.colors.gray,
+  });

--- a/client/src/pages/MyPage/index.tsx
+++ b/client/src/pages/MyPage/index.tsx
@@ -1,0 +1,49 @@
+import {Button, Flex, FunnelLayout, MainLayout, Text, TextButton, TopNav, useTheme} from '@components/Design';
+
+import {mockImageStyle} from './MyPage.style';
+import Container from './Container';
+
+const MyPage = () => {
+  const {theme} = useTheme();
+
+  return (
+    <MainLayout backgroundColor="gray">
+      <TopNav>
+        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
+      </TopNav>
+      <FunnelLayout>
+        <Container>
+          <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem">
+            <Flex gap="1rem" alignItems="center">
+              <div css={mockImageStyle(theme)}></div>
+              <Text size="bodyBold" textColor="onTertiary">
+                이름이 올 곳
+              </Text>
+            </Flex>
+            <Button variants="tertiary" size="small">
+              로그아웃
+            </Button>
+          </Flex>
+        </Container>
+        <Container>
+          <Flex flexDirection="column" margin="0 1.5rem" gap="1rem">
+            <TextButton textColor="onTertiary" textSize="body">
+              닉네임 설정하기
+            </TextButton>
+            <TextButton textColor="onTertiary" textSize="body">
+              기본 계좌 번호 설정하기
+            </TextButton>
+            <TextButton textColor="onTertiary" textSize="body">
+              내가 만든 행사 목록 보기
+            </TextButton>
+            <TextButton textColor="onTertiary" textSize="body">
+              탈퇴하기
+            </TextButton>
+          </Flex>
+        </Container>
+      </FunnelLayout>
+    </MainLayout>
+  );
+};
+
+export default MyPage;

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -28,6 +28,7 @@ const AddImagesPage = lazy(() => import('@pages/AddImagesPage/AddImagesPage'));
 const EssentialQueryApp = lazy(() => import('./EssentialQueryApp'));
 const QRCodePage = lazy(() => import('@pages/QRCodePage/QRCodePage'));
 const LoginPage = lazy(() => import('@pages/LoginPage'));
+const MyPage = lazy(() => import('@pages/MyPage'));
 
 const router = createBrowserRouter([
   {
@@ -57,6 +58,10 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.login,
             element: <LoginPage />,
+          },
+          {
+            path: ROUTER_URLS.myPage,
+            element: <MyPage />,
           },
           {
             path: ROUTER_URLS.event,


### PR DESCRIPTION
## issue
- close #838 

## 구현 사항
### 마이페이지 퍼블리싱 작업 수행
![image](https://github.com/user-attachments/assets/53ab2690-d223-4585-bdeb-e6135e4c1c57)

로그인 후 사용자가 혜택을 누릴 수 있는 화면, 마이페이지 화면 퍼블리싱 작업만 수행했습니다.
이 페이지에서 로그아웃, 닉네임 설정, 계좌번호 설정, 내가 만든 행사 목록, 탈퇴 기능을 수행할 수 있습니다.
피그마에 있는 레이아웃 대로 작업했으며 기능은 추후에 추가할 예정입니다.


## 🫡 참고사항
