### PR TITLE
[FE] 로그인 상태라면 행사 생성시 로그인 페이지를 띄우지 않음

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,11 @@
 import {Outlet} from 'react-router-dom';
 import {Global} from '@emotion/react';
+import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 
 import AmplitudeInitializer from '@components/AmplitudeInitializer/AmplitudeInitializer';
+import ErrorCatcher from '@components/AppErrorBoundary/ErrorCatcher';
+import QueryClientBoundary from '@components/QueryClientBoundary/QueryClientBoundary';
+import ToastContainer from '@components/Toast/ToastContainer';
 
 import {HDesignProvider} from '@HDesign/index';
 
@@ -15,10 +19,16 @@ const App: React.FC = () => {
     <HDesignProvider>
       <UnPredictableErrorBoundary>
         <Global styles={GlobalStyle} />
-        <NetworkStateCatcher />
-        <AmplitudeInitializer>
-          <Outlet />
-        </AmplitudeInitializer>
+        <ErrorCatcher>
+          <QueryClientBoundary>
+            <ReactQueryDevtools initialIsOpen={false} />
+            <NetworkStateCatcher />
+            <ToastContainer />
+            <AmplitudeInitializer>
+              <Outlet />
+            </AmplitudeInitializer>
+          </QueryClientBoundary>
+        </ErrorCatcher>
       </UnPredictableErrorBoundary>
     </HDesignProvider>
   );

--- a/client/src/apis/endpointPrefix.ts
+++ b/client/src/apis/endpointPrefix.ts
@@ -1,3 +1,4 @@
 // TODO: (@weadie) 반복되서 쓰이는 이 api/events가 추후 수정 가능성이 있어서 일단 편집하기 편하게 이 변수를 재사용하도록 했습니다.
 export const USER_API_PREFIX = '/api/events';
 export const ADMIN_API_PREFIX = '/api/admin/events';
+export const MEMBER_API_PREFIX = '/api/users';

--- a/client/src/apis/request/auth.ts
+++ b/client/src/apis/request/auth.ts
@@ -1,5 +1,7 @@
+import {UserInfo} from 'types/serviceType';
+
 import {BASE_URL} from '@apis/baseUrl';
-import {ADMIN_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
+import {ADMIN_API_PREFIX, MEMBER_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
 import {requestGet, requestGetWithoutResponse, requestPostWithoutResponse} from '@apis/fetcher';
 import {WithEventId} from '@apis/withId.type';
 
@@ -41,4 +43,12 @@ export const requestGetKakaoLogin = async (code: string) => {
   });
 
   return null;
+};
+
+// 아직 안나온 api라 임의로 두었음
+export const requestGetUserInfo = async () => {
+  return await requestGet<UserInfo>({
+    baseUrl: BASE_URL.HD,
+    endpoint: `${MEMBER_API_PREFIX}/mine`,
+  });
 };

--- a/client/src/apis/request/auth.ts
+++ b/client/src/apis/request/auth.ts
@@ -45,10 +45,10 @@ export const requestGetKakaoLogin = async (code: string) => {
   return null;
 };
 
-// 아직 안나온 api라 임의로 두었음
 export const requestGetUserInfo = async () => {
   return await requestGet<UserInfo>({
     baseUrl: BASE_URL.HD,
     endpoint: `${MEMBER_API_PREFIX}/mine`,
+    errorHandlingStrategy: 'unsubscribe',
   });
 };

--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -1,7 +1,7 @@
 import {Event, EventCreationData, EventId, EventName, User} from 'types/serviceType';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
 
-import {ADMIN_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
+import {ADMIN_API_PREFIX, MEMBER_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
 import {requestGet, requestPatch, requestPostWithResponse} from '@apis/fetcher';
 import {WithEventId} from '@apis/withId.type';
 
@@ -47,7 +47,7 @@ export type RequestPatchUser = Partial<User>;
 
 export const requestPatchUser = async (args: RequestPatchUser) => {
   return requestPatch({
-    endpoint: `/api/users`,
+    endpoint: MEMBER_API_PREFIX,
     body: {
       ...args,
     },

--- a/client/src/components/QueryClientBoundary/QueryClientBoundary.tsx
+++ b/client/src/components/QueryClientBoundary/QueryClientBoundary.tsx
@@ -23,6 +23,7 @@ const QueryClientBoundary = ({children}: React.PropsWithChildren) => {
       onError: (error: Error) => {
         // errorBoundary로 처리해야하는 에러인 경우 updateAppError를 하지 못하도록 얼리리턴
         if (error instanceof RequestGetError && error.errorHandlingStrategy === 'errorBoundary') return;
+        if (error instanceof RequestGetError && error.errorHandlingStrategy === 'unsubscribe') return;
 
         updateAppError(error);
       },

--- a/client/src/constants/queryKeys.ts
+++ b/client/src/constants/queryKeys.ts
@@ -8,6 +8,7 @@ const QUERY_KEYS = {
   images: 'images',
   kakaoClientId: 'kakao-client-id',
   kakaoLogin: 'kakao-login',
+  userInfo: 'user-info',
 };
 
 export default QUERY_KEYS;

--- a/client/src/errors/RequestGetError.ts
+++ b/client/src/errors/RequestGetError.ts
@@ -1,7 +1,7 @@
 import RequestError from './RequestError';
 import {RequestErrorType} from './requestErrorType';
 
-type ErrorHandlingStrategy = 'toast' | 'errorBoundary';
+type ErrorHandlingStrategy = 'toast' | 'errorBoundary' | 'unsubscribe';
 
 export type WithErrorHandlingStrategy<P = unknown> = P & {
   errorHandlingStrategy?: ErrorHandlingStrategy;

--- a/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
+++ b/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
@@ -1,4 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
+import {useEffect} from 'react';
 
 import {requestGetUserInfo} from '@apis/request/auth';
 
@@ -10,6 +11,15 @@ const useRequestGetUserInfo = () => {
   const {data, ...rest} = useQuery({
     queryKey: [QUERY_KEYS.userInfo],
     queryFn: () => requestGetUserInfo(),
+    // quernFn은 ErrorCatcher 구독을 하지 않으며 오류가 났을 경우 로그인 화면을 띄워야하므로 initialData를 설정했습니다.
+    throwOnError: false,
+    initialData: {
+      isGuest: true,
+      nickname: '',
+      profileImage: '',
+      accountNumber: '',
+      bankName: '',
+    },
   });
 
   return {

--- a/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
+++ b/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
@@ -20,6 +20,7 @@ const useRequestGetUserInfo = () => {
       accountNumber: '',
       bankName: '',
     },
+    initialDataUpdatedAt: 0,
   });
 
   return {

--- a/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
+++ b/client/src/hooks/queries/auth/useRequestGetUserInfo.ts
@@ -1,0 +1,21 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {requestGetUserInfo} from '@apis/request/auth';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+export type UseRequestGetUserInfo = ReturnType<typeof useRequestGetUserInfo>;
+
+const useRequestGetUserInfo = () => {
+  const {data, ...rest} = useQuery({
+    queryKey: [QUERY_KEYS.userInfo],
+    queryFn: () => requestGetUserInfo(),
+  });
+
+  return {
+    ...data,
+    ...rest,
+  };
+};
+
+export default useRequestGetUserInfo;

--- a/client/src/mocks/handlers/authHandlers.ts
+++ b/client/src/mocks/handlers/authHandlers.ts
@@ -23,6 +23,19 @@ export const authHandler = [
     return new HttpResponse(null, {status: 200});
   }),
 
+  http.get(`${MOCK_API_PREFIX}/api/users/mine`, () => {
+    return HttpResponse.json(
+      {
+        nickname: '크리스마스',
+        isGuest: false,
+        profileImage: '',
+        bankName: '',
+        accountNumber: '',
+      },
+      {status: 200},
+    );
+  }),
+
   // POST /api/eventId/login (requestPostToken)
   http.post<{eventId: string}, {password: string}>(
     `${MOCK_API_PREFIX}${USER_API_PREFIX}/:eventId/login`,

--- a/client/src/pages/MainPage/MainPage.tsx
+++ b/client/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,7 @@
+import {useEffect} from 'react';
+
 import Image from '@components/Design/components/Image/Image';
+import useRequestGetUserInfo from '@hooks/queries/auth/useRequestGetUserInfo';
 
 import usePageBackground from '@hooks/usePageBackground';
 
@@ -13,10 +16,12 @@ import CreatorSection from './Section/CreatorSection/CreatorSection';
 
 const MainPage = () => {
   const {isVisible} = usePageBackground();
+  const {isGuest} = useRequestGetUserInfo();
+
   return (
     <div css={mainContainer}>
-      <Nav />
-      <MainSection />
+      <Nav isGuest={isGuest} />
+      <MainSection isGuest={isGuest} />
       <DescriptionSection />
       <FeatureSection />
       <CreatorSection />

--- a/client/src/pages/MainPage/Nav/Nav.tsx
+++ b/client/src/pages/MainPage/Nav/Nav.tsx
@@ -14,7 +14,7 @@ const Nav = ({isGuest}: NavProps) => {
   const navigate = useNavigate();
 
   const goLogin = () => {
-    navigate(isGuest ? ROUTER_URLS.createMemberEvent : ROUTER_URLS.login);
+    navigate(isGuest ? ROUTER_URLS.login : ROUTER_URLS.createMemberEvent);
   };
 
   return (

--- a/client/src/pages/MainPage/Nav/Nav.tsx
+++ b/client/src/pages/MainPage/Nav/Nav.tsx
@@ -1,16 +1,20 @@
 import {useNavigate} from 'react-router-dom';
 
+import {UseRequestGetUserInfo} from '@hooks/queries/auth/useRequestGetUserInfo';
+
 import {Button, Text, Icon, TopNav, IconButton} from '@HDesign/index';
 
 import {ROUTER_URLS} from '@constants/routerUrls';
 
 import {navFixedStyle, navStyle, navWrapperStyle} from './Nav.style';
 
-const Nav = () => {
+type NavProps = Pick<UseRequestGetUserInfo, 'isGuest'>;
+
+const Nav = ({isGuest}: NavProps) => {
   const navigate = useNavigate();
 
   const goLogin = () => {
-    navigate(ROUTER_URLS.login);
+    navigate(isGuest ? ROUTER_URLS.createMemberEvent : ROUTER_URLS.login);
   };
 
   return (

--- a/client/src/pages/MainPage/Section/MainSection/MainSection.tsx
+++ b/client/src/pages/MainPage/Section/MainSection/MainSection.tsx
@@ -2,6 +2,7 @@ import {useNavigate} from 'react-router-dom';
 
 import Button from '@HDesign/components/Button/Button';
 import Text from '@HDesign/components/Text/Text';
+import {UseRequestGetUserInfo} from '@hooks/queries/auth/useRequestGetUserInfo';
 
 import {Icon} from '@components/Design';
 
@@ -9,11 +10,13 @@ import {ROUTER_URLS} from '@constants/routerUrls';
 
 import {animateWithDelay, chevronStyle, mainSectionStyle, sectionStyle} from './MainSection.style';
 
-const MainSection = () => {
+type NavProps = Pick<UseRequestGetUserInfo, 'isGuest'>;
+
+const MainSection = ({isGuest}: NavProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(ROUTER_URLS.login);
+    navigate(isGuest ? ROUTER_URLS.createMemberEvent : ROUTER_URLS.login);
   };
 
   return (

--- a/client/src/pages/MainPage/Section/MainSection/MainSection.tsx
+++ b/client/src/pages/MainPage/Section/MainSection/MainSection.tsx
@@ -16,7 +16,7 @@ const MainSection = ({isGuest}: NavProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(isGuest ? ROUTER_URLS.createMemberEvent : ROUTER_URLS.login);
+    navigate(isGuest ? ROUTER_URLS.login : ROUTER_URLS.createMemberEvent);
   };
 
   return (

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -49,99 +49,94 @@ const router = createBrowserRouter([
         element: <MainPage />,
       },
       {
-        element: <EssentialQueryApp />,
+        path: ROUTER_URLS.createGuestEvent,
+        element: <CreateGuestEventFunnel />,
+      },
+      {
+        path: ROUTER_URLS.createMemberEvent,
+        element: <CreateMemberEventFunnel />,
+      },
+      {
+        path: ROUTER_URLS.login,
+        element: <LoginPage />,
+      },
+      {
+        path: ROUTER_URLS.myPage,
+        element: <MyPage />,
+      },
+      {
+        path: ROUTER_URLS.kakaoLoginRedirectUri,
+        element: <LoginRedirectPage />,
+        errorElement: <LoginFailFallback />,
+      },
+      {
+        path: ROUTER_URLS.event,
+        element: (
+          <EventLoader>
+            <EventPage />
+          </EventLoader>
+        ),
         children: [
           {
-            path: ROUTER_URLS.createGuestEvent,
-            element: <CreateGuestEventFunnel />,
-          },
-          {
-            path: ROUTER_URLS.createMemberEvent,
-            element: <CreateMemberEventFunnel />,
-          },
-          {
-            path: ROUTER_URLS.login,
-            element: <LoginPage />,
-          },
-          {
-            path: ROUTER_URLS.myPage,
-            element: <MyPage />,
-          },
-          {
-            path: ROUTER_URLS.kakaoLoginRedirectUri,
-            element: <LoginRedirectPage />,
-            errorElement: <LoginFailFallback />,
-          },
-          {
-            path: ROUTER_URLS.event,
+            path: ROUTER_URLS.eventManage,
             element: (
-              <EventLoader>
-                <EventPage />
-              </EventLoader>
+              <AuthGate>
+                <AdminPage />
+              </AuthGate>
             ),
-            children: [
-              {
-                path: ROUTER_URLS.eventManage,
-                element: (
-                  <AuthGate>
-                    <AdminPage />
-                  </AuthGate>
-                ),
-              },
-              {
-                path: ROUTER_URLS.home,
-                element: <HomePage />,
-              },
-              {
-                path: ROUTER_URLS.guestEventLogin,
-                element: <GuestEventLogin />,
-              },
-              {
-                path: ROUTER_URLS.memberEventLogin,
-                element: <MemberEventLogin />,
-              },
-            ],
           },
           {
-            path: ROUTER_URLS.addBill,
-            element: <AddBillFunnel />,
+            path: ROUTER_URLS.home,
+            element: <HomePage />,
           },
           {
-            path: ROUTER_URLS.member,
-            element: <EventMember />,
+            path: ROUTER_URLS.guestEventLogin,
+            element: <GuestEventLogin />,
           },
           {
-            path: ROUTER_URLS.editBill,
-            element: <EditBillPage />,
-          },
-          {
-            path: ROUTER_URLS.eventEdit,
-            element: <Account />,
-          },
-          {
-            path: ROUTER_URLS.images,
-            element: <ImagesPage />,
-          },
-          {
-            path: ROUTER_URLS.addImages,
-            element: <AddImagesPage />,
-          },
-          {
-            path: ROUTER_URLS.send,
-            element: <SendPage />,
-            errorElement: <SendErrorPage />,
-          },
-          {
-            path: ROUTER_URLS.qrCode,
-            element: <QRCodePage />,
+            path: ROUTER_URLS.memberEventLogin,
+            element: <MemberEventLogin />,
           },
         ],
       },
       {
-        path: '*',
-        element: <ErrorPage />,
+        path: ROUTER_URLS.addBill,
+        element: <AddBillFunnel />,
+      },
+      {
+        path: ROUTER_URLS.member,
+        element: <EventMember />,
+      },
+      {
+        path: ROUTER_URLS.editBill,
+        element: <EditBillPage />,
+      },
+      {
+        path: ROUTER_URLS.eventEdit,
+        element: <Account />,
+      },
+      {
+        path: ROUTER_URLS.images,
+        element: <ImagesPage />,
+      },
+      {
+        path: ROUTER_URLS.addImages,
+        element: <AddImagesPage />,
+      },
+      {
+        path: ROUTER_URLS.send,
+        element: <SendPage />,
+        errorElement: <SendErrorPage />,
+      },
+      {
+        path: ROUTER_URLS.qrCode,
+        element: <QRCodePage />,
       },
     ],
+  },
+  {
+    path: '*',
+    element: <ErrorPage />,
   },
 ]);
 

--- a/client/src/types/serviceType.ts
+++ b/client/src/types/serviceType.ts
@@ -92,3 +92,9 @@ export interface ImageFile {
   id: number;
   url: string;
 }
+
+export type UserInfo = BankAccount & {
+  nickname: string;
+  isGuest: boolean;
+  profileImage: string;
+};


### PR DESCRIPTION
# pr 수정 내용
1. isGuest가 반대로 되어 로그인 상황일 때 로그인 페이지가 뜨고, 로그인 상황이 아닐 때 로그인 페이지가 안뜨는 문제를 해결했습니다.
2. MainPage에서 호출하는 회원 정보 확인 api에서 오류 토스트가 뜨는 문제를 해결했습니다.
3. initialData와 initialDataUpdatedAt 을 사용해 회원 정보 확인 api에서 오류가 떴을 때도 정상적으로 플로우가 수행되도록 했습니다.

## 구현 사항
### 1. isGuest가 반대로 되어 로그인 상황일 때 로그인 페이지가 뜨고, 로그인 상황이 아닐 때 로그인 페이지가 안뜨는 문제를 해결했습니다.
```jsx
// 이전
    navigate(isGuest ? ROUTER_URLS.createMemberEvent : ROUTER_URLS.login);

// 이후
    navigate(isGuest ? ROUTER_URLS.login : ROUTER_URLS.createMemberEvent);
```

### 2. MainPage에서 호출하는 회원 정보 확인 api에서 오류 토스트가 뜨는 문제를 해결했습니다.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/131d83b6-465c-4c1f-90f5-48ad250271e8" />

이 pr이 반영된다면 로그인 상태가 아닌 채로 MainPage에 진입하면 `로그인 정보를 확인하는 api`에서 401 쿠키없음 에러를 받습니다. 그리고 이 에러가 에러 핸들러에서 처리가 되기 때문에 "로그인해야 이용할 수 있습니다"라고 토스트가 뜨는 문제가 있었습니다. 

`로그인 정보를 확인하는 api`에서는 쿠키가 없을 때 쿠키 없음 에러를 뱉지 않고 200에 리스폰스 바디에 에러코드로 분기해달라고 요청할 수도 있었으나, 백엔드 설계를 많이 바꿔야할 것 같아 다른 방법을 생각했습니다. 

해당 api에서 에러가 발생하는 경우는 쿠키가 없을 때 즉 비회원인 경우입니다. 에러의 발생 여부로 회원, 비회원을 판단하는 것입니다. 따라서 디폴트로 수행되는 에러 핸들러의 동작을 이 api에서는 막아줘야 합니다. 

그래서 커스텀 에러 객체의 errorHandlingStrategy에 'unsubscribe' 속성을 유니온에 추가하였고 이 속성을 사용하는 api일 경우 에러 핸들링이 되지 않도록 했습니다. 

### 3. initialData와 initialDataUpdatedAt 을 사용해 회원 정보 확인 api에서 오류가 떴을 때도 정상적으로 플로우가 수행되도록 했습니다.

에러 핸들링이 무시되었다면 기본적으로 api의 반환 값(캐싱되는 값)이 null로 남아있습니다. 그래서 initialData를 주어 에러가 났을 때에는 initialData를 주어 사용하고 에러가 안나서 무사히 fetch가 되었을 때는 받아온 정보의 isGuest를 사용하여 로그인 페이지 유무를 결정하도록 했습니다.

이때 initialData를 계속 사용하지 않도록 하려면 즉, 신선한 데이터를 사용하도록 api를 호출하도록 하려면  useQuery의 `initialDataUpdatedAt`이라는 속성을 지정해주어야 합니다. `initialDataUpdatedAt`은 간단하게 말하면 이 initialData가 언제 캐시되었느냐(fetch되었느냐)를 말합니다. 그래서 0으로 지정하면 이 initialData가 기본적으로 적용되있는 staleTime과 비교해 다시 fetch됩니다. 즉 initialData를 사용하는 경우인 `로그인 정보를 확인하는 api에서 오류가 났을 때`만 매번 다시 요청을 하고, initialData가 아닌 실제 데이터가 캐싱되어있을 때는 기본적으로 적용되어있는 staleTime을 사용하게 됩니다. 

staleTime을 0을 주는 방법도 있었으나 그러면 해당 api를 사용하는 다른 곳에서 캐싱 이득을 보지 못하기 때문에 initialDataUpdatedAt을 사용해봤습니다.

## issue
- close #855 

## 구현 목적
최근에 로그인 했다면 다시 로그인 페이지를 띄우지 않고 바로 행사 생성을 할 수 있도록 합니다. 

## 구현 사항
로그인 여부는 쿠키에 저장됩니다. 
다만 쿠키를 클라이언트가 확인할 수 없기 때문에, 로그인 여부가 포함된 `회원 정보 확인 api`를 호출해 로그인 여부를 확인합니다.

`회원 정보 확인 api`를 호출하는 시점은 "정산 시작하기"버튼을 눌렀을때로 하려다가,  api 호출이 오래걸리면 MainPage에 계속 머물러있는게 이상할 것 같아서 MainPage 진입 시 호출하도록 했습니다. 

이를 위해 현재 MainPage에서 tanstackquery호출이 안되도록 분리해놓았던 것을 예전대로 롤백시켜놓았습니다.

그리고 현재 회원 정보 확인 api가 나와있지 않은 상황이므로 msw를 사용하여 테스트했습니다.
