### PR TITLE
[FE] 행사 계좌 번호 수정 api 연결

### DIFF
--- a/client/src/apis/endpointPrefix.ts
+++ b/client/src/apis/endpointPrefix.ts
@@ -1,4 +1,3 @@
-// TODO: (@weadie) 반복되서 쓰이는 이 api/events가 추후 수정 가능성이 있어서 일단 편집하기 편하게 이 변수를 재사용하도록 했습니다.
 export const MEMBER_API_PREFIX = '/api/events';
 export const ADMIN_API_PREFIX = '/api/admin/events';
 export const USER_API_PREFIX = '/api/users';

--- a/client/src/apis/request/event.ts
+++ b/client/src/apis/request/event.ts
@@ -2,7 +2,7 @@ import {BankAccount, CreatedEvents, Event, EventCreationData, EventName} from 't
 import {WithErrorHandlingStrategy} from '@errors/RequestGetError';
 
 import {ADMIN_API_PREFIX, MEMBER_API_PREFIX} from '@apis/endpointPrefix';
-import {requestGet, requestPatch, requestPostWithResponse} from '@apis/request';
+import {requestGet, requestPatchWithoutResponse, requestPostWithResponse} from '@apis/request';
 import {WithEventId} from '@apis/withId.type';
 
 export const requestPostGuestEvent = async (postEventArgs: EventCreationData) => {
@@ -39,7 +39,7 @@ export type PartialEvent = Partial<
 export type RequestPatchEvent = WithEventId & PartialEvent;
 
 export const requestPatchEvent = async ({eventId, ...event}: RequestPatchEvent) => {
-  return requestPatch({
+  await requestPatchWithoutResponse({
     endpoint: `${ADMIN_API_PREFIX}/${eventId}`,
     body: {
       ...event,

--- a/client/src/pages/event/[eventId]/admin/edit-account/EditAccountPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/edit-account/EditAccountPage.tsx
@@ -1,6 +1,6 @@
 import {useLocation} from 'react-router-dom';
 
-import useRequestPatchUser from '@hooks/queries/event/useRequestPatchUser';
+import useRequestPatchEvent from '@hooks/queries/event/useRequestPatchEvent';
 
 import useEventDataContext from '@hooks/useEventDataContext';
 
@@ -10,7 +10,7 @@ import getEventBaseUrl from '@utils/getEventBaseUrl';
 
 const EditAccountPage = () => {
   const {bankName, accountNumber} = useEventDataContext();
-  const {patchUser} = useRequestPatchUser();
+  const {patchEvent} = useRequestPatchEvent();
 
   const location = useLocation();
   const redirectUrlOnSubmit = `/${getEventBaseUrl(location.pathname)}/admin`;
@@ -19,7 +19,7 @@ const EditAccountPage = () => {
     <EditAccountPageView
       bankName={bankName}
       accountNumber={accountNumber}
-      onSubmit={patchUser}
+      onSubmit={patchEvent}
       redirectUrlOnSubmit={redirectUrlOnSubmit}
     />
   );


### PR DESCRIPTION
## issue
- close #887 

## 구현 목적
행사의 계좌번호와 유저의 계좌번호를 분리하기로 결정하게 되어 기존의 행사 계좌 번호를 준비되어있는 행사 계좌 번호 수정 api를 사용하여 수정합니다.

## 구현 사항

EditAccountPage에서 EditAccountPageView 의 onSubmit인자로 넘겨줄 api 콜 함수만 행사 계좌 번호 수정 api로 변경해주었습니다.

```jsx
const EditAccountPage = () => {
  const {bankName, accountNumber} = useEventDataContext();
  const {patchEvent} = useRequestPatchEvent(); // 여기만 다른 api로 연결

  const location = useLocation();
  const redirectUrlOnSubmit = `/${getEventBaseUrl(location.pathname)}/admin`;

  return (
    <EditAccountPageView
      bankName={bankName}
      accountNumber={accountNumber}
      onSubmit={patchEvent}
      redirectUrlOnSubmit={redirectUrlOnSubmit}
    />
  );
};
```

그리고 `useRequestPatchEvent`는 리스폰스 바디가 없으므로 `requestPatchWithoutResponse`를 사용해 PATCH요청을 보내도록 수정했습니다.