### PR TITLE
[FE] 행사 삭제 비회원은 불가능하도록 변경

### DIFF
--- a/client/src/components/Design/components/Dropdown/ButtonBase.tsx
+++ b/client/src/components/Design/components/Dropdown/ButtonBase.tsx
@@ -31,9 +31,10 @@ const ButtonBase = ({isOpen, setIsOpen, dropdownRef, baseButtonText, onBaseButto
       {isOpen && (
         <section ref={dropdownRef}>
           <Flex {...dropdownButtonBaseStyle(theme)}>
-            {children.map((button, index) => (
-              <DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />
-            ))}
+            {children.map((button, index) => {
+              if (button) return <DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />;
+              return null;
+            })}
           </Flex>
         </section>
       )}

--- a/client/src/components/Design/components/Dropdown/Dropdown.type.ts
+++ b/client/src/components/Design/components/Dropdown/Dropdown.type.ts
@@ -9,5 +9,5 @@ export type DropdownProps = {
   base?: DropdownBase;
   baseButtonText?: string;
   onBaseButtonClick?: () => void;
-  children: React.ReactElement<DropdownButtonProps>[];
+  children: (React.ReactElement<DropdownButtonProps> | null)[];
 };

--- a/client/src/components/Design/components/Dropdown/MeatballBase.tsx
+++ b/client/src/components/Design/components/Dropdown/MeatballBase.tsx
@@ -26,9 +26,10 @@ const MeatballBase = ({isOpen, setIsOpen, dropdownRef, children}: MeatballBasePr
       {isOpen && (
         <section ref={dropdownRef}>
           <Flex {...dropdownStyle(theme)}>
-            {children.map((button, index) => (
-              <DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />
-            ))}
+            {children.map((button, index) => {
+              if (button) return <DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />;
+              return null;
+            })}
           </Flex>
         </section>
       )}

--- a/client/src/pages/event/[eventId]/admin/AdminPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/AdminPage.tsx
@@ -54,13 +54,8 @@ const AdminPage = () => {
     navigate(`/event/${eventId}/admin/add-bill`);
   };
 
-  const deleteEventAndNavigateByUser = async () => {
-    if (createdByGuest) {
-      navigate(ROUTER_URLS.main, {replace: true});
-    } else {
-      navigate(ROUTER_URLS.createdEvents, {replace: true});
-    }
-
+  const deleteEventAndNavigateCreatedEventsPage = async () => {
+    navigate(ROUTER_URLS.createdEvents, {replace: true});
     await deleteEvents({eventIds: [eventId]});
   };
 
@@ -75,7 +70,9 @@ const AdminPage = () => {
             <DropdownButton text="전체 참여자 관리" onClick={navigateEventMemberManage} />
             <DropdownButton text="계좌번호 입력하기" onClick={navigateAccountInputPage} />
             <DropdownButton text="사진 첨부하기" onClick={navigateAddImages} />
-            <DropdownButton text="행사 삭제하기" onClick={deleteEventAndNavigateByUser} />
+            {!createdByGuest ? (
+              <DropdownButton text="행사 삭제하기" onClick={deleteEventAndNavigateCreatedEventsPage} />
+            ) : null}
           </Dropdown>
         }
       />


### PR DESCRIPTION
## issue
- close #919 

## 구현 사항
### 비회원은 행사 삭제를 할 수 없도록 설정
회원은 행사 삭제 후 생성한 이벤트 페이지로, 비회원은 행사 삭제 후 랜딩 페이지로 보냈으나, 회의 결과 비회원은 행사 삭제를 할 수 없도록 제한하자는 결과를 반영했습니다.

제한하는 방식은 행사 삭제하기 버튼을 보이지 않도록 하는 것입니다.
![image](https://github.com/user-attachments/assets/2f10e7c8-eb39-4bbf-bba6-922696131597)


### Children 타입을 고정하면서 생긴 고려 사항
Dropdown의 children을 DropdownButton으로 제한하고자 ReactElement<DropdownButtonProps>을 사용했었고 문제가 없었습니다. 

```ts
export type DropdownProps = {
  ...
  children: React.ReactElement<DropdownButtonProps>[];
}
```

하지만 게스트 여부로 버튼을 조건부로 보여주는 과정에서 문제가 발생했습니다.

```tsx
<Dropdown>
  <DropdownButton text="행사 이름 변경" onClick={navigateEditEventName} />
  <DropdownButton text="전체 참여자 관리" onClick={navigateEventMemberManage} />
  <DropdownButton text="계좌번호 입력하기" onClick={navigateAccountInputPage} />
  <DropdownButton text="사진 첨부하기" onClick={navigateAddImages} />
   {!createdByGuest ? (
     <DropdownButton text="행사 삭제하기" onClick={deleteEventAndNavigateCreatedEventsPage} />
   ) : null}
</Dropdown>
```

이제 children은 DropdownButton과 null 두 가지 타입이 돼서 타입 에러가 발생했습니다.
그래서 null도 포함할 수 있도록 변경했습니다.

```ts
export type DropdownProps = {
  ...
  children: (React.ReactElement<DropdownButtonProps> | null)[];
}
```

어제 여기까지 시도했다가 에러가 나서 금방 해결할 수 없었습니다. 
그 이유는 이제 children이 null일 수도 있기 때문에 아래 코드가 문제가 생긴 것이었는데

```ts
{children.map((button, index) => (
<DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />
))}
```

여기서 button이 null일 수도 있다는 에러를 터뜨리는 것이었습니다. 어제는 시간이 급해서 이를 해결하지 못 했지만 다시 살펴보니 여기서도 조건부로 렌더링 하면 된다는 것을 깨닫고 이렇게 수정했습니다.

```tsx
{children.map((button, index) => {
  if (button) return <DropdownButton key={index} setIsOpen={setIsOpen} {...button.props} />;
  return null;
})}
```

이렇게 수정하니 이제 타입 에러가 일어나지 않게 됐고 문제를 해결할 수 있었습니다.


## 🫡 참고사항
