### PR TITLE
[FE] 회원탈퇴 페이지 퍼블리싱 및 api 연결

### DIFF
--- a/client/src/apis/endpointPrefix.ts
+++ b/client/src/apis/endpointPrefix.ts
@@ -1,3 +1,4 @@
 // TODO: (@weadie) 반복되서 쓰이는 이 api/events가 추후 수정 가능성이 있어서 일단 편집하기 편하게 이 변수를 재사용하도록 했습니다.
 export const USER_API_PREFIX = '/api/events';
 export const ADMIN_API_PREFIX = '/api/admin/events';
+export const MEMBER_API_PREFIX = '/api/users';

--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -1,7 +1,7 @@
 import {Event, EventCreationData, EventId, EventName, User} from 'types/serviceType';
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
 
-import {ADMIN_API_PREFIX, USER_API_PREFIX} from '@apis/endpointPrefix';
+import {ADMIN_API_PREFIX, USER_API_PREFIX, MEMBER_API_PREFIX} from '@apis/endpointPrefix';
 import {requestGet, requestPatch, requestPostWithResponse} from '@apis/fetcher';
 import {WithEventId} from '@apis/withId.type';
 
@@ -45,9 +45,10 @@ export const requestPatchEventName = async ({eventId, eventName}: RequestPatchEv
 
 export type RequestPatchUser = Partial<User>;
 
+// TODO: (@soha) 해당 요청은 user.ts 파일로 이동하는 건 어떨지?
 export const requestPatchUser = async (args: RequestPatchUser) => {
   return requestPatch({
-    endpoint: `/api/users`,
+    endpoint: MEMBER_API_PREFIX,
     body: {
       ...args,
     },

--- a/client/src/apis/request/user.ts
+++ b/client/src/apis/request/user.ts
@@ -1,0 +1,10 @@
+import {BASE_URL} from '@apis/baseUrl';
+import {MEMBER_API_PREFIX} from '@apis/endpointPrefix';
+import {requestDelete} from '@apis/fetcher';
+
+export const requestDeleteUser = async () => {
+  await requestDelete({
+    baseUrl: BASE_URL.HD,
+    endpoint: `${MEMBER_API_PREFIX}`,
+  });
+};

--- a/client/src/assets/image/check.svg
+++ b/client/src/assets/image/check.svg
@@ -1,3 +1,3 @@
-<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 3L4.5 8.5L2 6" stroke="#B575FF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 3.75L5.625 10.625L2.5 7.5" stroke="white" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/client/src/components/Design/components/Checkbox/Checkbox.stories.tsx
+++ b/client/src/components/Design/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,57 @@
+/** @jsxImportSource @emotion/react */
+import type {Meta, StoryObj} from '@storybook/react';
+
+import {useEffect, useState} from 'react';
+
+import Checkbox from './Checkbox';
+
+const meta = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    labelText: {
+      description: '',
+      control: {type: 'text'},
+    },
+    isChecked: {
+      description: '',
+      control: {type: 'boolean'},
+    },
+    onChange: {
+      description: '',
+      control: {type: 'object'},
+    },
+  },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    isChecked: false,
+    onChange: () => {},
+    labelText: '체크박스',
+  },
+  render: ({isChecked, onChange, labelText, ...args}) => {
+    const [isCheckedState, setIsCheckedState] = useState(isChecked);
+    const [labelTextState, setLabelTextState] = useState(labelText);
+
+    useEffect(() => {
+      setIsCheckedState(isChecked);
+      setLabelTextState(labelText);
+    }, [isChecked, labelText]);
+
+    const handleToggle = () => {
+      setIsCheckedState(!isCheckedState);
+      onChange();
+    };
+
+    return <Checkbox {...args} isChecked={isCheckedState} onChange={handleToggle} labelText={labelTextState} />;
+  },
+};

--- a/client/src/components/Design/components/Checkbox/Checkbox.style.ts
+++ b/client/src/components/Design/components/Checkbox/Checkbox.style.ts
@@ -1,0 +1,38 @@
+import {css} from '@emotion/react';
+
+import {WithTheme} from '@components/Design/type/withTheme';
+
+interface CheckboxStyleProps {
+  isChecked: boolean;
+}
+
+export const checkboxStyle = () =>
+  css({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: '0.75rem',
+    cursor: 'pointer',
+  });
+
+export const inputGroupStyle = ({theme, isChecked}: WithTheme<CheckboxStyleProps>) =>
+  css({
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+
+    '.check-icon': {
+      position: 'absolute',
+    },
+
+    '.checkbox-input': {
+      width: '1.375rem',
+      height: '1.375rem',
+      border: '1px solid',
+      borderRadius: '0.5rem',
+      borderColor: isChecked ? theme.colors.primary : theme.colors.tertiary,
+      backgroundColor: isChecked ? theme.colors.primary : theme.colors.white,
+    },
+  });

--- a/client/src/components/Design/components/Checkbox/Checkbox.tsx
+++ b/client/src/components/Design/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+import {useTheme} from '@components/Design/theme/HDesignProvider';
+
+import Text from '../Text/Text';
+import Icon from '../Icon/Icon';
+
+import {checkboxStyle, inputGroupStyle} from './Checkbox.style';
+
+interface Props {
+  labelText: string;
+  isChecked: boolean;
+  onChange: () => void;
+}
+
+const Checkbox = ({labelText, isChecked = false, onChange}: Props) => {
+  const {theme} = useTheme();
+  return (
+    <label css={checkboxStyle}>
+      <div css={inputGroupStyle({theme, isChecked})}>
+        {isChecked ? <Icon iconType="check" className="check-icon" /> : null}
+        <input type="checkbox" checked={isChecked} onChange={onChange} className="checkbox-input" />
+      </div>
+      <Text size="bodyBold">{labelText}</Text>
+    </label>
+  );
+};
+
+export default Checkbox;

--- a/client/src/components/Design/components/Icon/Icon.style.ts
+++ b/client/src/components/Design/components/Icon/Icon.style.ts
@@ -37,7 +37,11 @@ export const iconStyle = ({iconType, theme, iconColor}: IconStylePropsWithTheme)
 const getIconColor = ({iconType, theme, iconColor}: IconStylePropsWithTheme) => {
   if (iconColor) {
     return css({
-      color: theme.colors[iconColor as ColorKeys],
+      svg: {
+        path: {
+          stroke: theme.colors[iconColor as ColorKeys],
+        },
+      },
     });
   } else {
     return css({color: theme.colors[ICON_DEFAULT_COLOR[iconType]]});

--- a/client/src/components/Design/components/Textarea/Textarea.stories.tsx
+++ b/client/src/components/Design/components/Textarea/Textarea.stories.tsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource @emotion/react */
+import type {Meta, StoryObj} from '@storybook/react';
+
+import {useEffect, useState} from 'react';
+
+import Textarea from './Textarea';
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    // isFocus: {
+    //   description: '',
+    //   control: {type: 'boolean'},
+    // },
+    placeholder: {
+      description: '',
+      control: {type: 'text'},
+    },
+    maxLength: {
+      description: '',
+      control: {type: 'number'},
+    },
+
+    value: {
+      description: '',
+      control: {type: 'text'},
+    },
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    placeholder: '내용을 입력해주세요.',
+    maxLength: 100,
+    value: '',
+  },
+  render: ({placeholder, value, maxLength, ...args}) => {
+    const [placeholderState, setPlaceholderState] = useState(placeholder);
+    const [maxLengthState, setMaxLengthState] = useState(maxLength);
+    const [valueState, setValueState] = useState(value);
+
+    useEffect(() => {
+      setPlaceholderState(placeholder);
+      setMaxLengthState(maxLength);
+      setValueState(value);
+    }, [maxLength, placeholder, value]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setValueState(event.target.value);
+    };
+
+    return (
+      <Textarea
+        {...args}
+        value={valueState}
+        onChange={handleChange}
+        placeholder={placeholderState}
+        maxLength={maxLengthState}
+      />
+    );
+  },
+};

--- a/client/src/components/Design/components/Textarea/Textarea.stories.tsx
+++ b/client/src/components/Design/components/Textarea/Textarea.stories.tsx
@@ -13,10 +13,6 @@ const meta = {
     layout: 'centered',
   },
   argTypes: {
-    // isFocus: {
-    //   description: '',
-    //   control: {type: 'boolean'},
-    // },
     placeholder: {
       description: '',
       control: {type: 'text'},

--- a/client/src/components/Design/components/Textarea/Textarea.style.ts
+++ b/client/src/components/Design/components/Textarea/Textarea.style.ts
@@ -5,10 +5,11 @@ import {WithTheme} from '@components/Design/type/withTheme';
 import {inputBoxAnimationStyle} from '../Input/Input.style';
 
 interface Props {
+  height?: string;
   isFocus: boolean;
 }
 
-export const textareaStyle = ({theme, isFocus}: WithTheme<Props>) =>
+export const textareaStyle = ({theme, isFocus, height}: WithTheme<Props>) =>
   css(
     {
       backgroundColor: theme.colors.lightGrayContainer,
@@ -21,7 +22,7 @@ export const textareaStyle = ({theme, isFocus}: WithTheme<Props>) =>
       color: theme.colors.onTertiary,
 
       width: '100%',
-      height: '100%',
+      height: height ? height : '100%',
       '::placeholder': {
         color: theme.colors.gray,
       },

--- a/client/src/components/Design/components/Textarea/Textarea.style.ts
+++ b/client/src/components/Design/components/Textarea/Textarea.style.ts
@@ -1,0 +1,31 @@
+import {css} from '@emotion/react';
+
+import {WithTheme} from '@components/Design/type/withTheme';
+
+import {inputBoxAnimationStyle} from '../Input/Input.style';
+
+interface Props {
+  isFocus: boolean;
+}
+
+export const textareaStyle = ({theme, isFocus}: WithTheme<Props>) =>
+  css(
+    {
+      backgroundColor: theme.colors.lightGrayContainer,
+      border: '1px solid',
+      borderColor: isFocus ? theme.colors.primary : theme.colors.lightGrayContainer,
+      borderRadius: '1rem',
+      padding: '12px',
+      overflowWrap: 'break-word',
+      whiteSpace: 'pre-wrap',
+      color: theme.colors.onTertiary,
+
+      width: '100%',
+      height: '100%',
+      '::placeholder': {
+        color: theme.colors.gray,
+      },
+    },
+    theme.typography.body,
+    inputBoxAnimationStyle(),
+  );

--- a/client/src/components/Design/components/Textarea/Textarea.tsx
+++ b/client/src/components/Design/components/Textarea/Textarea.tsx
@@ -7,7 +7,7 @@ import {textareaStyle} from './Textarea.style';
 import {TextareaProps} from './Textarea.type';
 
 const Textarea: React.FC<TextareaProps> = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textrea(
-  {placeholder, maxLength, onChange, value, ...htmlProps}: TextareaProps,
+  {placeholder, maxLength, onChange, value, height, ...htmlProps}: TextareaProps,
   ref,
 ) {
   const {theme} = useTheme();
@@ -32,7 +32,7 @@ const Textarea: React.FC<TextareaProps> = forwardRef<HTMLTextAreaElement, Textar
       onChange={onChange}
       value={value}
       ref={inputRef}
-      css={textareaStyle({theme, isFocus})}
+      css={textareaStyle({theme, isFocus, height})}
       {...htmlProps}
     ></textarea>
   );

--- a/client/src/components/Design/components/Textarea/Textarea.tsx
+++ b/client/src/components/Design/components/Textarea/Textarea.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @emotion/react */
+import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
+
+import {useTheme} from '@components/Design/theme/HDesignProvider';
+
+import {textareaStyle} from './Textarea.style';
+import {TextareaProps} from './Textarea.type';
+
+const Textarea: React.FC<TextareaProps> = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textrea(
+  {placeholder, maxLength, onChange, value, ...htmlProps}: TextareaProps,
+  ref,
+) {
+  const {theme} = useTheme();
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [isFocus, setIsFocus] = useState(false);
+
+  useImperativeHandle(ref, () => inputRef.current!);
+
+  useEffect(() => {
+    inputRef.current?.addEventListener('focus', () => setIsFocus(true));
+    inputRef.current?.addEventListener('blur', () => setIsFocus(false));
+    return () => {
+      inputRef.current?.removeEventListener('focus', () => setIsFocus(true));
+      inputRef.current?.removeEventListener('blur', () => setIsFocus(false));
+    };
+  }, []);
+
+  return (
+    <textarea
+      maxLength={maxLength}
+      placeholder={placeholder}
+      onChange={onChange}
+      value={value}
+      ref={inputRef}
+      css={textareaStyle({theme, isFocus})}
+      {...htmlProps}
+    ></textarea>
+  );
+});
+export default Textarea;

--- a/client/src/components/Design/components/Textarea/Textarea.type.ts
+++ b/client/src/components/Design/components/Textarea/Textarea.type.ts
@@ -1,0 +1,13 @@
+export interface TextareaStyleProps {}
+
+export interface TextareaCustomProps {
+  // isFocus: boolean;
+  // onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string;
+  maxLength?: number;
+  placeholder?: string;
+}
+
+export type TextareaOptionProps = TextareaStyleProps & TextareaCustomProps;
+
+export type TextareaProps = React.ComponentProps<'textarea'> & TextareaOptionProps;

--- a/client/src/components/Design/components/Textarea/Textarea.type.ts
+++ b/client/src/components/Design/components/Textarea/Textarea.type.ts
@@ -1,8 +1,8 @@
-export interface TextareaStyleProps {}
+export interface TextareaStyleProps {
+  height?: string;
+}
 
 export interface TextareaCustomProps {
-  // isFocus: boolean;
-  // onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   value: string;
   maxLength?: number;
   placeholder?: string;

--- a/client/src/components/Design/index.tsx
+++ b/client/src/components/Design/index.tsx
@@ -24,6 +24,8 @@ import DepositToggle from './components/DepositToggle/DepositToggle';
 import Amount from './components/Amount/Amount';
 import Dropdown from './components/Dropdown/Dropdown';
 import DropdownButton from './components/Dropdown/DropdownButton';
+import Checkbox from './components/Checkbox/Checkbox';
+import Textarea from './components/Textarea/Textarea';
 import {Select} from './components/Select';
 
 export {
@@ -55,4 +57,6 @@ export {
   DropdownButton,
   useTheme,
   Select,
+  Checkbox,
+  Textarea,
 };

--- a/client/src/components/Logo/StandingDogLogo.tsx
+++ b/client/src/components/Logo/StandingDogLogo.tsx
@@ -2,12 +2,16 @@ import Image from '@components/Design/components/Image/Image';
 
 import getImageUrl from '@utils/getImageUrl';
 
-import {logoStyle} from './Logo.style';
+import {logoStyle, logoImageStyle} from './Logo.style';
 
 const StandingDogLogo = () => {
   return (
     <div css={logoStyle}>
-      <Image src={getImageUrl('standingDog', 'webp')} fallbackSrc={getImageUrl('standingDog', 'png')} />
+      <Image
+        src={getImageUrl('standingDog', 'webp')}
+        fallbackSrc={getImageUrl('standingDog', 'png')}
+        css={logoImageStyle}
+      />
     </div>
   );
 };

--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -18,6 +18,7 @@ export const ROUTER_URLS = {
   event: EVENT,
   login: '/login',
   myPage: '/mypage',
+  withdraw: '/mypage/withdraw',
   guestEventLogin: `${EVENT_WITH_EVENT_ID}/admin/guest/login`,
   memberEventLogin: `${EVENT_WITH_EVENT_ID}/admin/member/login`,
   kakaoLoginRedirectUri: process.env.KAKAO_REDIRECT_URI,

--- a/client/src/hooks/queries/user/useRequestDeleteUser.ts
+++ b/client/src/hooks/queries/user/useRequestDeleteUser.ts
@@ -1,0 +1,21 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+
+import {requestDeleteUser} from '@apis/request/user';
+
+import QUERY_KEYS from '@constants/queryKeys';
+
+const useRequestDeleteUser = () => {
+  const queryClient = useQueryClient();
+
+  const {mutateAsync, ...rest} = useMutation({
+    mutationFn: () => requestDeleteUser(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.kakaoLogin]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.kakaoClientId]});
+    },
+  });
+
+  return {deleteAsyncUser: mutateAsync, ...rest};
+};
+
+export default useRequestDeleteUser;

--- a/client/src/hooks/useWithdrawFunnel.ts
+++ b/client/src/hooks/useWithdrawFunnel.ts
@@ -1,0 +1,28 @@
+import {useEffect, useState} from 'react';
+
+export type WithdrawStep =
+  | 'withdrawReason'
+  | 'notUseService'
+  | 'unableToUseDueToError'
+  | 'cantFigureOutHowToUseIt'
+  | 'etc'
+  | 'checkBeforeWithdrawing'
+  | 'withdrawalCompleted';
+
+const useWithdrawFunnel = () => {
+  const [step, setStep] = useState<WithdrawStep>('withdrawReason');
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, []);
+
+  const handleMoveStep = (nextStep: WithdrawStep) => setStep(nextStep);
+
+  return {step, handleMoveStep};
+};
+
+export default useWithdrawFunnel;

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -1,0 +1,20 @@
+import useWithdrawFunnel from '@hooks/useWithdrawFunnel';
+
+import {MainLayout, TopNav} from '@components/Design';
+
+import ReasonStep from './steps/ReasonStep';
+
+const WithdrawPage = () => {
+  const {step, handleMoveStep} = useWithdrawFunnel();
+
+  return (
+    <MainLayout backgroundColor="white">
+      <TopNav>
+        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
+      </TopNav>
+      {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
+    </MainLayout>
+  );
+};
+
+export default WithdrawPage;

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -5,6 +5,7 @@ import {MainLayout, TopNav} from '@components/Design';
 import ReasonStep from './steps/ReasonStep';
 import NotUseServiceStep from './steps/NotUseServiceStep';
 import EtcStep from './steps/EtcStep';
+import CheckBeforeWithdrawingStep from './steps/CheckBeforeWithdrawingStep';
 
 const WithdrawPage = () => {
   const {step, handleMoveStep} = useWithdrawFunnel();
@@ -17,6 +18,7 @@ const WithdrawPage = () => {
       {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
       {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}
       {step === 'etc' && <EtcStep handleMoveStep={handleMoveStep} />}
+      {step === 'checkBeforeWithdrawing' && <CheckBeforeWithdrawingStep handleMoveStep={handleMoveStep} />}
     </MainLayout>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -7,6 +7,7 @@ import NotUseServiceStep from './steps/NotUseServiceStep';
 import EtcStep from './steps/EtcStep';
 import CheckBeforeWithdrawingStep from './steps/CheckBeforeWithdrawingStep';
 import WithdrawalCompleted from './steps/WithdrawalCompleted';
+import UnableToUseDueToError from './steps/UnableToUseDueToError';
 
 const WithdrawPage = () => {
   const {step, handleMoveStep} = useWithdrawFunnel();
@@ -18,6 +19,7 @@ const WithdrawPage = () => {
       </TopNav>
       {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
       {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}
+      {step === 'unableToUseDueToError' && <UnableToUseDueToError handleMoveStep={handleMoveStep} />}
       {step === 'etc' && <EtcStep handleMoveStep={handleMoveStep} />}
       {step === 'checkBeforeWithdrawing' && <CheckBeforeWithdrawingStep handleMoveStep={handleMoveStep} />}
       {step === 'withdrawalCompleted' && <WithdrawalCompleted />}

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -3,6 +3,7 @@ import useWithdrawFunnel from '@hooks/useWithdrawFunnel';
 import {MainLayout, TopNav} from '@components/Design';
 
 import ReasonStep from './steps/ReasonStep';
+import NotUseServiceStep from './steps/NotUseServiceStep';
 
 const WithdrawPage = () => {
   const {step, handleMoveStep} = useWithdrawFunnel();
@@ -13,6 +14,7 @@ const WithdrawPage = () => {
         <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
       </TopNav>
       {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
+      {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}
     </MainLayout>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -4,6 +4,7 @@ import {MainLayout, TopNav} from '@components/Design';
 
 import ReasonStep from './steps/ReasonStep';
 import NotUseServiceStep from './steps/NotUseServiceStep';
+import EtcStep from './steps/EtcStep';
 
 const WithdrawPage = () => {
   const {step, handleMoveStep} = useWithdrawFunnel();
@@ -15,6 +16,7 @@ const WithdrawPage = () => {
       </TopNav>
       {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
       {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}
+      {step === 'etc' && <EtcStep handleMoveStep={handleMoveStep} />}
     </MainLayout>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/WithdrawPage.tsx
@@ -6,6 +6,7 @@ import ReasonStep from './steps/ReasonStep';
 import NotUseServiceStep from './steps/NotUseServiceStep';
 import EtcStep from './steps/EtcStep';
 import CheckBeforeWithdrawingStep from './steps/CheckBeforeWithdrawingStep';
+import WithdrawalCompleted from './steps/WithdrawalCompleted';
 
 const WithdrawPage = () => {
   const {step, handleMoveStep} = useWithdrawFunnel();
@@ -19,6 +20,7 @@ const WithdrawPage = () => {
       {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}
       {step === 'etc' && <EtcStep handleMoveStep={handleMoveStep} />}
       {step === 'checkBeforeWithdrawing' && <CheckBeforeWithdrawingStep handleMoveStep={handleMoveStep} />}
+      {step === 'withdrawalCompleted' && <WithdrawalCompleted />}
     </MainLayout>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
@@ -28,7 +28,7 @@ const CheckBeforeWithdrawingStep = ({handleMoveStep}: {handleMoveStep: (nextStep
         </Flex>
         <StandingDogLogo />
       </div>
-      <FixedButton onClick={() => handleMoveStep('checkBeforeWithdrawing')}>탈퇴하기</FixedButton>
+      <FixedButton onClick={() => handleMoveStep('withdrawalCompleted')}>탈퇴하기</FixedButton>
     </>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
@@ -1,12 +1,27 @@
 import {css} from '@emotion/react';
 
 import StandingDogLogo from '@components/Logo/StandingDogLogo';
+import useRequestDeleteUser from '@hooks/queries/user/useRequestDeleteUser';
+import toast from '@hooks/useToast/toast';
 
 import {WithdrawStep} from '@hooks/useWithdrawFunnel';
 
 import {Top, FixedButton, Flex, Text} from '@components/Design';
 
 const CheckBeforeWithdrawingStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  const {deleteAsyncUser} = useRequestDeleteUser();
+
+  const handleWithdraw = async () => {
+    try {
+      await deleteAsyncUser();
+      handleMoveStep('withdrawalCompleted');
+    } catch (error) {
+      toast.error('회원 탈퇴에 실패했어요.', {
+        showingTime: 3000,
+        position: 'bottom',
+      });
+    }
+  };
   return (
     <>
       <div
@@ -28,7 +43,7 @@ const CheckBeforeWithdrawingStep = ({handleMoveStep}: {handleMoveStep: (nextStep
         </Flex>
         <StandingDogLogo />
       </div>
-      <FixedButton onClick={() => handleMoveStep('withdrawalCompleted')}>탈퇴하기</FixedButton>
+      <FixedButton onClick={handleWithdraw}>탈퇴하기</FixedButton>
     </>
   );
 };

--- a/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/CheckBeforeWithdrawingStep.tsx
@@ -1,0 +1,36 @@
+import {css} from '@emotion/react';
+
+import StandingDogLogo from '@components/Logo/StandingDogLogo';
+
+import {WithdrawStep} from '@hooks/useWithdrawFunnel';
+
+import {Top, FixedButton, Flex, Text} from '@components/Design';
+
+const CheckBeforeWithdrawingStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="탈퇴하기 전에 확인해주세요" emphasize={['탈퇴하기 전에 확인해주세요']} />
+        </Top>
+
+        <Flex flexDirection="column" gap="0.5rem">
+          <Text textColor="onTertiary">• 행동대장에서 관리했던 __님의 모든 개인정보를 다시 볼 수 없어요.</Text>
+          <Text textColor="onTertiary">• 지난 행사 목록이 모두 사라져요.</Text>
+          <Text textColor="onTertiary">• 개인 정보는 즉시 파기돼요.</Text>
+        </Flex>
+        <StandingDogLogo />
+      </div>
+      <FixedButton onClick={() => handleMoveStep('checkBeforeWithdrawing')}>탈퇴하기</FixedButton>
+    </>
+  );
+};
+
+export default CheckBeforeWithdrawingStep;

--- a/client/src/pages/MyPage/WithdrawPage/steps/EtcStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/EtcStep.tsx
@@ -1,0 +1,37 @@
+import {css} from '@emotion/react';
+
+import {WithdrawStep} from '@hooks/useWithdrawFunnel';
+
+import {Top, Textarea, FixedButton, Flex} from '@components/Design';
+
+const EtcStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="더 나은 행동대장이" emphasize={['더 나은 행동대장']} />
+          <Top.Line text="될 수 있도록 의견을 들려주세요" emphasize={['의견']} />
+        </Top>
+
+        <Flex flexDirection="column" gap="1rem">
+          <Textarea value={''} placeholder="내용을 입력해주세요." maxLength={300} height="275px" />
+        </Flex>
+      </div>
+      <FixedButton
+        onClick={() => handleMoveStep('checkBeforeWithdrawing')}
+        onBackClick={() => handleMoveStep('withdrawReason')}
+      >
+        탈퇴하기
+      </FixedButton>
+    </>
+  );
+};
+
+export default EtcStep;

--- a/client/src/pages/MyPage/WithdrawPage/steps/EtcStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/EtcStep.tsx
@@ -24,6 +24,7 @@ const EtcStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => 
           <Textarea value={''} placeholder="내용을 입력해주세요." maxLength={300} height="275px" />
         </Flex>
       </div>
+      {/* TODO: (@soha) 1글자라도 작성해야 탈퇴하기 버튼 활성화 */}
       <FixedButton
         onClick={() => handleMoveStep('checkBeforeWithdrawing')}
         onBackClick={() => handleMoveStep('withdrawReason')}

--- a/client/src/pages/MyPage/WithdrawPage/steps/NotUseServiceStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/NotUseServiceStep.tsx
@@ -29,6 +29,7 @@ const NotUseServiceStep = ({handleMoveStep}: {handleMoveStep: (nextStep: Withdra
           <Checkbox isChecked={false} onChange={() => {}} labelText="기타" />
         </Flex>
       </div>
+      {/* TODO: (@soha) checkbox를 하나라도 해야 탈퇴하기 버튼 활성화 */}
       <FixedButton
         onClick={() => handleMoveStep('checkBeforeWithdrawing')}
         onBackClick={() => handleMoveStep('withdrawReason')}

--- a/client/src/pages/MyPage/WithdrawPage/steps/NotUseServiceStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/NotUseServiceStep.tsx
@@ -1,0 +1,42 @@
+import {css} from '@emotion/react';
+
+import {WithdrawStep} from '@hooks/useWithdrawFunnel';
+
+import {Top, Checkbox, FixedButton, Flex} from '@components/Design';
+
+const NotUseServiceStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="행동대장을" />
+          <Top.Line text="사용하지 않는 이유는 무엇인가요?" emphasize={['사용하지 않는 이유']} />
+        </Top>
+
+        <Flex flexDirection="column" gap="1rem">
+          {/* TODO: (@soha) 백엔드와 어떻게 관리할 지 논의 후에 기능(hook) 추가 예정 */}
+          <Checkbox isChecked={false} onChange={() => {}} labelText="예상했던 서비스가 아님" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="디자인이 별로임" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="사용하기 불편함" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="원하는 기능이 없음" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="기타" />
+        </Flex>
+      </div>
+      <FixedButton
+        onClick={() => handleMoveStep('checkBeforeWithdrawing')}
+        onBackClick={() => handleMoveStep('withdrawReason')}
+      >
+        탈퇴하기
+      </FixedButton>
+    </>
+  );
+};
+
+export default NotUseServiceStep;

--- a/client/src/pages/MyPage/WithdrawPage/steps/ReasonStep.style.ts
+++ b/client/src/pages/MyPage/WithdrawPage/steps/ReasonStep.style.ts
@@ -1,0 +1,17 @@
+import {css} from '@emotion/react';
+
+export const stepButtonBoxStyle = () =>
+  css({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    cursor: 'pointer',
+  });
+
+export const stepButtonGroupStyle = () =>
+  css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+  });

--- a/client/src/pages/MyPage/WithdrawPage/steps/ReasonStep.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/ReasonStep.tsx
@@ -1,0 +1,54 @@
+import {css} from '@emotion/react';
+
+import {WithdrawStep} from '@hooks/useWithdrawFunnel';
+
+import {Top, Icon, Text} from '@components/Design';
+
+import {stepButtonGroupStyle, stepButtonBoxStyle} from './ReasonStep.style';
+
+const ReasonStep = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="행동대장을" />
+          <Top.Line text="탈퇴하는 이유가 무엇인가요?" emphasize={['탈퇴하는 이유']} />
+        </Top>
+        <div css={stepButtonGroupStyle}>
+          <StepButton stepText="사용하지 않는 서비스에요" nextStep={() => handleMoveStep('notUseService')} />
+          <StepButton stepText="오류가 생겨서 쓸 수 없어요" nextStep={() => handleMoveStep('unableToUseDueToError')} />
+          <StepButton
+            stepText="서비스 사용 방법을 모르겠어요"
+            nextStep={() => handleMoveStep('cantFigureOutHowToUseIt')}
+          />
+          <StepButton stepText="기타" nextStep={() => handleMoveStep('etc')} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface StepButtonProps {
+  stepText: string;
+  nextStep: () => void;
+}
+
+const StepButton = ({stepText, nextStep}: StepButtonProps) => {
+  return (
+    <div css={stepButtonBoxStyle} onClick={nextStep}>
+      <Text size="bodyBold" textColor="onTertiary">
+        {stepText}
+      </Text>
+      <Icon iconType="rightChevron" />
+    </div>
+  );
+};
+
+export default ReasonStep;

--- a/client/src/pages/MyPage/WithdrawPage/steps/UnableToUseDueToError.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/UnableToUseDueToError.tsx
@@ -1,0 +1,42 @@
+import {css} from '@emotion/react';
+
+import {WithdrawStep} from '@hooks/useWithdrawFunnel';
+
+import {Top, Checkbox, FixedButton, Flex} from '@components/Design';
+
+const UnableToUseDueToError = ({handleMoveStep}: {handleMoveStep: (nextStep: WithdrawStep) => void}) => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="어떤 오류가 발생했나요?" emphasize={['오류']} />
+        </Top>
+
+        <Flex flexDirection="column" gap="1rem">
+          {/* TODO: (@soha) 백엔드와 어떻게 관리할 지 논의 후에 기능(hook) 추가 예정 */}
+          <Checkbox isChecked={false} onChange={() => {}} labelText="행사 생성" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="지출 내역 추가" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="정산 초대하기" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="관리자에게 송금" />
+          <Checkbox isChecked={false} onChange={() => {}} labelText="기타" />
+        </Flex>
+      </div>
+      {/* TODO: (@soha) checkbox를 하나라도 해야 탈퇴하기 버튼 활성화 */}
+      <FixedButton
+        onClick={() => handleMoveStep('checkBeforeWithdrawing')}
+        onBackClick={() => handleMoveStep('withdrawReason')}
+      >
+        탈퇴하기
+      </FixedButton>
+    </>
+  );
+};
+
+export default UnableToUseDueToError;

--- a/client/src/pages/MyPage/WithdrawPage/steps/WithdrawalCompleted.tsx
+++ b/client/src/pages/MyPage/WithdrawPage/steps/WithdrawalCompleted.tsx
@@ -1,0 +1,34 @@
+import {css} from '@emotion/react';
+
+import RunningDogLogo from '@components/Logo/RunningDogLogo';
+
+import {Top, FixedButton, Flex, Text} from '@components/Design';
+
+const WithdrawalCompleted = () => {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          padding: 1rem;
+        `}
+      >
+        <Top>
+          <Top.Line text="회원 탈퇴가 완료되었습니다." emphasize={['회원 탈퇴가 완료되었습니다.']} />
+        </Top>
+
+        <Flex flexDirection="column" gap="0.5rem">
+          <Text textColor="onTertiary">그동안 행동대장을 사용해주셔서 감사합니다.</Text>
+          <Text textColor="onTertiary">더 나은 서비스로 발전해나가겠습니다.</Text>
+        </Flex>
+        <RunningDogLogo />
+      </div>
+      {/* TODO: (@soha) 홈으로 이동 */}
+      <FixedButton onClick={() => {}}>홈으로</FixedButton>
+    </>
+  );
+};
+
+export default WithdrawalCompleted;

--- a/client/src/pages/MyPage/index.tsx
+++ b/client/src/pages/MyPage/index.tsx
@@ -1,10 +1,15 @@
+import {useNavigate} from 'react-router-dom';
+
 import {Button, Flex, FunnelLayout, MainLayout, Text, TextButton, TopNav, useTheme} from '@components/Design';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
 
 import {mockImageStyle} from './MyPage.style';
 import Container from './Container';
 
 const MyPage = () => {
   const {theme} = useTheme();
+  const navigate = useNavigate();
 
   return (
     <MainLayout backgroundColor="gray">
@@ -36,7 +41,7 @@ const MyPage = () => {
             <TextButton textColor="onTertiary" textSize="body">
               내가 만든 행사 목록 보기
             </TextButton>
-            <TextButton textColor="onTertiary" textSize="body">
+            <TextButton textColor="onTertiary" textSize="body" onClick={() => navigate(ROUTER_URLS.withdraw)}>
               탈퇴하기
             </TextButton>
           </Flex>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -33,6 +33,7 @@ const LoginPage = lazy(() => import('@pages/LoginPage'));
 const MyPage = lazy(() => import('@pages/MyPage'));
 const LoginRedirectPage = lazy(() => import('@pages/LoginPage/LoginRedirectPage'));
 const LoginFailFallback = lazy(() => import('@pages/LoginPage/LoginFailFallback'));
+const WithdrawPage = lazy(() => import('@pages/MyPage/WithdrawPage/WithdrawPage'));
 
 const router = createBrowserRouter([
   {
@@ -66,6 +67,10 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.myPage,
             element: <MyPage />,
+          },
+          {
+            path: ROUTER_URLS.withdraw,
+            element: <WithdrawPage />,
           },
           {
             path: ROUTER_URLS.kakaoLoginRedirectUri,


### PR DESCRIPTION
## issue
- close #848 
## 구현 이유

행동대장 서비스에 소셜 로그인을 도입하게 되었다. 그러면서 다양한 기능들이 새롭게 추가되어야 했는데, 그 중에 하나가 바로 회원탈퇴 기능이다.

회원 가입을 했기 때문에 당연히 회원 탈퇴를 할 수 있는 기능은 필수이다. 물론 자주 발생하지 않을 이벤트로 추측되지만, 그렇다고 개발자가 편하기 위해서 구글 스프레드 시트나 문의 사항으로 대체 할 수는 없다. 그렇게 된다면 사용자는 불편해지게 되면서 행동대장 서비스의 사용성이 안 좋아지게 될 것이다. 이는 우리 서비스에 대한 안 좋은 인식으로 퍼질 수 있다. 따라서, 회원탈퇴 기능도 사용자가 편할 수 있도록 구현하고자 신경썼다.

## 구현 과정

### 디자인

내가 개발하면서 가장 신경쓰는 부분은 UI/UX를 이쁘고 편하게 만드는 것이다. 그렇기에 디자인을 할 때, 토스를 참고하여 행동대장 서비스에 맞게 디자인을 신경썼다.

회원 탈퇴 기능에서 UI/UX 뿐 아니라 회원을 탈퇴하는 이유를 명확하게 수집하고자 했다. 단, 앞서 언급한 UX가 편하면서 탈퇴 이유 데이터를 수집할 수 있도록 해야 했다. 그러려면 사용자가 탈퇴하는 이유를 우리에게 말해줄 때 귀찮지 않게 해야 한다고 생각했다. 그래서 나는 탈퇴 이유를 큰 카테고리로 한 번 나누고, 그 카테고리 안에서 상세 내용을 선택할 수 있도록 다양한 선지를 사용자에게 주었다. 

<img width="666" alt="스크린샷 2024-12-17 15 01 31" src="https://github.com/user-attachments/assets/add257b2-e4ae-4bf5-99ce-6786c84e924e" />


### 구현 | checkbox 컴포넌트

- Icon 컴포넌트에서 svg 아이콘의 색상을 변경할 수 없는 에러가 존재하여 수정하였습니다.
- check icon이 기존에 존재했지만 다른 곳에서 사용하고 있지 않았고, 현재 사용해야 하는 check와 색상 및 사이즈가 달랐기 때문에 해당 컴포넌트에서 사용하는 check 아이콘으로 변경했습니다.

<img width="135" alt="스크린샷 2024-12-17 15 10 48" src="https://github.com/user-attachments/assets/9a1d1651-3891-4aeb-858d-d91731ea98f7" />


### 구현 | textarea 컴포넌트

<img width="358" alt="스크린샷 2024-12-17 15 11 10" src="https://github.com/user-attachments/assets/a132ded4-dd6f-46b2-9e58-e8c9d91669c3" />

### 구현 | 회원 탈퇴 페이지 펴블리싱

- 회원 탈퇴를 위한 총 7가지의 페이지중 6가지 페이지 퍼블리싱 완료
    
    구현하지 않은 1가지 페이지는 현재 디자인 미확정 (사용방법 설명 페이지)
    
- useRequestDeleteUser 생성
    
    회원탈퇴 api 연결을 위해 apis 폴더에 user.ts 파일 생성. 해당 파일에 requestDeleteUser 함수 생성. endpoint `api/users`
    
    useRequestDeleteUser에서 requestDeleteUser 요청이 정상적으로 실행되면 querykey kakaoLogin과 kakaoClientId를 무효화 시킴.
    
    ```tsx
    const useRequestDeleteUser = () => {
      const queryClient = useQueryClient();
    
      const {mutateAsync, ...rest} = useMutation({
        mutationFn: () => requestDeleteUser(),
        onSuccess: () => {
          queryClient.invalidateQueries({queryKey: [QUERY_KEYS.kakaoLogin]});
          queryClient.invalidateQueries({queryKey: [QUERY_KEYS.kakaoClientId]});
        },
      });
    
      return {deleteAsyncUser: mutateAsync, ...rest};
    };
    ```
    
    회원 탈퇴 api를 실행하기 때문에 이와 연관된 소셜 로그인 queryKey를 무효화 했는데.. 다른 부분들도 무효화 시킬 필요가 있을지? 의견 부탁드립니다-
    
- *CheckBeforeWithdrawingStep*
    
    해당 페이지는 회원 탈퇴를 진행하기 전 유의사항을 안내하는 페이지.
    
    ```tsx
    const handleWithdraw = async () => {
        try {
          await deleteAsyncUser();
          handleMoveStep('withdrawalCompleted');
        } catch (error) {
          toast.error('회원 탈퇴에 실패했어요.', {
            showingTime: 3000,
            position: 'bottom',
          });
        }
      };
    ```
    
    해당 페이지의 탈퇴하기 버튼을 클릭하면 deleteAsyncUser가 실횅됨. 해당 함수가 정상적으로 실행되면 회원 탈퇴 완료 페이지(withdrawalCompleted) Step으로 이동함. 만약, 회원 탈퇴가 정상적으로 진행되지 않았을 경우 toast로 회원 탈퇴가 실패했다는 에러 메세지를 띄움. 
    

## 구현 결과
<img width="276" alt="스크린샷 2024-12-17 15 11 48" src="https://github.com/user-attachments/assets/8ca016b8-ace4-4e59-bee9-eba3b20ac0dc" />
<img width="282" alt="스크린샷 2024-12-17 15 12 14" src="https://github.com/user-attachments/assets/05ec47de-55a6-4acd-9c52-54a8b36ae37c" />
<img width="292" alt="스크린샷 2024-12-17 15 12 31" src="https://github.com/user-attachments/assets/2b3d6842-39e8-4726-b1a9-c0eedf86d1bf" />
<img width="283" alt="스크린샷 2024-12-17 15 12 43" src="https://github.com/user-attachments/assets/b8c367ce-61a1-4f80-8bdc-f6a34e553749" />

- 회원 탈퇴 api가 정상적으로 요청되었을 경우에만 해당 페이지로 이동함
<img width="884" alt="스크린샷 2024-12-17 15 13 02" src="https://github.com/user-attachments/assets/641fb3a6-c7f3-4a7d-8d7d-b1db9bc158a8" />


## 논의하고 싶은 것

### 회원탈퇴 routerUrl

회원탈퇴 페이지는 마이 페이지 하위에 존재하는 페이지입니다. 따라서 url도 ‘/mypage/withdraw’ 형식으로 가야한다고 생각했습니다. 다른 분들은 어떠신지 궁금합니다!

### endpointPrefix 변경 논의

현재 endpointPrefix는 다음과 같이 존재합니다.

```tsx
export const USER_API_PREFIX = '/api/events';
export const ADMIN_API_PREFIX = '/api/admin/events';
// 새로 추가된 api
export const MEMBER_API_PREFIX = '/api/users';
```

이번에 회원가입이 생기면서 새롭게 MEMBER_API_PREFIX를 추가하게 되었습니다.

현 상황의 네이밍은 혼동을 줄 수 있을 것이라고 판단했습니다.
events를 위한 prefix의 네이밍에 user를 사용하고 user를 위한 prefix에 member 네이밍을 사용하기 때문입니다.

따라서, 위와 같은 네이밍을 아래와 같이 변경하는건 어떨지 논의하고 싶습니다!

```tsx
export const EVENT_API_PREFIX = '/api/events';
export const ADMIN_API_PREFIX = '/api/admin/events';
export const USER_API_PREFIX = '/api/users';
```

### useRequestDeleteUser

위에서도 언급한것과 같이 queryKey를 소셜 로그인과 관련된 것만 무효화하면 될지.. 아님 추가적으로 행사들도 모두 무효화하는 것이 좋을지 다른 분들의 생각이 궁금합니다.

또한, 회원 탈퇴 api가 정상적으로 요청이 가는 것은 확인했으나, 진짜로! 정상적으로 회원탈퇴가 잘 이뤄졌는지는 확인하지 못했습니다~

## 구현과 관련된 공유 사항

- 두번째 Step에서 Checkbox로 사유를 선택하거나 Textarea에 이유를 작성하는 등의 데이터 값들을 현재 상태관리는 하고 있지 않습니다. 이 부분은 다음 회의때 프엔+백엔드와 논의 후에 진행해야 할 것 같아서 제외했습니다. 다음 task에 같이 진행하도록 하겠습니다~

- 로그아웃 기능에 관하여 (구현X)
  기존에 제가 맡은 task에는 로그아웃 기능도 같이 존재했습니다. 이건 저번에도 논의했다 싶이 token이 만료되면 자동 로그아웃이 진행될텐데, 로그아웃 기능이 필요한지? 의문이 들어 여러분과 더 이야기를 나누고 싶습니다. 우리 서비스는 여러 계정이 필요한 서비스가 아닌 단 하나의 계정만으로 서비스 이용이 가능합니다. 따라서 사용자가 의도적으로 로그아웃 기능을 사용하는 경우는 거의 없을 것으로 보입니다. 그렇기에 일단은 로그아웃 기능이 필요한지..? 의문이 들어서 따로 구현은 진행하지 않았습니다.