### PR TITLE
[FE] 이벤트 페이지 프로필 표시(로그인 유지) 및 이벤트 페이지 로딩 화면 설정

### DIFF
--- a/client/src/apis/request/user.ts
+++ b/client/src/apis/request/user.ts
@@ -1,0 +1,11 @@
+import {User} from 'types/serviceType';
+
+import {BASE_URL} from '@apis/baseUrl';
+import {requestGet} from '@apis/fetcher';
+
+export const requestGetUserInfo = async () => {
+  return await requestGet<User>({
+    baseUrl: BASE_URL.HD,
+    endpoint: `/api/users/mine`,
+  });
+};

--- a/client/src/components/Design/components/Image/Image.tsx
+++ b/client/src/components/Design/components/Image/Image.tsx
@@ -1,4 +1,5 @@
-type ImageProps = React.ComponentProps<'img'> & {
+/** @jsxImportSource @emotion/react */
+export type ImageProps = React.ComponentProps<'img'> & {
   src: string;
   fallbackSrc?: string;
 };

--- a/client/src/components/Design/components/Profile/Profile.stories.tsx
+++ b/client/src/components/Design/components/Profile/Profile.stories.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource @emotion/react */
+import type {Meta, StoryObj} from '@storybook/react';
+
+import getImageUrl from '@utils/getImageUrl';
+
+import {Profile} from './Profile';
+
+const meta: Meta<typeof Profile> = {
+  title: 'Components/Profile',
+  component: Profile,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div style={{width: '200px', height: '200px', backgroundColor: 'white', padding: '1rem'}}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    src: 'https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%9B%A8%EB%94%94%286%EA%B8%B0%29/g583lirp8yg.jpg',
+    size: 100,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Playground 스토리
+export const Playground: Story = {};

--- a/client/src/components/Design/components/Profile/Profile.stories.tsx
+++ b/client/src/components/Design/components/Profile/Profile.stories.tsx
@@ -1,8 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import type {Meta, StoryObj} from '@storybook/react';
 
-import getImageUrl from '@utils/getImageUrl';
-
 import {Profile} from './Profile';
 
 const meta: Meta<typeof Profile> = {

--- a/client/src/components/Design/components/Profile/Profile.stories.tsx
+++ b/client/src/components/Design/components/Profile/Profile.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Profile> = {
   },
   decorators: [
     Story => (
-      <div style={{width: '200px', height: '200px', backgroundColor: 'white', padding: '1rem'}}>
+      <div style={{width: '200px', height: '200px', padding: '1rem'}}>
         <Story />
       </div>
     ),

--- a/client/src/components/Design/components/Profile/Profile.stories.tsx
+++ b/client/src/components/Design/components/Profile/Profile.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Profile> = {
   ],
   args: {
     src: 'https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%9B%A8%EB%94%94%286%EA%B8%B0%29/g583lirp8yg.jpg',
-    size: 100,
+    size: 'large',
   },
 };
 

--- a/client/src/components/Design/components/Profile/Profile.style.ts
+++ b/client/src/components/Design/components/Profile/Profile.style.ts
@@ -1,0 +1,17 @@
+import {css} from '@emotion/react';
+
+import {Theme} from '@components/Design/theme/theme.type';
+
+export const profileContainerStyle = (theme: Theme, size: number) =>
+  css({
+    display: 'flex',
+
+    width: `${size}px`,
+    height: `${size}px`,
+
+    borderRadius: '50%',
+
+    backgroundColor: theme.colors.white,
+
+    objectFit: 'cover',
+  });

--- a/client/src/components/Design/components/Profile/Profile.style.ts
+++ b/client/src/components/Design/components/Profile/Profile.style.ts
@@ -2,12 +2,20 @@ import {css} from '@emotion/react';
 
 import {Theme} from '@components/Design/theme/theme.type';
 
-export const profileContainerStyle = (theme: Theme, size: number) =>
-  css({
+import {ProfileSize} from './Profile.type';
+
+const SEMANTIC_SIZE: Record<ProfileSize, string> = {
+  small: '1rem',
+  medium: '1.75rem',
+  large: '3rem',
+};
+
+export const profileContainerStyle = (theme: Theme, size: ProfileSize) => {
+  return css({
     display: 'flex',
 
-    width: `${size}px`,
-    height: `${size}px`,
+    width: SEMANTIC_SIZE[size],
+    height: SEMANTIC_SIZE[size],
 
     borderRadius: '50%',
 
@@ -15,3 +23,4 @@ export const profileContainerStyle = (theme: Theme, size: number) =>
 
     objectFit: 'cover',
   });
+};

--- a/client/src/components/Design/components/Profile/Profile.tsx
+++ b/client/src/components/Design/components/Profile/Profile.tsx
@@ -1,0 +1,13 @@
+/** @jsxImportSource @emotion/react */
+import {useTheme} from '@components/Design/theme/HDesignProvider';
+
+import Image from '../Image/Image';
+
+import {profileContainerStyle} from './Profile.style';
+import {ProfileProps} from './Profile.type';
+
+export const Profile = ({size = 28, ...profileProps}: ProfileProps) => {
+  const {theme} = useTheme();
+
+  return <Image aria-label="프로필 이미지" {...profileProps} css={profileContainerStyle(theme, size)} />;
+};

--- a/client/src/components/Design/components/Profile/Profile.tsx
+++ b/client/src/components/Design/components/Profile/Profile.tsx
@@ -6,7 +6,7 @@ import Image from '../Image/Image';
 import {profileContainerStyle} from './Profile.style';
 import {ProfileProps} from './Profile.type';
 
-export const Profile = ({size = 28, ...profileProps}: ProfileProps) => {
+export const Profile = ({size = 'medium', ...profileProps}: ProfileProps) => {
   const {theme} = useTheme();
 
   return <Image aria-label="프로필 이미지" {...profileProps} css={profileContainerStyle(theme, size)} />;

--- a/client/src/components/Design/components/Profile/Profile.type.ts
+++ b/client/src/components/Design/components/Profile/Profile.type.ts
@@ -1,5 +1,7 @@
 import {ImageProps} from '../Image/Image';
 
+export type ProfileSize = 'small' | 'medium' | 'large';
+
 export type ProfileProps = ImageProps & {
-  size?: number;
+  size?: ProfileSize;
 };

--- a/client/src/components/Design/components/Profile/Profile.type.ts
+++ b/client/src/components/Design/components/Profile/Profile.type.ts
@@ -1,0 +1,5 @@
+import {ImageProps} from '../Image/Image';
+
+export type ProfileProps = ImageProps & {
+  size?: number;
+};

--- a/client/src/components/Loader/EventLoader.tsx
+++ b/client/src/components/Loader/EventLoader.tsx
@@ -1,4 +1,4 @@
-import {useQueries} from '@tanstack/react-query';
+import {useSuspenseQueries} from '@tanstack/react-query';
 import {useEffect} from 'react';
 
 import {requestGetEvent} from '@apis/request/event';
@@ -16,7 +16,7 @@ import QUERY_KEYS from '@constants/queryKeys';
 const EventLoader = ({children, ...props}: React.PropsWithChildren<WithErrorHandlingStrategy | null> = {}) => {
   const eventId = getEventIdByUrl();
 
-  const queries = useQueries({
+  const queries = useSuspenseQueries({
     queries: [
       {queryKey: [QUERY_KEYS.event], queryFn: () => requestGetEvent({eventId, ...props})},
       {
@@ -44,9 +44,7 @@ const EventLoader = ({children, ...props}: React.PropsWithChildren<WithErrorHand
     }
   }, [stepsData.data, stepsData.isSuccess, updateTotalExpenseAmount]);
 
-  const isLoading = queries.some(query => query.isLoading === true);
-
-  return !isLoading && children;
+  return children;
 };
 
 export default EventLoader;

--- a/client/src/components/ShareEventButton/DesktopShareEventButton.tsx
+++ b/client/src/components/ShareEventButton/DesktopShareEventButton.tsx
@@ -27,12 +27,10 @@ const DesktopShareEventButton = ({onCopy}: DesktopShareEventButtonProps) => {
   };
 
   return (
-    <div style={{marginRight: '1rem'}}>
-      <Dropdown base="button" baseButtonText="정산 초대하기">
-        <DropdownButton text="링크 복사하기" onClick={copyAndToast} />
-        <DropdownButton text="QR코드로 초대하기" onClick={navigateQRPage} />
-      </Dropdown>
-    </div>
+    <Dropdown base="button" baseButtonText="정산 초대하기">
+      <DropdownButton text="링크 복사하기" onClick={copyAndToast} />
+      <DropdownButton text="QR코드로 초대하기" onClick={navigateQRPage} />
+    </Dropdown>
   );
 };
 

--- a/client/src/components/ShareEventButton/MobileShareEventButton.tsx
+++ b/client/src/components/ShareEventButton/MobileShareEventButton.tsx
@@ -29,13 +29,11 @@ const MobileShareEventButton = ({copyShare, kakaoShare}: MobileShareEventButtonP
   };
 
   return (
-    <div style={{marginRight: '1rem'}}>
-      <Dropdown base="button" baseButtonText="정산 초대하기" onBaseButtonClick={initKakao}>
-        <DropdownButton text="링크 복사하기" onClick={copyAndToast} />
-        <DropdownButton text="QR코드로 초대하기" onClick={navigateQRPage} />
-        <DropdownButton text="카카오톡으로 초대하기" onClick={kakaoShare} />
-      </Dropdown>
-    </div>
+    <Dropdown base="button" baseButtonText="정산 초대하기" onBaseButtonClick={initKakao}>
+      <DropdownButton text="링크 복사하기" onClick={copyAndToast} />
+      <DropdownButton text="QR코드로 초대하기" onClick={navigateQRPage} />
+      <DropdownButton text="카카오톡으로 초대하기" onClick={kakaoShare} />
+    </Dropdown>
   );
 };
 

--- a/client/src/constants/queryKeys.ts
+++ b/client/src/constants/queryKeys.ts
@@ -8,6 +8,7 @@ const QUERY_KEYS = {
   images: 'images',
   kakaoClientId: 'kakao-client-id',
   kakaoLogin: 'kakao-login',
+  userInfo: 'userinfo',
 };
 
 export default QUERY_KEYS;

--- a/client/src/hooks/queries/user/useRequestGetUserInfo.ts
+++ b/client/src/hooks/queries/user/useRequestGetUserInfo.ts
@@ -1,0 +1,16 @@
+import {useSuspenseQuery} from '@tanstack/react-query';
+
+import {requestGetUserInfo} from '@apis/request/user';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+const useRequestGetUserInfo = () => {
+  const {data} = useSuspenseQuery({
+    queryKey: [QUERY_KEYS.userInfo],
+    queryFn: requestGetUserInfo,
+  });
+
+  return {userInfo: data};
+};
+
+export default useRequestGetUserInfo;

--- a/client/src/hooks/useEventPageLayout.ts
+++ b/client/src/hooks/useEventPageLayout.ts
@@ -6,6 +6,7 @@ import getEventIdByUrl from '@utils/getEventIdByUrl';
 import useRequestGetEvent from './queries/event/useRequestGetEvent';
 import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
 import useRequestGetSteps from './queries/step/useRequestGetSteps';
+import useRequestGetUserInfo from './queries/user/useRequestGetUserInfo';
 
 const useEventPageLayout = () => {
   const eventId = getEventIdByUrl();
@@ -14,6 +15,7 @@ const useEventPageLayout = () => {
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
   const {members} = useRequestGetAllMembers();
   const {steps} = useRequestGetSteps();
+  const {userInfo} = useRequestGetUserInfo();
   const billsCount = steps.flatMap(step => [...step.bills]).length;
 
   const event = {
@@ -21,6 +23,7 @@ const useEventPageLayout = () => {
     bankName,
     accountNumber,
     createdByGuest,
+    userInfo,
   };
 
   const eventSummary = {

--- a/client/src/pages/EventPage/EventPageFallback/EventPageLoading.tsx
+++ b/client/src/pages/EventPage/EventPageFallback/EventPageLoading.tsx
@@ -1,0 +1,23 @@
+import {Flex, Icon, IconButton, MainLayout, TopNav} from '@components/Design';
+import {Footer} from '@components/Footer';
+
+const EventPageLoading = () => {
+  return (
+    <MainLayout backgroundColor="gray">
+      <Flex justifyContent="spaceBetween" alignItems="center">
+        <TopNav>
+          <TopNav.Item routePath="/">
+            <IconButton variants="none">
+              <Icon iconType="heundeut" />
+            </IconButton>
+          </TopNav.Item>
+          <TopNav.Item displayName="홈" routePath="/home" />
+          <TopNav.Item displayName="관리" routePath="/admin" />
+        </TopNav>
+      </Flex>
+      <Footer />
+    </MainLayout>
+  );
+};
+
+export default EventPageLoading;

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -77,7 +77,7 @@ const EventPageLayout = () => {
           )}
           {isKakaoUser && (
             <Link to={ROUTER_URLS.myPage}>
-              <Profile src={event.userInfo.profileImage ?? getImageUrl('runningDog', 'png')} />
+              <Profile src={event.userInfo.profileImage ?? getImageUrl('runningDog', 'png')} size="medium" />
             </Link>
           )}
         </Flex>

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -1,7 +1,9 @@
 import type {Event} from 'types/serviceType';
 
-import {Outlet} from 'react-router-dom';
+import {Link, Outlet} from 'react-router-dom';
 import {useEffect} from 'react';
+
+import {Profile} from '@components/Design/components/Profile/Profile';
 
 import useEventPageLayout from '@hooks/useEventPageLayout';
 import useShareEvent from '@hooks/useShareEvent';
@@ -14,6 +16,9 @@ import {Flex, Icon, IconButton, MainLayout, TopNav} from '@HDesign/index';
 
 import {isMobileDevice} from '@utils/detectDevice';
 import {updateMetaTag} from '@utils/udpateMetaTag';
+import getImageUrl from '@utils/getImageUrl';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
 
 export type EventPageContextProps = Event & {
   isAdmin: boolean;
@@ -62,11 +67,16 @@ const EventPageLayout = () => {
           <TopNav.Item displayName="홈" routePath="/home" />
           <TopNav.Item displayName="관리" routePath="/admin" />
         </TopNav>
-        {isMobile ? (
-          <MobileShareEventButton copyShare={trackLinkShare} kakaoShare={trackKakaoShare} />
-        ) : (
-          <DesktopShareEventButton onCopy={trackLinkShare} />
-        )}
+        <Flex alignItems="center" gap="0.75rem" margin="0 1rem 0 0">
+          {isMobile ? (
+            <MobileShareEventButton copyShare={trackLinkShare} kakaoShare={trackKakaoShare} />
+          ) : (
+            <DesktopShareEventButton onCopy={trackLinkShare} />
+          )}
+          <Link to={ROUTER_URLS.myPage}>
+            <Profile src={getImageUrl('runningDog', 'png')} />
+          </Link>
+        </Flex>
       </Flex>
       <Outlet context={outletContext} />
       <Footer />

--- a/client/src/pages/EventPage/EventPageLayout.tsx
+++ b/client/src/pages/EventPage/EventPageLayout.tsx
@@ -55,6 +55,8 @@ const EventPageLayout = () => {
     };
   }, []);
 
+  const isKakaoUser = event.userInfo && event.userInfo.isGuest === false;
+
   return (
     <MainLayout backgroundColor="gray">
       <Flex justifyContent="spaceBetween" alignItems="center">
@@ -73,9 +75,11 @@ const EventPageLayout = () => {
           ) : (
             <DesktopShareEventButton onCopy={trackLinkShare} />
           )}
-          <Link to={ROUTER_URLS.myPage}>
-            <Profile src={getImageUrl('runningDog', 'png')} />
-          </Link>
+          {isKakaoUser && (
+            <Link to={ROUTER_URLS.myPage}>
+              <Profile src={event.userInfo.profileImage ?? getImageUrl('runningDog', 'png')} />
+            </Link>
+          )}
         </Flex>
       </Flex>
       <Outlet context={outletContext} />

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -33,6 +33,7 @@ const LoginPage = lazy(() => import('@pages/LoginPage'));
 const MyPage = lazy(() => import('@pages/MyPage'));
 const LoginRedirectPage = lazy(() => import('@pages/LoginPage/LoginRedirectPage'));
 const LoginFailFallback = lazy(() => import('@pages/LoginPage/LoginFailFallback'));
+const EventPageLoading = lazy(() => import('@pages/EventPage/EventPageFallback/EventPageLoading'));
 
 const router = createBrowserRouter([
   {
@@ -75,9 +76,11 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.event,
             element: (
-              <EventLoader>
-                <EventPage />
-              </EventLoader>
+              <Suspense fallback={<EventPageLoading />}>
+                <EventLoader>
+                  <EventPage />
+                </EventLoader>
+              </Suspense>
             ),
             children: [
               {

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -71,6 +71,8 @@ export type Event = BankAccount & {
 
 export type User = BankAccount & {
   nickname: Nickname;
+  isGuest: boolean;
+  profileImage: string | null;
 };
 
 export interface Report {


### PR DESCRIPTION
## issue
- close #849 

## 구현 사항
### Profile 디자인 컴포넌트 생성
Image 컴포넌트를 그대로 이용해서 구현해도 됐었지만, 프로필 이미지라는 것은 서비스의 성격을 띈다고 생각했습니다. 그래서 프로필의 스타일을 가진 (둥글고 사진이 들어가는) 디자인 컴포넌트를 제작하여 이용하도록 구성했습니다.

구현은 이미지 컴포넌트에 aria-label로 프로필 이미지를 의미하도록 설정해줬으며, 스타일을 적용해줬습니다.
size의 기본값은 28px으로 외부에서 이를 변경할 수 있도록 확장했습니다. 나머지 props는 ImageProps와 동일합니다.
```tsx
export const Profile = ({size = 28, ...profileProps}: ProfileProps) => {
  const {theme} = useTheme();

  return <Image aria-label="프로필 이미지" {...profileProps} css={profileContainerStyle(theme, size)} />;
};
```

![image](https://github.com/user-attachments/assets/29d3e9dd-564c-4600-b92b-535c50c44f77)


### 프로필 버튼을 클릭하면 마이페이지로 이동하도록 구현
이벤트 페이지에서 카카오 로그인 유저일 때 프로필이 보이도록 설정했으며, 이를 클릭할 때 제가 저번 pr에 퍼블리싱한 마이페이지가 보이도록 했습니다


### 카카오 유저인지 확인하여 프로필 버튼을 보여주는 기능
비회원/회원 여부, 닉네임, 카카오 이미지 정보를 조회할 수 있는 api(/api/users/mine)가 추가되었습니다. 
Get 메서드이며 User 타입(nickname, bankName, accountNumber)에 isGuest, profileImage가 추가된 응답을 받습니다.

profileImage 정보를 이용하여 프로필 이미지를 보여주며, 만일 이 값이 null일 경우 행댕이 이미지가 보이도록 설정했습니다.

```tsx
<Profile src={event.userInfo.profileImage ?? getImageUrl('runningDog', 'png')} />
```

* 이 기능을 구현하며 고민한 점
1. api 호출 위치
이 api는 이벤트에 한정되는 도메인이 아니라 서비스 전체의 성격을 띈다고 생각했습니다. 실제로 백엔드에서도 이벤트와 유저는 다른 성격으로 인지해서 이를 분리해서 관리하고 있습니다.
현재 EventLoader를 사용해서 Reports, Steps, AllMembers 데이터를 미리 불러와 놓고 있습니다. 여기에 추가하게 되면 간단하지만 이벤트로더는 이벤트와 관련된 api를 불러와야 한다고 판단하여 EventLoader가 아닌 내부에서 호출하기로 결정했습니다.

| ![Image 1](https://github.com/user-attachments/assets/d240839c-4d91-46ea-8f4e-15f278445299) | ![Image 2](https://github.com/user-attachments/assets/014891fe-88bf-4d6d-b1ee-a3556e57d9ef) |
|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|

2. api를 useQuery로 불러올지 useSuspense로 불러올 지에 대한 점
제가 생각하는 useSuspenseQuery를 사용해야 하는 경우를 두 가지로 정리해보겠습니다.
1) 데이터를 보장 받아야 할 필요가 있을 때
2) 선언적 로딩 화면을 보여주고 싶을 때

이 경우에는 사용자 경험을 위해서 데이터를 보장 받아야 할 필요가 있다고 판단했습니다.
조건부 렌더링을 사용하여 프로필 컴포넌트를 보여주고 있는데 여기서 값을 보장할 수 없다면 깜빡거리는 현상을 일으키기 때문입니다. 아래 useQuery를 적용할 경우, useSuspenseQuery를 적용할 경우에 대한 gif를 아래 비교 첨부하겠습니다.


| useQuery          |  useSuspenseQuery          |
|----------------------|----------------------|
| ![GIF 1](https://github.com/user-attachments/assets/8d435f59-a0d9-44c9-8614-c67b914903e2) | ![GIF 2](https://github.com/user-attachments/assets/ef1054fd-a26c-4d99-bb6a-bbd412c99dbb) |


### 이벤트 페이지 로딩 화면 설정
이벤트 로딩 화면을 보여주도록 설정했습니다. 이전에는 데이터를 불러올 때까지 흰 화면만 보여주게 되어 지금 데이터를 불러오고 있는 것인지, 아니면 경로가 잘못되어 이상한 화면을 보여주고 있는 것인지 인지하기 어려웠기 때문입니다.
그래서 이벤트 페이지의 일부라도 보여주어 지금 데이터를 불러오고 있는 중이라는 것을 알려주도록 변경했습니다.

여기서 EventLoader의 useQueries를 useSuspenseQueries로 변경했습니다. 그 이유는 위에서 설명한 2) 선언적 로딩 화면을 보여주고 싶을 때를 만족하기 때문입니다. 데이터를 불러오는 동안 대체로 보여줄 Fallback이 필요하고 이를 선언적으로 처리하기 위해 useSuspenseQueries로 변경했습니다.

그리고 라우터에서 Suspense 컴포넌트로 감싸서 Fallback을 보여주도록 했습니다.

* Fallback 화면을 구성하며 고민한 점
1) 헤더 정보를 어디까지 보여줄까?
이벤트 페이지 헤더에는 흔듯콘, 홈, 관리를 포함하는 TopNav와 초대하기, 프로필을 감싸는 두 구역으로 나뉘어있습니다.
Fallback이 보여진다는 것은 아직 이벤트 정보를 불러오고 있다는 중을 의미합니다. 그래서 이 때 초대하기나 프로필을 누르는 액션이 일어난다면 버그가 발생할 수 있다 생각했습니다. 그래서 헤더는 아래 사진대로 TopNav만 보이도록 했습니다.

```tsx
path: ROUTER_URLS.event,
element: (
<Suspense fallback={<EventPageLoading />}>
  <EventLoader>
    <EventPage />
  </EventLoader>
</Suspense>
),
```

| 이전          |  이후          |
|----------------------|----------------------|
| ![Image 1](https://github.com/user-attachments/assets/621a3337-ee0b-4ade-9841-8b7fd1957e3b) | ![Image 2](https://github.com/user-attachments/assets/78f5b615-c1fb-4000-85ec-a6a81edb2e49) |


## 중점적으로 리뷰받고 싶은 부분
이전에 로딩 중에 흰 화면이 보이는 것을 이제야 보완했어요.. 지금 방식 보다 더 나은 방식이 있다면? 아니면 더 나은 로딩 화면 디자인이 있다면 의견 주세요!

## 논의하고 싶은 부분
제가 생각하는 useSuspenseQuery의 사용 조건에 대해 공감하시는지 궁금합니다!
1) 데이터를 보장 받아야 할 필요가 있을 때
2) 선언적 로딩 화면을 보여주고 싶을 때

다른 의견이 있다면 코멘트로 남겨주세요

## 🫡 참고사항
