### PR TITLE
[FE] 회원 이름 변경 구현

### DIFF
--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -23,6 +23,7 @@ export const ROUTER_URLS = {
   withdraw: `${MY_PAGE}/withdraw`,
   createdEvents: `${MY_PAGE}/events`,
   editUserAccount: `${MY_PAGE}/edit-account`,
+  editUserNickname: `${MY_PAGE}/edit-nickname`,
   guestEventLogin: `${EVENT_WITH_EVENT_ID}/admin/login/guest`,
   userEventLogin: `${EVENT_WITH_EVENT_ID}/admin/login/user`,
   kakaoLoginRedirectUri: process.env.KAKAO_REDIRECT_URI,

--- a/client/src/pages/event/[eventId]/admin/edit-event-name/EditEventNamePage.tsx
+++ b/client/src/pages/event/[eventId]/admin/edit-event-name/EditEventNamePage.tsx
@@ -12,7 +12,6 @@ import getEventBaseUrl from '@utils/getEventBaseUrl';
 const EditEventNamePage = () => {
   const location = useLocation();
   const locationState = location.state as EventName | null;
-  console.log(locationState);
 
   const navigate = useNavigate();
 

--- a/client/src/pages/mypage/MyPage.tsx
+++ b/client/src/pages/mypage/MyPage.tsx
@@ -7,8 +7,6 @@ import useRequestSuspenseGetUserInfo from '@hooks/queries/auth/useRequestSuspens
 import MyPageError from '@pages/fallback/MyPageError';
 import MyPageLoading from '@pages/fallback/MyPageLoading';
 
-import useUserInfoContext from '@hooks/useUserInfoContext';
-
 import {Flex, FunnelLayout, MainLayout, Text, TextButton, TopNav} from '@components/Design';
 
 import getImageUrl from '@utils/getImageUrl';
@@ -51,13 +49,11 @@ const UserInfoSection = () => {
 const SettingSection = () => {
   const navigate = useNavigate();
 
-  const {nickname} = useUserInfoContext();
-
   return (
     <SectionContainer>
       <Flex flexDirection="column" margin="0 1.5rem" gap="1rem">
         <TextButton textColor="onTertiary" textSize="body" onClick={() => navigate(ROUTER_URLS.editUserNickname)}>
-          닉네임 설정하기
+          이름 변경하기
         </TextButton>
         <TextButton textColor="onTertiary" textSize="body">
           기본 계좌 번호 설정하기

--- a/client/src/pages/mypage/MyPage.tsx
+++ b/client/src/pages/mypage/MyPage.tsx
@@ -56,7 +56,7 @@ const SettingSection = () => {
   return (
     <SectionContainer>
       <Flex flexDirection="column" margin="0 1.5rem" gap="1rem">
-        <TextButton textColor="onTertiary" textSize="body">
+        <TextButton textColor="onTertiary" textSize="body" onClick={() => navigate(ROUTER_URLS.editUserNickname)}>
           닉네임 설정하기
         </TextButton>
         <TextButton textColor="onTertiary" textSize="body">

--- a/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
+++ b/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
@@ -1,5 +1,7 @@
 import {useNavigate} from 'react-router-dom';
 
+import useRequestPatchUser from '@hooks/queries/event/useRequestPatchUser';
+
 import useUserInfoContext from '@hooks/useUserInfoContext';
 import useMemberName from '@hooks/useMemberName';
 
@@ -9,6 +11,7 @@ import {ROUTER_URLS} from '@constants/routerUrls';
 
 const EditUserNicknamePage = () => {
   const {nickname} = useUserInfoContext();
+  const {patchUser} = useRequestPatchUser();
 
   const {errorMessage, canSubmit, name, handleNameChange} = useMemberName(nickname);
 
@@ -17,6 +20,7 @@ const EditUserNicknamePage = () => {
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
+    await patchUser({nickname: name});
     navigate(ROUTER_URLS.myPage);
   };
   return (

--- a/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
+++ b/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
@@ -1,0 +1,50 @@
+import {useNavigate} from 'react-router-dom';
+
+import useUserInfoContext from '@hooks/useUserInfoContext';
+import useMemberName from '@hooks/useMemberName';
+
+import {FixedButton, FunnelLayout, Input, MainLayout, Top, TopNav} from '@components/Design';
+
+import {ROUTER_URLS} from '@constants/routerUrls';
+
+const EditUserNicknamePage = () => {
+  const {nickname} = useUserInfoContext();
+
+  const {errorMessage, canSubmit, name, handleNameChange} = useMemberName(nickname);
+
+  const navigate = useNavigate();
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    navigate(ROUTER_URLS.myPage);
+  };
+  return (
+    <MainLayout backgroundColor="white">
+      <TopNav>
+        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
+      </TopNav>
+      <FunnelLayout>
+        <Top>
+          <Top.Line text="행사에서 사용할" />
+          <Top.Line text="본인의 이름을 입력해주세요" emphasize={['본인의 이름']} />
+        </Top>
+        <form onSubmit={event => onSubmit(event)}>
+          <Input
+            labelText="행사 이름"
+            errorText={errorMessage ?? ''}
+            value={name}
+            type="text"
+            placeholder="박행댕"
+            onChange={handleNameChange}
+            isError={!!errorMessage}
+            autoFocus
+          />
+          <FixedButton disabled={!canSubmit}>변경완료</FixedButton>
+        </form>
+      </FunnelLayout>
+    </MainLayout>
+  );
+};
+
+export default EditUserNicknamePage;

--- a/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
+++ b/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
@@ -1,5 +1,6 @@
 import {useNavigate} from 'react-router-dom';
 
+import toast from '@hooks/useToast/toast';
 import useRequestPatchUser from '@hooks/queries/event/useRequestPatchUser';
 
 import useUserInfoContext from '@hooks/useUserInfoContext';
@@ -20,8 +21,13 @@ const EditUserNicknamePage = () => {
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    await patchUser({nickname: name});
-    navigate(ROUTER_URLS.myPage);
+    try {
+      await patchUser({nickname: name});
+      toast.confirm('이름 변경이 완료되었어요!');
+      navigate(ROUTER_URLS.myPage);
+    } catch (error) {
+      toast.error('이름 변경에 실패했어요. 다시 시도해주세요.');
+    }
   };
   return (
     <MainLayout backgroundColor="white">

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -7,6 +7,7 @@ import App from './App';
 
 const UserInfoLoader = lazy(() => import('@components/Loader/UserInfo/UserInfoLoader'));
 const EditUserAccountPage = lazy(() => import('@pages/mypage/edit-account/EditUserAccountPage'));
+const EditUserNicknamePage = lazy(() => import('@pages/mypage/edit-nickname/EditUserNicknamePage'));
 const ErrorPage = lazy(() => import('@pages/fallback/ErrorPage'));
 const SendErrorPage = lazy(() => import('@pages/fallback/SendErrorPage'));
 const CreateGuestEventFunnel = lazy(() => import('@pages/event/create/guest/CreateGuestEventFunnel'));
@@ -62,11 +63,6 @@ const router = createBrowserRouter([
       {
         path: ROUTER_URLS.login,
         element: <LoginPage />,
-      },
-
-      {
-        path: ROUTER_URLS.withdraw,
-        element: <WithdrawPage />,
       },
       {
         path: ROUTER_URLS.createdEvents,
@@ -132,6 +128,14 @@ const router = createBrowserRouter([
           {
             path: ROUTER_URLS.editUserAccount,
             element: <EditUserAccountPage />,
+          },
+          {
+            path: ROUTER_URLS.editUserNickname,
+            element: <EditUserNicknamePage />,
+          },
+          {
+            path: ROUTER_URLS.withdraw,
+            element: <WithdrawPage />,
           },
         ],
       },


### PR DESCRIPTION
## issue
- close #910 

## 구현 목적

회원을 위한 서비스 중 닉네임 저장하기 기능을 구현하고자 합니다. 해당 기능은 행사를 생성할 때 주최자의 닉네임 작성이라는 단계를 줄여주고자 도입했습니다. 이를 통해, 회원은 비회원과 달리 행사 생성 단계를 줄일 수 있어 빠르게 행사 생성이 가능합니다.

회원은 마이페이지에서 `닉네임 변경하기` 탭을 클릭하여 기존에 입력했던 닉네임을 수정할 수 있습니다.

## 구현 사항

### 페이지 디자인

- `닉네임 변경하기`를 `이름 변경하기`로 수정
    
    닉네임이라는 단어를 사용할 경우 유저가 **익명성의 이름을 작성하라는 것처럼** 받아드릴 것이라고 생각했습니다. 
    우리의 서비스는 익명성 사용이 유도될 필요가 없는 서비스라고 판단했기 때문에 `닉네임 → 이름`으로 워딩을 변경했습니다. 또한, 그간의 서비스에서 사용한 워딩이 `참여한 사람`, `이름` 등으로 사용했기에 통일성을 주고자 닉네임이 아닌 이름을 사용한 이유도 있습니다.
    
    **🚨유저에게 보이는 페이지에서만 이름으로 변경했을 뿐, 개발에서 사용되는 용어는 그대로 nickname을 사용했습니다!**
    
    <img width="311" alt="스크린샷 2025-01-06 18 05 40" src="https://github.com/user-attachments/assets/6e81cf9d-4883-4eb5-a6f7-c59b69663c03" />

    
- 이름 변경하기 페이지
    
    Top 컴포넌트의 text에 `변경할 이름` 이라는 워딩을 넣는 것이 좋을지 고민하였습니다만. 
    마이페이지에서 이름 변경하기를 클릭한 후 해당 페이지로 이동하기 때문에 **변경 이라는 워딩을 넣지 않아도 된다고 생각**하여 다음과 같이 작성하였습니다. 
    
    <img width="203" alt="스크린샷 2025-01-06 18 06 07" src="https://github.com/user-attachments/assets/1fad076c-a31f-442c-9df7-9f2532e7ec8c" />

### 기능 구현

- 이름 유효성 검사 및 onChange
    
    기존에 비회원으로 행사 생성을 진행하면 `관리자 이름`을 입력하는 단계가 존재했습니다. 해당 단계에서 `useMemberName`이라는 hook을 사용하고 있었습니다. 
    
    회원의 이름을 변경하는 로직과 비회원의 관리자 이름을 입력하는 **로직이 100% 동일**하다고 판단하여 해당 기능에서도 useMemberName hook을 사용했습니다.
    
    단, 회원 이름 변경은 **항상 default 이름이 존재**하므로, useMemberName의 인자로 useUserInfoContext에서 받아온 nickname을 넣어주었습니다.
    
    ```jsx
    const {nickname} = useUserInfoContext();
    
    const {errorMessage, canSubmit, name, handleNameChange} = useMemberName(nickname);
    
    // ...
    
    await patchUser({nickname: name});
    ```
    
- 회원 이름변경 api 연결
    
    useRequestPatchUser()를 사용하여 회원의 이름을 변경하도록 api를 연결했습니다.
    
- 이름 변경 요청 상태 toast 띄우기
    
    이름 변경 api가 정상적으로 작동되었을 경우와 에러가 발생했을 경우 toast를 띄우도록 구현했습니다.
    
    ```tsx
    const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
      event.preventDefault();
    
      try {
        await patchUser({nickname: name});
        toast.confirm('이름 변경이 완료되었어요!');
        navigate(ROUTER_URLS.myPage);
      } catch (error) {
        toast.error('이름 변경에 실패했어요. 다시 시도해주세요.');
      }
    };
    ```
   <img width="262" alt="스크린샷 2025-01-06 18 08 20" src="https://github.com/user-attachments/assets/cfc5c3bd-d443-40ea-b4a0-42bbddc09c55" />
   <img width="262" alt="스크린샷 2025-01-06 18 07 48" src="https://github.com/user-attachments/assets/47000fc0-e2ef-4f5f-8095-179a8d33b94e" />

## 논의하고 싶은 부분(선택)
이름 변경 페이지의 Top 컴포넌트 문구 부분이 적절한지 논의하고 싶습니다!