### PR TITLE
[FE] 회원 행사 생성 endpoint가 맞지 않아 에러 발생됐던 원인 해결

### DIFF
--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -16,7 +16,7 @@ export const requestPostGuestEvent = async (postEventArgs: EventCreationData) =>
 
 export const requestPostMemberEvent = async (eventName: EventName) => {
   return await requestPostWithResponse<EventId>({
-    endpoint: `${USER_API_PREFIX}/events`,
+    endpoint: USER_API_PREFIX,
     body: {
       eventName,
     },


### PR DESCRIPTION
## issue
- close #841 

## 구현 사항
### 회원 행사 생성 endpoint 변경
백엔드에서 endpoint가 변화해서 이를 반영했습니다.
반영 후 제 브랜치에서 정상 작동 확인했어요 :)

## 🫡 참고사항
