### PR TITLE
[FE] 행사 생성 시 관리자 이름 유효성 검사가 올바르게 수행되지 않는 버그와 그 외

### DIFF
--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -52,7 +52,8 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
 export const ERROR_MESSAGE = {
   eventName: SERVER_ERROR_MESSAGES.EVENT_NAME_LENGTH_INVALID,
   eventPasswordType: SERVER_ERROR_MESSAGES.EVENT_PASSWORD_FORMAT_INVALID,
-  memberName: `이름은 ${RULE.maxMemberNameLength}자까지 입력 가능해요.`,
+  memberNameLength: `이름은 ${RULE.maxMemberNameLength}자까지 입력 가능해요.`,
+  memberNameFormat: `이름은 한글, 영어만 가능해요.`,
   purchasePrice: `${RULE.maxPrice.toLocaleString('ko-kr')}원 이하의 숫자만 입력이 가능해요`,
   purchaseTitle: `지출 이름은 ${RULE.maxBillNameLength}자 이하의 한글, 영어, 숫자만 가능해요`,
   preventEmpty: '값은 비어있을 수 없어요',

--- a/client/src/hooks/createEvent/useSetNicknameStep.ts
+++ b/client/src/hooks/createEvent/useSetNicknameStep.ts
@@ -12,18 +12,15 @@ const useSetNicknameStep = () => {
 
   const handleNicknameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const name = event.target.value;
-    const {isValid, errorMessage: errorMessageResult} = validateMemberName(name);
-
+    const {memberName: nicknameResult, isValid, errorMessage: errorMessageResult} = validateMemberName(name);
     setErrorMessage(errorMessageResult);
 
-    if (isValid) {
-      setNickname(name);
+    if (isValid || name.length === 0) {
+      setNickname(nicknameResult);
+      setCanSubmit(isValid);
     }
-
-    setCanSubmit(name.length !== 0);
   };
 
   return {handleNicknameChange, canSubmit, nickname, errorMessage};
 };
-
 export {useSetNicknameStep, type UseSetNicknameStepProps};

--- a/client/src/utils/validate/validateMemberName.ts
+++ b/client/src/utils/validate/validateMemberName.ts
@@ -4,22 +4,28 @@ import RULE from '@constants/rule';
 
 import {ValidateResult} from './type';
 
-const validateMemberName = (name: string): ValidateResult => {
-  let errorMessage = null;
+const validateMemberName = (name: string) => {
+  const slicedName = name.trim().slice(0, RULE.maxMemberNameLength);
 
   const validateOnlyString = () => {
-    return REGEXP.memberName.test(name);
+    return REGEXP.memberName.test(slicedName);
   };
 
   const validateLength = () => {
-    return name.length <= RULE.maxMemberNameLength;
+    return slicedName.length > 0;
   };
 
-  if (validateOnlyString() && validateLength()) {
-    return {isValid: true, errorMessage: null};
-  }
+  const getErrorMessage = () => {
+    if (!validateOnlyString()) return ERROR_MESSAGE.memberNameFormat;
+    if (name.length > RULE.maxMemberNameLength) return ERROR_MESSAGE.memberNameLength;
+    return null;
+  };
 
-  return {isValid: false, errorMessage: errorMessage || ERROR_MESSAGE.memberName};
+  return {
+    memberName: slicedName,
+    isValid: validateLength() && validateOnlyString(),
+    errorMessage: getErrorMessage(),
+  };
 };
 
 export default validateMemberName;


### PR DESCRIPTION
## issue
- close #859 

## 구현 목적
1. 관리자 이름 유효성을 검증하는 유틸 함수인 validateMemberName이 이름에 맞는 일을 하고있지 않습니다. 현재 하고 있는 일은 setNickname을 수행할 수 있는지 여부를 반환하고 있습니다. setNickname은 할 수 있더라도 그게 valid한 값이 아닐 수 있습니다.
2. ‘aa’에서 ‘aa2’처럼 숫자를 입력하면 이름은 4자까지 입력 가능하다는 에러메세지가 뜨고있습니다. '숫자를 입력할 수 없다'라는 에러메세지가 떠야합니다.
3. 공백을(‘ ‘) 입력하면 name.length !== 0이 아니기 때문에 true가 되어 다음 단계로 넘어갈 수 있습니다. 올바른 이름이 아니므로 넘어가면 안됩니다.

## 구현 사항
### 1. 관리자 이름 유효성을 검증하는 유틸 함수인 validateMemberName이 이름에 맞는 일을 하고있지 않습니다. ⋯

이 pr본문에서 validateMemberName은 기니까 `검증 함수`로 줄여서 지칭하겠습니다! 

이름의 유효 갈이는 0자 초과 4자 이하여야 합니다. 따라서 검증 함수에서 4까지 slice하고 0이상임을 확인하도록 했습니다.
```js
const slicedName = name.trim().slice(0, RULE.maxMemberNameLength);

  const validateLength = () => {
    return slicedName.length > 0;
  };
```
그냥 validateLength에 넣으면 되지 왜 slice를 하는 건지 의문이 들 텐데요.
validateLength에서 && 로 함께 최대 길이를 검증할 경우 초과 입력의 경우 isValid가 false가 되기 때문입니다. 하지만 input안에 이름은 4자까지만 입력되기 때문에 초과 입력이 발생해도 이전 4자까지의 입력이 유효하다면 isValid는 true여야합니다. 즉, 초과 입력 발생 시 평가 대상은 `4자 까지의 이름`입니다. 그래서 isValid의 계산식에 포함되어있는 validateLength에서 최대 길이 조건을 빼고 대신 slicedName에 포함시켜 유효성 검사를 slicedName로 수행하도록 했습니다.

이제 초과 입력이 발생해도 4자까지의 이름이 유효하다면 isValid=true로 평가됩니다. 하지만 에러 메세지는 떠야 사용자가 왜 4자 초과로 입력되지 않는건지 이해할 수 있습니다. 따라서 에러 메세지의 경우 입력을 시도하고 있는 값인 target.value(검증 함수에서 name 변수)를 사용해 계산합니다.
```js
const getErrorMessage = () => {
    if (!validateOnlyString()) return ERROR_MESSAGE.memberNameFormat;
    
    //    ⬇️ 여기
    if (name.length > RULE.maxMemberNameLength) return ERROR_MESSAGE.memberNameLength; 
    return null;
  };
```
이렇게 유효한 이름인지 여부인 isValid를 올바르게 계산할 수 있도록 고쳤습니다.

그리고 slicedName을 setNickname에 사용할 수 있도록 return했습니다. 4자 까지만 보기 때문에 초과입력이 들어와도 isValid는 유지됩니다. 이때 4자만큼만 input에 들어갈 수 있도록 하려면 검증 함수가 아닌 setNickname을 수행하는 곳에서 slice해도 되지만, slice는 유효성 책임이 큰 것 같아 검증 함수에서 유효하게 잘라 반환해 그 값을 set하도록 했어요.

### 2. ‘aa’에서 ‘aa2’처럼 숫자를 입력하면 이름은 4자까지 입력 가능하다는 에러메세지가 뜨고있습니다. ⋯
오류 메세지가 null이거나 이름 길이 이렇게 2개로만 변화되고 있기 때문에 틀린 조건에 따라 다른 에러 메세지를 띄워주도록 했습니다.

```js
const getErrorMessage = () => {
    if (!validateOnlyString()) return ERROR_MESSAGE.memberNameFormat;
    if (name.length > RULE.maxMemberNameLength) return ERROR_MESSAGE.memberNameLength;
    return null;
  };
  ```
  
### 3. 공백을(‘ ‘) 입력하면 name.length !== 0이 아니기 때문에 true가 되어 다음 단계로 넘어갈 수 있습니다. ⋯
1번의 수정 결과로 isValid로 올바른 이름인지 여부를 판별할 수 있게 되었습니다.

그래서 이름이 수정될 때(setNickname 호출) setCanSubmit을 함께 수정하도록 했습니다.
이때 setCanSubmit에 넘겨주는 값은 isValid로 주었는데요.
이름이 수정되어도 빈 값('')으로 수정되는 경우는 canSubmit이 false여야 합니다. 그래서 수정될 때 isValid값에 따라 cnaSubmit이 변하도록 했습니다.

## 결과
왼쪽에 로그찍히는게 현재 키보드 입력 값입니다. event.target.value의 예상 값을 저 로그로 추측하면 됩니다. 로그가 key up, down으로 2개 세트로 뜨기 때문에 1개로 해석해주시면 됩니다~!

▼ 전 ('aa1'를 입력할 경우 길이 오류가 뜬다. + spacebar와 숫자 입력 시 다음 넘어가기 가능)

https://github.com/user-attachments/assets/c0da276d-7758-41be-8656-1f3d520f5b34

▼ 후  ('aa2'를 입력할 경우 숫자 입력할 수 없다고 한다. + spacebar와 숫자 입력 시 다음 넘어가기 불가능)

https://github.com/user-attachments/assets/7169e0de-46d5-4d26-a07a-89b62acfed55


## 논의 사항
빠뜨린 논리가 있을까요?

## 기타
아마 이전 검증 함수를 사용하고 있는 곳은 비슷한 오류가 나고 있을 것으로 예상됩니다.


