### PR TITLE
[FE] CD 환경 변수 설정 버그 수정

### DIFF
--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -30,18 +30,21 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      # 4. Dev 환경으로 빌드
+      # 4. 환경변수 파일 github secret에서 가져와서 생성
+      - name: Create environments from github secrets
+        run: |
+          echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" >> .env.dev
+          echo "AMPLITUDE_KEY=${{ secrets.AMPLITUDE_KEY }}" >> .env.dev
+          echo "KAKAO_JAVASCRIPT_KEY=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.dev
+          echo "IMAGE_URL=${{ secrets.IMAGE_URL }}" >> .env.dev
+          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env.dev
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.dev
+
+      # 5. Dev 환경으로 빌드
       - name: Build for Dev environment
         run: npm run build-dev
-        env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
-          AMPLITUDE_KEY: ${{ secrets.AMPLITUDE_KEY }}
-          KAKAO_JAVASCRIPT_KEY: ${{ secrets.KAKAO_JAVASCRIPT_KEY }}
-          IMAGE_URL: ${{ secrets.IMAGE_URL }}
-          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      # 5. AWS 인증 설정
+      # 6. AWS 인증 설정
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -49,11 +52,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # 6. S3에 빌드 결과 업로드
+      # 7. S3에 빌드 결과 업로드
       - name: Upload build results to S3
         run: aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }}/dev/ --delete
 
-      # 7. CloudFront 캐시 무효화
+      # 8. CloudFront 캐시 무효화
       - name: Invalidate CloudFront Cache
         run: |
           aws cloudfront create-invalidation \

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -30,18 +30,21 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      # 4. Prod 환경으로 빌드
+      # 4. 환경변수 파일 github secret에서 가져와서 생성
+      - name: Create environments from github secrets
+        run: |
+          echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" >> .env.prod
+          echo "AMPLITUDE_KEY=${{ secrets.AMPLITUDE_KEY }}" >> .env.prod
+          echo "KAKAO_JAVASCRIPT_KEY=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.prod
+          echo "IMAGE_URL=${{ secrets.IMAGE_URL }}" >> .env.prod
+          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env.prod
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.prod
+
+      # 5. Prod 환경으로 빌드
       - name: Build for Prod environment
         run: npm run build
-        env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
-          AMPLITUDE_KEY: ${{ secrets.AMPLITUDE_KEY }}
-          KAKAO_JAVASCRIPT_KEY: ${{ secrets.KAKAO_JAVASCRIPT_KEY }}
-          IMAGE_URL: ${{ secrets.IMAGE_URL }}
-          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      # 5. AWS 인증 설정
+      # 6. AWS 인증 설정
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -49,11 +52,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # 6. S3에 빌드 결과 업로드
+      # 7. S3에 빌드 결과 업로드
       - name: Upload build results to S3
         run: aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }}/prod/ --delete
 
-      # 7. CloudFront 캐시 무효화
+      # 8. CloudFront 캐시 무효화
       - name: Invalidate CloudFront Cache
         run: |
           aws cloudfront create-invalidation \


### PR DESCRIPTION
## issue
- close #916 

## 구현 사항
### env 파일을 생성해서 빌드하는 방식으로 변경
이전 방식은 빌드 과정에서 env를 secret으로 넣어줬지만 정상적으로 환경 변수가 들어가지 않는 문제가 있었습니다.
그래서 빌드 전에 env 파일을 만드는 과정을 추가하여 환경 변수가 작동하도록 설정했습니다.
dev는 .env.dev를 만들고 prod는 .env.prod를 만들도록 설정하여 이제 빌드 과정에서 env가 없는 문제가 일어나지 않게 됐습니다.

```yml
 # 4. 환경변수 파일 github secret에서 가져와서 생성
      - name: Create environments from github secrets
        run: |
          echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" >> .env.dev
          echo "AMPLITUDE_KEY=${{ secrets.AMPLITUDE_KEY }}" >> .env.dev
          echo "KAKAO_JAVASCRIPT_KEY=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.dev
          echo "IMAGE_URL=${{ secrets.IMAGE_URL }}" >> .env.dev
          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env.dev
          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.dev

      # 5. Dev 환경으로 빌드
      - name: Build for Dev environment
        run: npm run build-dev
```

fork한 레포지토리로 확인해 본 결과 문제 없음을 확인했습니다 휴유

![image](https://github.com/user-attachments/assets/d9ed5568-c796-4b69-a40e-941d2cb5b578)


또한 어제 회의하며 echo를 실행하는 과정에서 값 노출의 우려가 있었는데 확인해 본 결과 노출되지 않는다는 것도 확인했습니다

![image](https://github.com/user-attachments/assets/2baf6641-4874-40b3-94d7-05334570e292)


## 🫡 참고사항
