### PR TITLE
[FE] 생성한 행사 모아보기 페이지

### DIFF
--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -1,4 +1,4 @@
-import {Event, EventCreationData, EventId, EventName, User} from 'types/serviceType';
+import {CreatedEvents, Event, EventCreationData, EventId, EventName, User} from 'types/serviceType';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
 
 import {ADMIN_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
@@ -51,5 +51,11 @@ export const requestPatchUser = async (args: RequestPatchUser) => {
     body: {
       ...args,
     },
+  });
+};
+
+export const requestGetCreatedEvents = async () => {
+  return await requestGet<CreatedEvents>({
+    endpoint: `${USER_API_PREFIX}/mine`,
   });
 };

--- a/client/src/components/Design/components/ChipGroup/ChipGroup.tsx
+++ b/client/src/components/Design/components/ChipGroup/ChipGroup.tsx
@@ -18,7 +18,7 @@ const ChipGroup = ({color, texts}: Props) => {
   return (
     <div css={chipGroupStyle}>
       {texts.map(text => (
-        <Chip color={color} text={text} />
+        <Chip key={text} color={color} text={text} />
       ))}
     </div>
   );

--- a/client/src/components/Design/components/CreatedEvent/CreatedEvent.style.ts
+++ b/client/src/components/Design/components/CreatedEvent/CreatedEvent.style.ts
@@ -1,0 +1,19 @@
+import {css} from '@emotion/react';
+
+import {WithTheme} from '@components/Design/type/withTheme';
+
+export const inProgressCheckStyle = ({inProgress, theme}: WithTheme<{inProgress: boolean}>) =>
+  css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.125rem',
+    border: `1px solid ${inProgress ? theme.colors.primary : theme.colors.gray}`,
+    borderRadius: '0.5rem',
+    padding: '0.25rem 0.375rem',
+    height: '1.25rem',
+
+    '.in-progress-check-text': {
+      color: inProgress ? theme.colors.primary : theme.colors.gray,
+      paddingTop: '0.0625rem',
+    },
+  });

--- a/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
+++ b/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
@@ -36,8 +36,9 @@ function CreatedEventItem({createdEvent}: CreatedEventItemProps) {
       height="2.5rem"
       padding="0.5rem 1rem"
       paddingInline="0.5rem"
+      onClick={onClick}
     >
-      <Flex gap="0.5rem" alignItems="center" onClick={onClick}>
+      <Flex gap="0.5rem" alignItems="center">
         <InProgressCheck inProgress={createdEvent.isFinished} />
         <Text size="bodyBold" color="onTertiary">
           {createdEvent.eventName}

--- a/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
+++ b/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
@@ -1,0 +1,66 @@
+/** @jsxImportSource @emotion/react */
+import Text from '@HDcomponents/Text/Text';
+
+import Flex from '../Flex/Flex';
+import {CreatedEventItemProps, CreatedEventListProps} from './CreatedEvent.type';
+import {useNavigate} from 'react-router-dom';
+import Input from '../Input/Input';
+import {inProgressCheckStyle} from './CreatedEvent.style';
+import {useTheme} from '@components/Design';
+
+function InProgressCheck({inProgress}: {inProgress: boolean}) {
+  const {theme} = useTheme();
+
+  return (
+    <div css={inProgressCheckStyle({theme, inProgress})}>
+      <Text size="tiny" className="in-progress-check-text">
+        {inProgress ? '진행' : '완료'}
+      </Text>
+    </div>
+  );
+}
+
+function CreatedEventItem({createdEvent}: CreatedEventItemProps) {
+  const navigate = useNavigate();
+  const onClick = () => {
+    navigate(`/event/${createdEvent.eventId}/admin`);
+  };
+
+  return (
+    <Flex
+      justifyContent="spaceBetween"
+      alignItems="center"
+      height="2.5rem"
+      padding="0.5rem 1rem"
+      paddingInline="0.5rem"
+    >
+      <Flex gap="0.5rem" alignItems="center" onClick={onClick}>
+        <InProgressCheck inProgress={createdEvent.isFinished} />
+        <Text size="bodyBold" color="onTertiary">
+          {createdEvent.eventName}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+}
+
+function CreatedEventList({createdEvents, eventName, onSearch, placeholder}: CreatedEventListProps) {
+  return (
+    <Flex
+      flexDirection="column"
+      width="100%"
+      backgroundColor="white"
+      padding="0.5rem 1rem"
+      paddingInline="0.5rem"
+      gap="0.5rem"
+      height="100%"
+      cssProp={{borderRadius: '1rem'}}
+    >
+      <Input inputType="search" value={eventName} onChange={onSearch} placeholder={placeholder} />
+      {createdEvents.length !== 0 &&
+        createdEvents.map(createdEvent => <CreatedEventItem key={createdEvent.eventId} createdEvent={createdEvent} />)}
+    </Flex>
+  );
+}
+
+export default CreatedEventList;

--- a/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
+++ b/client/src/components/Design/components/CreatedEvent/CreatedEvent.tsx
@@ -1,12 +1,15 @@
 /** @jsxImportSource @emotion/react */
+import {useNavigate} from 'react-router-dom';
+
 import Text from '@HDcomponents/Text/Text';
 
-import Flex from '../Flex/Flex';
-import {CreatedEventItemProps, CreatedEventListProps} from './CreatedEvent.type';
-import {useNavigate} from 'react-router-dom';
-import Input from '../Input/Input';
-import {inProgressCheckStyle} from './CreatedEvent.style';
 import {useTheme} from '@components/Design';
+
+import Flex from '../Flex/Flex';
+import Input from '../Input/Input';
+
+import {CreatedEventItemProps, CreatedEventListProps} from './CreatedEvent.type';
+import {inProgressCheckStyle} from './CreatedEvent.style';
 
 function InProgressCheck({inProgress}: {inProgress: boolean}) {
   const {theme} = useTheme();

--- a/client/src/components/Design/components/CreatedEvent/CreatedEvent.type.ts
+++ b/client/src/components/Design/components/CreatedEvent/CreatedEvent.type.ts
@@ -1,0 +1,12 @@
+import {CreatedEvent} from './../../../../types/serviceType';
+
+export interface CreatedEventItemProps {
+  createdEvent: CreatedEvent;
+}
+
+export interface CreatedEventListProps {
+  eventName: string;
+  onSearch: ({target}: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  createdEvents: CreatedEvent[];
+}

--- a/client/src/constants/queryKeys.ts
+++ b/client/src/constants/queryKeys.ts
@@ -8,6 +8,7 @@ const QUERY_KEYS = {
   images: 'images',
   kakaoClientId: 'kakao-client-id',
   kakaoLogin: 'kakao-login',
+  createdEvents: 'createdEvents',
 };
 
 export default QUERY_KEYS;

--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -18,6 +18,7 @@ export const ROUTER_URLS = {
   event: EVENT,
   login: '/login',
   myPage: '/mypage',
+  createdEvents: '/mypage/events',
   guestEventLogin: `${EVENT_WITH_EVENT_ID}/admin/guest/login`,
   memberEventLogin: `${EVENT_WITH_EVENT_ID}/admin/member/login`,
   kakaoLoginRedirectUri: process.env.KAKAO_REDIRECT_URI,

--- a/client/src/hooks/queries/bill/useRequestGetBillDetails.ts
+++ b/client/src/hooks/queries/bill/useRequestGetBillDetails.ts
@@ -15,7 +15,7 @@ const useRequestGetBillDetails = ({billId, ...props}: WithErrorHandlingStrategy<
   const eventId = getEventIdByUrl();
 
   const {data, ...rest} = useQuery({
-    queryKey: [QUERY_KEYS.billDetails, billId],
+    queryKey: [QUERY_KEYS.billDetails, billId, eventId],
     queryFn: () => requestGetBillDetails({eventId, billId, ...props}),
   });
 

--- a/client/src/hooks/queries/event/useRequestGetCreatedEvents.ts
+++ b/client/src/hooks/queries/event/useRequestGetCreatedEvents.ts
@@ -8,10 +8,14 @@ const useRequestGetCreatedEvents = () => {
   const {data, ...rest} = useQuery({
     queryKey: [QUERY_KEYS.createdEvents],
     queryFn: () => requestGetCreatedEvents(),
+    select: data => ({
+      ...data,
+      events: data.events.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    }),
   });
 
   return {
-    events: data?.events.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    events: data?.events,
     ...rest,
   };
 };

--- a/client/src/hooks/queries/event/useRequestGetCreatedEvents.ts
+++ b/client/src/hooks/queries/event/useRequestGetCreatedEvents.ts
@@ -1,0 +1,19 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {requestGetCreatedEvents} from '@apis/request/event';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+const useRequestGetCreatedEvents = () => {
+  const {data, ...rest} = useQuery({
+    queryKey: [QUERY_KEYS.createdEvents],
+    queryFn: () => requestGetCreatedEvents(),
+  });
+
+  return {
+    events: data?.events.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    ...rest,
+  };
+};
+
+export default useRequestGetCreatedEvents;

--- a/client/src/hooks/queries/event/useRequestGetEvent.ts
+++ b/client/src/hooks/queries/event/useRequestGetEvent.ts
@@ -11,7 +11,7 @@ const useRequestGetEvent = ({...props}: WithErrorHandlingStrategy | null = {}) =
   const eventId = getEventIdByUrl();
 
   const {data, ...rest} = useSuspenseQuery({
-    queryKey: [QUERY_KEYS.event],
+    queryKey: [QUERY_KEYS.event, eventId],
     queryFn: () => requestGetEvent({eventId, ...props}),
   });
 

--- a/client/src/hooks/queries/member/useRequestGetAllMembers.ts
+++ b/client/src/hooks/queries/member/useRequestGetAllMembers.ts
@@ -11,7 +11,7 @@ const useRequestGetAllMembers = ({...props}: WithErrorHandlingStrategy | null = 
   const eventId = getEventIdByUrl();
 
   const {data, ...rest} = useQuery({
-    queryKey: [QUERY_KEYS.allMembers],
+    queryKey: [QUERY_KEYS.allMembers, eventId],
     queryFn: () => requestGetAllMembers({eventId, ...props}),
   });
 

--- a/client/src/hooks/queries/member/useRequestGetCurrentMembers.ts
+++ b/client/src/hooks/queries/member/useRequestGetCurrentMembers.ts
@@ -11,7 +11,7 @@ const useRequestGetCurrentMembers = ({...props}: WithErrorHandlingStrategy | nul
   const eventId = getEventIdByUrl();
 
   const {data, ...rest} = useQuery({
-    queryKey: [QUERY_KEYS.currentMembers],
+    queryKey: [QUERY_KEYS.currentMembers, eventId],
     queryFn: () => requestGetCurrentMembers({eventId, ...props}),
   });
 

--- a/client/src/hooks/queries/report/useRequestGetReports.ts
+++ b/client/src/hooks/queries/report/useRequestGetReports.ts
@@ -11,7 +11,7 @@ const useRequestGetReports = ({...props}: WithErrorHandlingStrategy | null = {})
   const eventId = getEventIdByUrl();
 
   const {data, ...rest} = useQuery({
-    queryKey: [QUERY_KEYS.reports],
+    queryKey: [QUERY_KEYS.reports, eventId],
     queryFn: () => requestGetReports({eventId, ...props}),
   });
 

--- a/client/src/hooks/queries/step/useRequestGetSteps.ts
+++ b/client/src/hooks/queries/step/useRequestGetSteps.ts
@@ -11,7 +11,7 @@ const useRequestGetSteps = ({...props}: WithErrorHandlingStrategy | null = {}) =
   const eventId = getEventIdByUrl();
 
   const queryResult = useQuery({
-    queryKey: [QUERY_KEYS.steps],
+    queryKey: [QUERY_KEYS.steps, eventId],
     queryFn: () => requestGetSteps({eventId, ...props}),
   });
 

--- a/client/src/pages/CreatedEventsPage/CreatedEventsPage.tsx
+++ b/client/src/pages/CreatedEventsPage/CreatedEventsPage.tsx
@@ -1,8 +1,10 @@
-import {MainLayout, Top, TopNav} from '@components/Design';
-import CreatedEventList from '@components/Design/components/CreatedEvent/CreatedEvent';
 import {css} from '@emotion/react';
-import useRequestGetCreatedEvents from '@hooks/queries/event/useRequestGetCreatedEvents';
 import {useEffect, useState} from 'react';
+
+import CreatedEventList from '@components/Design/components/CreatedEvent/CreatedEvent';
+import useRequestGetCreatedEvents from '@hooks/queries/event/useRequestGetCreatedEvents';
+
+import {MainLayout, Top, TopNav} from '@components/Design';
 
 export default function CreatedEventsPage() {
   const [eventName, setEventName] = useState('');

--- a/client/src/pages/CreatedEventsPage/CreatedEventsPage.tsx
+++ b/client/src/pages/CreatedEventsPage/CreatedEventsPage.tsx
@@ -1,0 +1,53 @@
+import {MainLayout, Top, TopNav} from '@components/Design';
+import CreatedEventList from '@components/Design/components/CreatedEvent/CreatedEvent';
+import {css} from '@emotion/react';
+import useRequestGetCreatedEvents from '@hooks/queries/event/useRequestGetCreatedEvents';
+import {useEffect, useState} from 'react';
+
+export default function CreatedEventsPage() {
+  const [eventName, setEventName] = useState('');
+  const {events} = useRequestGetCreatedEvents();
+  const [matchedEvents, setMatchedEvents] = useState(events);
+
+  useEffect(() => {
+    setMatchedEvents(events?.filter(event => event.eventName.includes(eventName)));
+  }, [eventName, events]);
+
+  const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEventName(e.target.value);
+  };
+
+  return (
+    <MainLayout backgroundColor="white">
+      <TopNav>
+        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
+      </TopNav>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="지금까지 주최했던 행사를" emphasize={['주최했던 행사']} />
+          <Top.Line text="확인해 보세요" />
+        </Top>
+      </div>
+      <div
+        css={css`
+          display: flex;
+          padding-inline: 0.5rem;
+        `}
+      >
+        <CreatedEventList
+          createdEvents={matchedEvents ?? []}
+          eventName={eventName}
+          onSearch={onSearch}
+          placeholder="행사 이름 검색"
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/client/src/pages/MyPage/index.tsx
+++ b/client/src/pages/MyPage/index.tsx
@@ -1,9 +1,11 @@
+import {useNavigate} from 'react-router-dom';
+
 import {Button, Flex, FunnelLayout, MainLayout, Text, TextButton, TopNav, useTheme} from '@components/Design';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
 
 import {mockImageStyle} from './MyPage.style';
 import Container from './Container';
-import {ROUTER_URLS} from '@constants/routerUrls';
-import {useNavigate} from 'react-router-dom';
 
 const MyPage = () => {
   const {theme} = useTheme();

--- a/client/src/pages/MyPage/index.tsx
+++ b/client/src/pages/MyPage/index.tsx
@@ -2,9 +2,12 @@ import {Button, Flex, FunnelLayout, MainLayout, Text, TextButton, TopNav, useThe
 
 import {mockImageStyle} from './MyPage.style';
 import Container from './Container';
+import {ROUTER_URLS} from '@constants/routerUrls';
+import {useNavigate} from 'react-router-dom';
 
 const MyPage = () => {
   const {theme} = useTheme();
+  const navigate = useNavigate();
 
   return (
     <MainLayout backgroundColor="gray">
@@ -33,7 +36,7 @@ const MyPage = () => {
             <TextButton textColor="onTertiary" textSize="body">
               기본 계좌 번호 설정하기
             </TextButton>
-            <TextButton textColor="onTertiary" textSize="body">
+            <TextButton textColor="onTertiary" textSize="body" onClick={() => navigate(ROUTER_URLS.createdEvents)}>
               내가 만든 행사 목록 보기
             </TextButton>
             <TextButton textColor="onTertiary" textSize="body">

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -33,6 +33,7 @@ const LoginPage = lazy(() => import('@pages/LoginPage'));
 const MyPage = lazy(() => import('@pages/MyPage'));
 const LoginRedirectPage = lazy(() => import('@pages/LoginPage/LoginRedirectPage'));
 const LoginFailFallback = lazy(() => import('@pages/LoginPage/LoginFailFallback'));
+const CreatedEventsPage = lazy(() => import('@pages/CreatedEventsPage/CreatedEventsPage'));
 
 const router = createBrowserRouter([
   {
@@ -134,6 +135,10 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.qrCode,
             element: <QRCodePage />,
+          },
+          {
+            path: ROUTER_URLS.createdEvents,
+            element: <CreatedEventsPage />,
           },
         ],
       },

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -92,3 +92,14 @@ export interface ImageFile {
   id: number;
   url: string;
 }
+
+export interface CreatedEvent {
+  eventId: string;
+  eventName: string;
+  isFinished: boolean;
+  createdAt: string;
+}
+
+export interface CreatedEvents {
+  events: CreatedEvent[];
+}


### PR DESCRIPTION
## issue
- close #854 

## 구현 목적
- 로그인 기능이 생긴 이후, 유저들이 지금까지 본인이 생성한 행사를 모아볼 수 있게 되었습니다.
- 사용자가 지금까지 정산을 진행한 페이지를 한눈에 모아볼 수 있도록 해당 페이지를 구현하여 제공합니다.

## 구현 사항
- route는 기존 @jinhokim98 이 구현한 `mypage`를 이용하여, `mypage/events` 로 정했습니다.
- 기존의 `EventHomePage`과 비슷한 UI, 기능들로 인하여 이를 참고하여 구현하였습니다.
- 피그마의 UX writing을 일부 수정하였습니다
- 기존 API는 오래된 것을 먼저 보여주지만, `useRequestGetCreatedEvents` hook 내부에서 data를 최신순으로 sort 하여 반환합니다.
![image](https://github.com/user-attachments/assets/94447985-f620-4430-ad7d-ef255b76d4f4)

- queryKey에 eventId 추가
- 기존 방식대로면, eventId가 변경되면서 다른 페이지에 접근해도, 기존의 요청 캐시로 인해 정보가 갱신되지 않았습니다. 이에 get 요청들의 query key에 eventId를 추가해 줌으로써, 페이지가 변경될 때 마다 새로 요청을 보내도록 변경했습니다.
- 개선 전

https://github.com/user-attachments/assets/aa8a5e9b-a9a5-430b-9a3f-09d9ed68ae27

- 개선 후

https://github.com/user-attachments/assets/3d35d099-8cc6-4125-986b-20e76d7b921b


## 논의하고 싶은 부분(선택)
### 1. Component 재사용성에 대한 논의
기존의 ExpenseList와 비슷한 UI라고 생각하여 이를 재사용하려 하였으나, 이 조차도`Event`엔티티에 깊게 결합되어있어 재사용할 수 없었습니다.
따라서, 비슷한 UI와 style 부분을 별도로 복사하여 작업하게 되었습니다.
계속 프로젝트가 진행될 때 마다, 이미 존재하는 디자인 요소를 그대로 사용함으로 인해서 확실히 생산성이 충분히 많이 향상되어 있다고 생각합니다.
하지만 반대로, 이와 같이 복사해서 사용하게 된다면 유지보수에 큰 어려움이 존재할 수 밖에 없다고 생각합니다.
앞으로 프로젝트를 얼마나 지속할지도, 디자인의 변경이 생겨 유지보수할 일도 예측이 불가능 하지만, 확실히 component들의 재사용성을 높여둔다면 지금까지 어느정도 필요한 component들이 모두 나온 상황에서 정말 최상의 재사용성을 유지할 수 있다고 생각합니다.

### 2.Page 폴더 디렉토리 및 route에 관한 논의
확실히 우리 서비스의 페이지가 많아지다 보니, 원하는 페이지 파일을 손쉽게 찾기 힘들어지고 있다고 느껴집니다.
`Pages` 디렉토리에 정말 많은 Page tsx 파일들이 있는데, 이를 route와 통일하여 논리적으로 쉽게 접근할 수 있는 방향을 함께 논의해보면 어떨까 싶습니다. 이런 작은 convention 하나하나가 모여 높은 생산성을 가진 협업의 기초가 되지 않을까 싶습니다...!
만약 논의가 되고 난 후, 새로운 페이지가 생기는 task를 가져갈 때, 해당 페이지의  route 및 directory를 함께 정하고 작업에 들어가도 좋을 것 같습니다!

### 결론
1. 많은 디자인 요소가 결정된 상황에서, 손쉬운 기능 추가 및 유지보수를 위해 component 재사용성을 높이고 싶다.
2. 쉬운 page 파일을 찾아내기 위해 `route path`, `/Page 디렉토리`, `page 파일 이름`에 대한 컨벤션을 정하고 싶다.

## 🫡 참고사항
