### PR TITLE
[FE] 카카오 로그인 프로필 연동을 선택하지 않을 경우 프로필 이미지 alt로 띄워지는 문제

### DIFF
--- a/client/src/pages/event/[eventId]/EventPageLayout.tsx
+++ b/client/src/pages/event/[eventId]/EventPageLayout.tsx
@@ -53,6 +53,7 @@ const EventPageLayout = () => {
   }, []);
 
   const isKakaoUser = event.userInfo && event.userInfo.isGuest === false;
+  const profileImage = event.userInfo.profileImage;
 
   return (
     <MainLayout backgroundColor="gray">
@@ -74,7 +75,7 @@ const EventPageLayout = () => {
           )}
           {isKakaoUser && (
             <Link to={ROUTER_URLS.myPage}>
-              <Profile src={event.userInfo.profileImage ?? getImageUrl('runningDog', 'png')} size="medium" />
+              <Profile src={profileImage ? profileImage : getImageUrl('runningDog', 'png')} size="large" />
             </Link>
           )}
         </Flex>

--- a/client/src/pages/mypage/MyPage.tsx
+++ b/client/src/pages/mypage/MyPage.tsx
@@ -36,7 +36,7 @@ const UserInfoSection = () => {
     <SectionContainer>
       <Flex justifyContent="spaceBetween" alignItems="center" margin="0 1rem">
         <Flex gap="1rem" alignItems="center">
-          <Profile src={profileImage ?? getImageUrl('runningDog', 'png')} size="large" />
+          <Profile src={profileImage ? profileImage : getImageUrl('runningDog', 'png')} size="large" />
           <Text size="bodyBold" textColor="onTertiary">
             {nickname}
           </Text>


### PR DESCRIPTION
## issue
- close #914

## 버그 발생 상황

카카오 로그인 프로필 연동을 선택하지 않을 경우 프로필 이미지가 alt로 띄워지는 문제가 존재합니다.

- 카카오 회원가입 시, 프로필 이미지를 연동하지 않음
    
    <img width="362" alt="카카오_마이페이지_프로필_연동_안함" src="https://github.com/user-attachments/assets/eb0b61f1-0b4a-4feb-954a-52186db948cb" />
    

정상적으로 동작했을 때와 버그 발생 상황의 요소를 비교해보면, 프로필 이미지를 연동하지 않았을 경우 source 태그의 srcset 값이 채워지고 있지 않음을 알 수 있습니다.

<img width="1070" alt="카카오_마이페이지_프로필_정상" src="https://github.com/user-attachments/assets/2b940a29-883c-42ed-b383-3638187a268d" />

<img width="1070" alt="카카오_마이페이지_프로필_버그" src="https://github.com/user-attachments/assets/c69a235b-bda9-4551-87b9-a3828bd3b1b5" />

## 문제 추론

우선 Mypage에서 getImageUrl()을 통해 runningDog 이미지가 잘 불러와짐을 확인했습니다.

MyPage는 Profile 컴포넌트를 통해 회원 프로필 이미지를 불러오고 있습니다. Profile 컴포넌트에서 Image 컴포넌트를 사용하고 있고, Image 컴포넌트에서 src 값으로 runningDog이 출력되어야 하는 것이 정상적입니다. 그러나 출력되지 않는 것을 확인했습니다.

이는 Profile 컴포넌트에서 runningDog 이미지를 넘겨받고 있지 않고 있음을 뜻합니다.

- 프로필 이미지를 연동했을 경우
    
    카카오 프로필 이미지를 연동했을 경우에는 Profile 컴포넌트에서 회원 프로필의 이미지 url을 정상적으로 받고 있습니다.
    
    <img width="1416" alt="카카오_마이페이지_프로필_정상_url" src="https://github.com/user-attachments/assets/905281ee-3689-4828-a4f3-c33b42f401d5" />
    
- 프로필 이미지를 연동하지 않았을 경우
    
    <img width="1416" alt="카카오_마이페이지_프로필_버그_url" src="https://github.com/user-attachments/assets/8138d4f8-182f-44f7-a8ad-2ba293debeb8" />
    
- profileImage의 값이 false일 경우 Profile 컴포넌트로 값이 넘겨지지 않는 것으로 판단되었습니다.

## 버그 해결

문제는 profileImage의 값이 boolean으로 판단했을 때 false일 경우라고 생각했습니다.

- 이전 코드
    
    ```tsx
    <Profile src={profileImage ?? getImageUrl('runningDog', 'png')} size="large" />
    ```
    

이전 코드를 보시면 문제를 알 수 있습니다. profileImage의 값이 true일 경우 profileImage를 렌더링합니다. profileImage의 값이 false일 경우에는? 동작하는 것이 없습니다.

`??`는 nullish 연산자로 profileImage의 값이 null 혹은 undefined일 경우에 `getImageUrl(’runningDog’,’png’)`을 실행합니다. falsy한 값일 경우에는 실행되는 것이 없습니다.

따라서 널리쉬 병합 연산자인 `??` 대신 삼항연산자를 사용하는 것으로 변경했습니다. 

- 변경 코드
    
    ```tsx
    <Profile src={profileImage ? profileImage : getImageUrl('runningDog', 'png')} size="large" />
    ```

## 결과
<img width="1416" alt="카카오_마이페이지_프로필_버그_해결" src="https://github.com/user-attachments/assets/664a2b0f-892c-4934-b0c2-77df29e767d5" />