### PR TITLE
[BE] 내 행사 조회 기능 추가

### DIFF
--- a/server/src/main/java/haengdong/event/application/EventService.java
+++ b/server/src/main/java/haengdong/event/application/EventService.java
@@ -6,6 +6,7 @@ import haengdong.common.exception.HaengdongException;
 import haengdong.event.application.request.EventAppRequest;
 import haengdong.event.application.request.EventGuestAppRequest;
 import haengdong.event.application.request.EventLoginAppRequest;
+import haengdong.event.application.request.EventMineAppResponse;
 import haengdong.event.application.request.EventUpdateAppRequest;
 import haengdong.event.application.response.EventAppResponse;
 import haengdong.event.application.response.EventDetailAppResponse;
@@ -84,9 +85,10 @@ public class EventService {
 
     public List<MemberBillReportAppResponse> getMemberBillReports(String token) {
         Event event = getEvent(token);
+        List<EventMember> eventMembers = eventMemberRepository.findAllByEvent(event);
         List<Bill> bills = billRepository.findAllByEvent(event);
 
-        MemberBillReport memberBillReport = MemberBillReport.createByBills(bills);
+        MemberBillReport memberBillReport = MemberBillReport.create(eventMembers, bills);
 
         return memberBillReport.getReports().entrySet().stream()
                 .map(this::createMemberBillReportResponse)
@@ -185,5 +187,12 @@ public class EventService {
     private EventImage getEventImage(Long imageId) {
         return eventImageRepository.findById(imageId)
                 .orElseThrow(() -> new HaengdongException(HaengdongErrorCode.IMAGE_NOT_FOUND));
+    }
+
+    public List<EventMineAppResponse> findByUserId(Long userId) {
+        return eventRepository.findByUserId(userId).stream()
+                .map(event -> EventMineAppResponse.of(
+                        event, !eventMemberRepository.existsByEventAndIsDeposited(event, false)))
+                .toList();
     }
 }

--- a/server/src/main/java/haengdong/event/application/request/EventMineAppResponse.java
+++ b/server/src/main/java/haengdong/event/application/request/EventMineAppResponse.java
@@ -1,0 +1,16 @@
+package haengdong.event.application.request;
+
+import haengdong.event.domain.event.Event;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public record EventMineAppResponse(
+        String eventId,
+        String eventName,
+        boolean isFinished,
+        LocalDateTime createdAt
+) {
+    public static EventMineAppResponse of(Event event, boolean isFinished) {
+        return new EventMineAppResponse(event.getToken(), event.getName(), isFinished, LocalDateTime.ofInstant(event.getCreatedAt(), ZoneId.of("Asia/Seoul")) );
+    }
+}

--- a/server/src/main/java/haengdong/event/domain/bill/MemberBillReport.java
+++ b/server/src/main/java/haengdong/event/domain/bill/MemberBillReport.java
@@ -2,10 +2,10 @@ package haengdong.event.domain.bill;
 
 import static java.util.stream.Collectors.toMap;
 
+import haengdong.event.domain.event.member.EventMember;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
-import haengdong.event.domain.event.member.EventMember;
 
 @Getter
 public class MemberBillReport {
@@ -16,13 +16,15 @@ public class MemberBillReport {
         this.reports = reports;
     }
 
-    public static MemberBillReport createByBills(List<Bill> bills) {
+    public static MemberBillReport create(List<EventMember> eventMembers, List<Bill> bills) {
         Map<EventMember, Long> reports = bills.stream()
                 .flatMap(bill -> bill.getBillDetails().stream())
                 .collect(toMap(
                         BillDetail::getEventMember,
                         BillDetail::getPrice,
-                        Long::sum
+                        Long::sum,
+                        () -> eventMembers.stream()
+                                .collect(toMap(member -> member, member -> 0L))
                 ));
 
         return new MemberBillReport(reports);

--- a/server/src/main/java/haengdong/event/domain/event/EventRepository.java
+++ b/server/src/main/java/haengdong/event/domain/event/EventRepository.java
@@ -1,5 +1,6 @@
 package haengdong.event.domain.event;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findByToken(String token);
 
     boolean existsByTokenAndUserId(String token, Long userId);
+
+    List<Event> findByUserId(Long userId);
 }

--- a/server/src/main/java/haengdong/event/domain/event/member/EventMemberRepository.java
+++ b/server/src/main/java/haengdong/event/domain/event/member/EventMemberRepository.java
@@ -7,4 +7,6 @@ import haengdong.event.domain.event.Event;
 public interface EventMemberRepository extends JpaRepository<EventMember, Long> {
 
     List<EventMember> findAllByEvent(Event event);
+
+    boolean existsByEventAndIsDeposited(Event event, boolean isDeposited);
 }

--- a/server/src/main/java/haengdong/event/presentation/EventController.java
+++ b/server/src/main/java/haengdong/event/presentation/EventController.java
@@ -6,6 +6,7 @@ import haengdong.common.properties.CookieProperties;
 import haengdong.event.application.EventImageFacadeService;
 import haengdong.event.application.EventService;
 import haengdong.event.application.request.EventAppRequest;
+import haengdong.event.application.request.EventMineAppResponse;
 import haengdong.event.application.response.EventAppResponse;
 import haengdong.event.application.response.EventImageUrlAppResponse;
 import haengdong.event.application.response.MemberBillReportAppResponse;
@@ -15,6 +16,7 @@ import haengdong.event.presentation.request.EventSaveRequest;
 import haengdong.event.presentation.response.EventDetailResponse;
 import haengdong.event.presentation.response.EventImagesResponse;
 import haengdong.event.presentation.response.EventResponse;
+import haengdong.event.presentation.response.EventsMineResponse;
 import haengdong.event.presentation.response.MemberBillReportsResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -46,6 +48,13 @@ public class EventController {
         EventDetailResponse eventDetailResponse = EventDetailResponse.of(eventService.findEvent(token));
 
         return ResponseEntity.ok(eventDetailResponse);
+    }
+
+    @GetMapping("/api/events/mine")
+    public ResponseEntity<EventsMineResponse> findMyEvents(@Login Long userId) {
+        List<EventMineAppResponse> responses = eventService.findByUserId(userId);
+
+        return ResponseEntity.ok(EventsMineResponse.of(responses));
     }
 
     @GetMapping("/api/events/{eventId}/reports")

--- a/server/src/main/java/haengdong/event/presentation/response/EventMineResponse.java
+++ b/server/src/main/java/haengdong/event/presentation/response/EventMineResponse.java
@@ -1,0 +1,16 @@
+package haengdong.event.presentation.response;
+
+import haengdong.event.application.request.EventMineAppResponse;
+import java.time.LocalDateTime;
+
+public record EventMineResponse(
+        String eventId,
+        String eventName,
+        boolean isFinished,
+        LocalDateTime createdAt
+) {
+
+    public static EventMineResponse of(EventMineAppResponse response) {
+        return new EventMineResponse(response.eventId(), response.eventName(), response.isFinished(), response.createdAt());
+    }
+}

--- a/server/src/main/java/haengdong/event/presentation/response/EventsMineResponse.java
+++ b/server/src/main/java/haengdong/event/presentation/response/EventsMineResponse.java
@@ -1,0 +1,17 @@
+package haengdong.event.presentation.response;
+
+import haengdong.event.application.request.EventMineAppResponse;
+import java.util.List;
+
+public record EventsMineResponse(
+        List<EventMineResponse> events
+) {
+
+    public static EventsMineResponse of(List<EventMineAppResponse> responses) {
+        List<EventMineResponse> events = responses.stream()
+                .map(EventMineResponse::of)
+                .toList();
+
+        return new EventsMineResponse(events);
+    }
+}

--- a/server/src/test/java/haengdong/domain/eventmember/EventMemberBillReportTest.java
+++ b/server/src/test/java/haengdong/domain/eventmember/EventMemberBillReportTest.java
@@ -16,19 +16,20 @@ class EventMemberBillReportTest {
 
     @DisplayName("지출 목록으로 참가자 정산 리포트를 생성한다.")
     @Test
-    void createByBills() {
+    void create() {
         Event event = Fixture.EVENT1;
         EventMember eventMember1 = new EventMember(1L, event, "소하", false);
         EventMember eventMember2 = new EventMember(2L, event, "감자", false);
         EventMember eventMember3 = new EventMember(3L, event, "쿠키", false);
         EventMember eventMember4 = new EventMember(4L, event, "고구마", false);
+        EventMember eventMember5 = new EventMember(5L, event, "조커", false);
         List<EventMember> eventMembers = List.of(eventMember1, eventMember2, eventMember3, eventMember4);
         List<Bill> bills = List.of(
                 Bill.create(event, "뽕족", 60_000L, eventMembers),
                 Bill.create(event, "인생네컷", 20_000L, eventMembers)
         );
-
-        MemberBillReport memberBillReport = MemberBillReport.createByBills(bills);
+        List<EventMember> eventMembersReal = List.of(eventMember1, eventMember2, eventMember3, eventMember4, eventMember5);
+        MemberBillReport memberBillReport = MemberBillReport.create(eventMembersReal, bills);
 
         assertThat(memberBillReport.getReports())
                 .containsAllEntriesOf(
@@ -36,7 +37,8 @@ class EventMemberBillReportTest {
                                 eventMember1, 20_000L,
                                 eventMember2, 20_000L,
                                 eventMember3, 20_000L,
-                                eventMember4, 20_000L
+                                eventMember4, 20_000L,
+                                eventMember5, 0L
                         )
                 );
     }


### PR DESCRIPTION
## issue
- close #845 

## 구현 사항
내 행사 조회 기능 추가

### API
GET /api/events/mine

### Response
```json
{
    "events": [
        {
            "eventId": "238ab144-11a0-4028-bc3b-f49b512ec66f",
            "eventName": "행동대앚",
            "isFinished": false,
            "createdAt": "2024-12-08T14:52:28.613223"
        },
        {
            "eventId": "238ab144-11a0-4028-bc3b-f49b512ec66f",
            "eventName": "행동대앚",
            "isFinished": false,
            "createdAt": "2024-12-08T14:52:28.613223"
        },
        {
            "eventId": "238ab144-11a0-4028-bc3b-f49b512ec66f",
            "eventName": "행동대앚",
            "isFinished": false,
            "createdAt": "2024-12-08T14:52:28.613223"
        }
    ]
}
```
