### PR TITLE
[FE] 토스/카카오톡 앱이 없을 때 앱스토어로 이동할 수 있도록 개선

### DIFF
--- a/client/src/hooks/useSendPage.ts
+++ b/client/src/hooks/useSendPage.ts
@@ -2,6 +2,7 @@ import {useLocation} from 'react-router-dom';
 import {useEffect, useState} from 'react';
 
 import {isMobileDevice} from '@utils/detectDevice';
+import navigateApp from '@utils/navigateApp';
 
 import {SendInfo} from './useReportsPage';
 import toast from './useToast/toast';
@@ -54,16 +55,32 @@ const useSendPage = () => {
   const onTossClick = () => {
     trackSendMoney({eventName, eventToken, amount, sendMethod: 'toss'});
 
-    const tossUrl = `supertoss://send?amount=${amount}&bank=${bankName}&accountNo=${accountNumber}`;
-    window.location.href = tossUrl;
+    navigateApp({
+      android: {
+        appScheme: `supertoss://send?amount=${amount}&bank=${bankName}&accountNo=${accountNumber}`,
+        storeUrl: 'intent://details?id=viva.republica.toss#Intent;scheme=market;package=com.android.vending;end;',
+      },
+      ios: {
+        appScheme: `supertoss://send?amount=${amount}&bank=${bankName}&accountNo=${accountNumber}`,
+        storeUrl: 'https://apps.apple.com/kr/app/%ED%86%A0%EC%8A%A4/id839333328',
+      },
+    });
   };
 
   const onKakaoPayClick = async () => {
     await window.navigator.clipboard.writeText(copyText);
     trackSendMoney({eventName, eventToken, amount, sendMethod: 'kakaopay'});
 
-    const kakaoPayUrl = 'kakaotalk://kakaopay/home';
-    window.location.href = kakaoPayUrl;
+    navigateApp({
+      android: {
+        appScheme: `kakaotalk://kakaopay/home`,
+        storeUrl: 'intent://details?id=com.kakao.talk#Intent;scheme=market;package=com.android.vending;end;',
+      },
+      ios: {
+        appScheme: `kakaotalk://kakaopay/home`,
+        storeUrl: 'https://apps.apple.com/kr/app/kakaotalk/id362057947',
+      },
+    });
   };
 
   const buttonText: Record<SendMethod, string> = {

--- a/client/src/utils/navigateApp.ts
+++ b/client/src/utils/navigateApp.ts
@@ -1,0 +1,44 @@
+import {isIOS, isMobileDevice} from '@utils/detectDevice';
+
+import toast from '../hooks/useToast/toast';
+
+type NavigateAppArgs = {
+  android: AppUrl;
+  ios: AppUrl;
+  options?: NavigateAppOptions;
+};
+
+type NavigateAppOptions = {
+  delayBeforeCheckTime?: number; // 앱 실행 후 설치 여부를 확인하기 전까지의 대기 시간.
+  installThresholdTime?: number; // 설치 여부를 판단하는 기준 시간.
+};
+
+const DEFAULT_DELAY_BEFORE_CHECK_TIME = 1000;
+const DEFAULT_INSTALL_THRESHOLD_TIME = 1500;
+
+type AppUrl = {
+  appScheme: string;
+  storeUrl: string;
+};
+
+const navigateApp = ({android, ios, options}: NavigateAppArgs) => {
+  if (!isMobileDevice()) {
+    toast.error('모바일 기기에서만 앱 실행이 가능해요\n 모바일 환경에서 이용해 주세요.');
+    return;
+  }
+
+  const url = isIOS() ? ios.appScheme : android.appScheme;
+  const storeUrl = isIOS() ? ios.storeUrl : android.storeUrl;
+
+  const now = Date.now();
+  window.location.href = url;
+
+  setTimeout(() => {
+    if (Date.now() - now < (options?.installThresholdTime ?? DEFAULT_INSTALL_THRESHOLD_TIME)) {
+      toast.error('앱이 설치되지 않았어요. 설치 후 이용해주세요');
+      window.location.href = storeUrl;
+    }
+  }, options?.delayBeforeCheckTime ?? DEFAULT_DELAY_BEFORE_CHECK_TIME);
+};
+
+export default navigateApp;


### PR DESCRIPTION
## issue
- close #871 

## 구현 사항
### 토스 / 카카오페이가 설치되지 않은 환경 대응
두 어플을 사용하지 않는 사용자는 송금하기 기능을 이용할 수 없습니다. 그래서 최후의 선택으로 복사하기 기능을 제공하여 사용자가 직접 송금할 수 있는 방법을 두었지만, 토스, 카카오페이를 선택한 후 송금하기를 클릭하면 아무런 반응이 일어나지 않는 에러가 있었습니다. 이 때 사용자에게 적절한 안내를 주어야 한다고 생각했기 때문에 설치를 위한 앱스토어로 이동하도록 기능을 추가했습니다.

#### 모바일이 아닌 환경에서는 앱 실행 할 수 없도록 설정
지금 설정은 노트북에서 토스 송금하기가 보이지 않도록 설정했지만 악의적인 조작으로 보이게 할 수 있습니다. 이 때도 예외처리를 적용하여 아래와 같이 토스트를 보여주도록 했습니다.

![image](https://github.com/user-attachments/assets/851fb590-880f-4edd-872f-24cd25d2d3fb)

#### 클릭한 후 일정 시간을 기다려 앱이 실행되지 않는지 판단
버튼을 클릭한 후 일정 시간을 기다렸지만 앱이 실행되지 않는 경우, 앱이 설치되지 않은 것이라 판단하여 설치 링크로 이동할 수 있도록 기능을 구현했습니다. 여기서 Android와 IOS가 다르게 이동해야 하기 때문에 각각 다른 주소를 넣어줬습니다.

이 때도 '앱이 설치되지 않았어요. 설치 후 이용해주세요' 라는 토스트를 보여줍니다.


## 🫡 참고사항
