### PR TITLE
[FE] 계좌번호 수정이 되지 않는 문제 해결

### DIFF
--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -1,4 +1,4 @@
-import {Event, EventCreationData, EventId, EventName} from 'types/serviceType';
+import {Event, EventCreationData, EventId, EventName, User} from 'types/serviceType';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
 
 import {ADMIN_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
@@ -31,14 +31,25 @@ export const requestGetEvent = async ({eventId, ...props}: WithEventId<WithError
 };
 
 export type RequestPatchEvent = WithEventId & {
-  eventOutline: Partial<Event>;
+  eventName: string;
 };
 
-export const requestPatchEvent = async ({eventId, eventOutline}: RequestPatchEvent) => {
+export const requestPatchEventName = async ({eventId, eventName}: RequestPatchEvent) => {
   return requestPatch({
     endpoint: `${ADMIN_API_PREFIX}/${eventId}`,
     body: {
-      ...eventOutline,
+      eventName,
+    },
+  });
+};
+
+export type RequestPatchUser = Partial<User>;
+
+export const requestPatchUser = async (args: RequestPatchUser) => {
+  return requestPatch({
+    endpoint: `/api/users`,
+    body: {
+      ...args,
     },
   });
 };

--- a/client/src/hooks/queries/event/useRequestPatchEventName.ts
+++ b/client/src/hooks/queries/event/useRequestPatchEventName.ts
@@ -2,19 +2,19 @@ import type {Event} from 'types/serviceType';
 
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
-import {requestPatchEvent} from '@apis/request/event';
+import {requestPatchEventName} from '@apis/request/event';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
 import QUERY_KEYS from '@constants/queryKeys';
 
-const useRequestPatchEventOutline = () => {
+const useRequestPatchEventName = () => {
   const eventId = getEventIdByUrl();
 
   const queryClient = useQueryClient();
 
   const {mutateAsync, ...rest} = useMutation({
-    mutationFn: (eventOutline: Partial<Event>) => requestPatchEvent({eventId, eventOutline}),
+    mutationFn: (eventName: string) => requestPatchEventName({eventId, eventName}),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.event],
@@ -28,4 +28,4 @@ const useRequestPatchEventOutline = () => {
   };
 };
 
-export default useRequestPatchEventOutline;
+export default useRequestPatchEventName;

--- a/client/src/hooks/queries/event/useRequestPatchUser.ts
+++ b/client/src/hooks/queries/event/useRequestPatchUser.ts
@@ -1,0 +1,25 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+
+import {RequestPatchUser, requestPatchUser} from '@apis/request/event';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+const useRequestPatchUser = () => {
+  const queryClient = useQueryClient();
+
+  const {mutateAsync, ...rest} = useMutation({
+    mutationFn: (args: RequestPatchUser) => requestPatchUser({...args}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.event],
+      });
+    },
+  });
+
+  return {
+    patchUser: mutateAsync,
+    ...rest,
+  };
+};
+
+export default useRequestPatchUser;

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -4,8 +4,8 @@ import validateAccountNumber from '@utils/validate/validateAccountNumber';
 
 import RULE from '@constants/rule';
 
-import useRequestPatchEvent from './queries/event/useRequestPatchEvent';
 import useRequestGetEvent from './queries/event/useRequestGetEvent';
+import useRequestPatchUser from './queries/event/useRequestPatchUser';
 
 const useAccount = () => {
   const {bankName, accountNumber} = useRequestGetEvent();
@@ -20,7 +20,7 @@ const useAccount = () => {
     setAccountNumber(accountNumber);
   }, [bankName, accountNumber]);
 
-  const {patchEventOutline} = useRequestPatchEvent();
+  const {patchUser} = useRequestPatchUser();
 
   const selectBank = (name: string) => {
     setBankName(name);
@@ -56,7 +56,7 @@ const useAccount = () => {
   };
 
   const enrollAccount = async () => {
-    await patchEventOutline({bankName: bankNameState, accountNumber: accountNumberState});
+    await patchUser({bankName: bankNameState, accountNumber: accountNumberState});
   };
 
   useEffect(() => {

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -59,12 +59,19 @@ export interface EventCreationData {
   password: Password;
 }
 
-export interface Event {
-  eventName: EventName;
+export type BankAccount = {
   bankName: string;
   accountNumber: string;
+};
+
+export type Event = BankAccount & {
+  eventName: EventName;
   createdByGuest: boolean;
-}
+};
+
+export type User = BankAccount & {
+  nickname: Nickname;
+};
 
 export interface Report {
   memberId: number;


### PR DESCRIPTION
## issue
- close #843 

## 구현 사항
### User type 생성
회원가입이 들어가며 계좌번호 관리 책임을 이벤트가 아니라 유저의 책임으로 백엔드 구조가 변경되며 api 명세가 변동되었습니다. 그래서 이에 맞춰 User 타입을 만들었습니다. 유저는 닉네임, 계좌번호, 은행 3가지를 가집니다.
또한 은행과 계좌번호를 합친 BankAccount 타입을 만들어 이를 &연산을 통해 Event와 User에 적용시켰습니다.
```tsx
export type BankAccount = {
  bankName: string;
  accountNumber: string;
};

export type Event = BankAccount & {
  eventName: EventName;
  createdByGuest: boolean;
};

export type User = BankAccount & {
  nickname: Nickname;
};
```

### api 변경 적용
useRequestPatchEventName는 이제 이름만 변경할 수 있고 useRequestPatchUser에서 계좌번호와 은행을 바꿀 수 있습니다.
닉네임 수정은 차후에 적용하겠습니다. 

## 🫡 참고사항
