### PR TITLE
[FE] api 호출 개선 : 지출 내역 과정

### DIFF
--- a/client/src/hooks/queries/bill/useRequestDeleteBill.ts
+++ b/client/src/hooks/queries/bill/useRequestDeleteBill.ts
@@ -14,10 +14,12 @@ const useRequestDeleteBill = () => {
 
   const {mutate, ...rest} = useMutation({
     mutationFn: ({billId}: WithBillId) => requestDeleteBill({eventId, billId}),
-    onSuccess: () => {
+    onSuccess: (_, {billId}) => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
+
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestDeleteBill.ts
+++ b/client/src/hooks/queries/bill/useRequestDeleteBill.ts
@@ -15,11 +15,11 @@ const useRequestDeleteBill = () => {
   const {mutate, ...rest} = useMutation({
     mutationFn: ({billId}: WithBillId) => requestDeleteBill({eventId, billId}),
     onSuccess: (_, {billId}) => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers, eventId]});
 
-      queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId, eventId]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPostBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPostBill.ts
@@ -13,11 +13,11 @@ const useRequestPostBill = () => {
   const {mutate, ...rest} = useMutation({
     mutationFn: ({title, price, memberIds}: RequestPostBill) => requestPostBill({eventId, title, price, memberIds}),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
 
       // admin으로 navigate 되기 전 invalidate 실행 시 api를 불러오는 문제 발생 => remove를 사용하여 캐시 데이터 삭제하는 방식으로 해결s
-      queryClient.removeQueries({queryKey: [QUERY_KEYS.currentMembers]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.currentMembers, eventId]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPostBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPostBill.ts
@@ -15,7 +15,9 @@ const useRequestPostBill = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
+
+      // admin으로 navigate 되기 전 invalidate 실행 시 api를 불러오는 문제 발생 => remove를 사용하여 캐시 데이터 삭제하는 방식으로 해결s
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.currentMembers]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPostBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPostBill.ts
@@ -16,7 +16,7 @@ const useRequestPostBill = () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
 
-      // admin으로 navigate 되기 전 invalidate 실행 시 api를 불러오는 문제 발생 => remove를 사용하여 캐시 데이터 삭제하는 방식으로 해결s
+      // admin으로 navigate 되기 전 invalidate 실행 시 api를 불러오는 문제 발생 => remove를 사용하여 캐시 데이터 삭제하는 방식으로 해결
       queryClient.removeQueries({queryKey: [QUERY_KEYS.currentMembers, eventId]});
     },
   });

--- a/client/src/hooks/queries/bill/useRequestPutBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBill.ts
@@ -17,7 +17,6 @@ const useRequestPutBill = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPutBill.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBill.ts
@@ -15,8 +15,8 @@ const useRequestPutBill = () => {
   const {mutate, mutateAsync, ...rest} = useMutation({
     mutationFn: ({billId, title, price}: WithBillId<RequestPutBill>) => requestPutBill({eventId, billId, title, price}),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
     },
   });
 

--- a/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
@@ -16,9 +16,9 @@ const useRequestPutBillDetails = ({billId}: WithBillId) => {
     mutationFn: ({billId, billDetails}: WithBillId<RequestPutBillDetails>) =>
       requestPutBillDetails({eventId, billId, billDetails}),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
+      queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId, eventId]});
     },
     // onMutate: async (newMembers: MemberReportInAction[]) => {
     //   await queryClient.cancelQueries({queryKey: [QUERY_KEYS.memberReportInAction, actionId]});

--- a/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
+++ b/client/src/hooks/queries/bill/useRequestPutBillDetails.ts
@@ -18,7 +18,6 @@ const useRequestPutBillDetails = ({billId}: WithBillId) => {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       queryClient.removeQueries({queryKey: [QUERY_KEYS.billDetails, billId]});
     },
     // onMutate: async (newMembers: MemberReportInAction[]) => {

--- a/client/src/hooks/queries/member/useRequestPostMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPostMembers.ts
@@ -13,6 +13,8 @@ const useRequestPostMembers = () => {
   const {mutate, mutateAsync, data, ...rest} = useMutation({
     mutationFn: ({members}: RequestPostMembers) => requestPostMembers({eventId, members}),
     onSuccess: responseData => {
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
+
       // post member는 현재 post bill 이전에만 실행되므로 아래 invalidate는 무의미하지만 나중에 단독으로 이 api가 불릴 때를 위해서 남겨뒀습니다.
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});

--- a/client/src/hooks/queries/member/useRequestPostMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPostMembers.ts
@@ -13,11 +13,11 @@ const useRequestPostMembers = () => {
   const {mutate, mutateAsync, data, ...rest} = useMutation({
     mutationFn: ({members}: RequestPostMembers) => requestPostMembers({eventId, members}),
     onSuccess: responseData => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers, eventId]});
 
       // post member는 현재 post bill 이전에만 실행되므로 아래 invalidate는 무의미하지만 나중에 단독으로 이 api가 불릴 때를 위해서 남겨뒀습니다.
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps, eventId]});
+      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports, eventId]});
       return responseData;
     },
   });

--- a/client/src/hooks/queries/member/useRequestPostMembers.ts
+++ b/client/src/hooks/queries/member/useRequestPostMembers.ts
@@ -13,10 +13,9 @@ const useRequestPostMembers = () => {
   const {mutate, mutateAsync, data, ...rest} = useMutation({
     mutationFn: ({members}: RequestPostMembers) => requestPostMembers({eventId, members}),
     onSuccess: responseData => {
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
+      // post member는 현재 post bill 이전에만 실행되므로 아래 invalidate는 무의미하지만 나중에 단독으로 이 api가 불릴 때를 위해서 남겨뒀습니다.
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.steps]});
       queryClient.invalidateQueries({queryKey: [QUERY_KEYS.reports]});
-      queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
       return responseData;
     },
   });

--- a/client/src/hooks/useEditBillActions.ts
+++ b/client/src/hooks/useEditBillActions.ts
@@ -25,7 +25,7 @@ const useEditBillActions = ({bill, billDetails, newBill, newBillDetails}: Props)
   const {deleteBill, isSuccess: isSuccessDeleteBill} = useRequestDeleteBill();
   const {
     putBillDetails,
-    isSuccess: isSusseccPutBillDetails,
+    isSuccess: isSuccessPutBillDetails,
     isPending: isPendingPutBillDetails,
   } = useRequestPutBillDetails({billId: bill.id});
 
@@ -54,10 +54,10 @@ const useEditBillActions = ({bill, billDetails, newBill, newBillDetails}: Props)
   };
 
   useEffect(() => {
-    if (isSuccessDeleteBill || isSusseccPutBillDetails || (isSuccessPutBill && !isBillDetailsChanged)) {
+    if (isSuccessDeleteBill || isSuccessPutBillDetails || (isSuccessPutBill && !isBillDetailsChanged)) {
       navigate(`/event/${eventId}/admin`);
     }
-  }, [isSuccessDeleteBill, isSusseccPutBillDetails, isSuccessPutBill, isBillDetailsChanged]);
+  }, [isSuccessDeleteBill, isSuccessPutBillDetails, isSuccessPutBill, isBillDetailsChanged]);
 
   const isPendingUpdate = () => {
     if (!isBillChanged) {

--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -1,6 +1,5 @@
 import {useEffect, useRef} from 'react';
 import {useNavigate} from 'react-router-dom';
-import {useQueryClient} from '@tanstack/react-query';
 
 import {BillInfo} from '@pages/event/[eventId]/admin/add-bill/AddBillFunnel';
 import {Member} from 'types/serviceType';

--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -11,7 +11,6 @@ import isDuplicated from '@utils/isDuplicate';
 
 import RULE from '@constants/rule';
 import {ERROR_MESSAGE} from '@constants/errorMessage';
-import QUERY_KEYS from '@constants/queryKeys';
 
 import useRequestPostMembers from './queries/member/useRequestPostMembers';
 import useRequestPostBill from './queries/bill/useRequestPostBill';
@@ -31,7 +30,6 @@ interface Props {
 const useMembersStep = ({billInfo, setBillInfo, setStep}: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const hiddenRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
 
   const {trackAddBillEnd} = useAmplitude();
 
@@ -93,20 +91,13 @@ const useMembersStep = ({billInfo, setBillInfo, setStep}: Props) => {
             name,
           })),
       });
-      postBill(
-        {
-          title: billInfo.title,
-          price: Number(billInfo.price.replace(/,/g, '')),
-          memberIds: billInfo.members.map(member =>
-            member.id === -1 ? newMembers.members.find(m => m.name === member.name)?.id || member.id : member.id,
-          ),
-        },
-        {
-          onSettled: () => {
-            queryClient.invalidateQueries({queryKey: [QUERY_KEYS.allMembers]});
-          },
-        },
-      );
+      postBill({
+        title: billInfo.title,
+        price: Number(billInfo.price.replace(/,/g, '')),
+        memberIds: billInfo.members.map(member =>
+          member.id === -1 ? newMembers.members.find(m => m.name === member.name)?.id || member.id : member.id,
+        ),
+      });
     } else {
       postBill({
         title: billInfo.title,


### PR DESCRIPTION
## issue
- close #921 

## 문제 상황


| 지출 내역을 추가할 때 인원을 추가하는 경우             | 지출 내역을 수정하는 경우            |
|--------------------------------------|--------------------------------------|
| ![image1](https://github.com/user-attachments/assets/dc7d37c2-f2a3-488c-9239-ff896b57fc80) | ![image2](https://github.com/user-attachments/assets/f7cabbea-3d06-46b8-9df2-655b93f2430a) | 


## 지출 내역 추가

### 개선 전
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/34b2812e-3f6b-4ef0-8373-288d41d81ba4" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/1aca1007-ea5e-4b4b-8bd0-d16a40935d39" width="300"/>
    </td>
    <td>
<img src="https://github.com/user-attachments/assets/b9abb912-2209-498a-8c58-21f2be99e72b" width="300" />
    </td>
  </tr>
</table>

___ 


개선 전의 모습을 보면 지출 내역 추가 시 api 호출이 총 5번이 일어나는 모습을 확인할 수 있고 그 중 **current api는 두 번 요청되는 모습**을 확인할 수 있습니다. 이 문제를 발견 후 각 페이지 별 캐시 상태를 비교해봤습니다.  (위 세 번째 사진 참고)

여기서 주목할 데이터는 `currentMembers` 입니다. 지출 내역 추가 후 관리 페이지로 이동한 후에는 currentMembers 데이터가 필요하지 않지만 두 번이나 서버로 요청을 보내는 문제가 있었습니다.


### 문제 원인
useRequestPostMembers와 useRequestPostBill hook에서 mutate 실행 후 invalidate를 해주는 과정에서 불필요한 api가 호출되었습니다.

우선 invalidateQueries가 실행된 후 언제 서버로 api를 호출하는지 설명하겠습니다. invalidateQueries는 캐시 데이터를 fresh에서 stale상태로 무효화 시켜줍니다. 그러면 데이터가 상했으니 서버로부터 최신 데이터를 불러오게 됩니다. 여기서 **서버로 요청을 보내는 조건은 캐시 데이터가 active할 때**입니다. 캐시 데이터가 active하는 것은 현재 마운트 되어있는 컴포넌트에서 사용하는 데이터입니다.


이 점을 인지한 상태로 아래 코드를 보면 문제를 알 수 있습니다.
```ts
const handlePostBill = async () => {
  const newMembers = await postMembersAsync();
  postBill(newMembers);
};

useEffect(() => {
  if (isSuccessPostBill) {
    navigate(`/event/${eventId}/admin`);
  }
}, [isSuccessPostBill]);
```

먼저 handlePostBill가 실행되면 postMembersAsync이 실행된 후 onSuccess가 실행되어 allMembers, steps, reports, currentMembers 캐시 데이터가 무효화됩니다. 그 다음으로 postBill이 실행된 후 onSuccess가 실행되어 steps, reports, currentMembers 캐시 데이터가 무효화됩니다. 마지막으로 isSuccessPostBill 상태가 true가 되어 그제서야 관리 페이지로 이동합니다.

`currentMembers`를 특정해서 문제 상황을 살펴보면 postMembersAsync가 실행된 후 요청이 성공해서 currentMembers가 무효화 되었습니다. 이 순간은 페이지 이동하기 전이라 currentMembers 데이터가 active합니다. 그래서 즉시 서버로 currentMembers 요청을 보내게 됩니다. 그 후 postBill이 실행되고 요청이 성공하여 currentMembers가 무효화 되었습니다. 이 순간도 페이지 이동하기 전이라 currentMembers 데이터가 active합니다. 그래서 즉시 서버로 currentMembers 요청을 보내게 됩니다. 마지막으로 isSuccessPostBill 상태가 true가 되어 그제서야 관리 페이지로 이동하게 됩니다. 하지만 관리 페이지에서는 currentMembers 데이터가 inactive한 상태입니다.


### 해결 방법
우선 postMembersAsync mutation의 onSuccess에서 currentMembers invalidate를 지워줬습니다. postMembersAsync는 항상 postBill 전에만 실행이 되기 때문에 문제 없다고 판단했습니다.

그 다음으로 useRequestPostBill에서 currentMembers를 invalidateQueries에서 removeQueries로 바꿔줬습니다.
```ts
queryClient.removeQueries({queryKey: [QUERY_KEYS.currentMembers]});
```

여기서는 단순히 코드를 지우지 않고 변경해 준 이유는 지출 내역 추가가 됐음에도 currentMembers 상태가 변하지 않는다면 다음 지출 내역을 추가할 때 영향이 생길 수 있기 때문입니다. 처리는 해줘야 하지만 invalidateQueries를 사용하면 stale로 변하고 현재 데이터가 active하기 때문에 바로 서버로 요청이 갑니다. 이 때 removeQueries를 사용해서 캐시 데이터를 아에 지워버린다면 서버로 요청하는 시점을 다음 지출 내역 추가로 미룰 수 있게 됩니다. (캐시 데이터를 아예 삭제했으므로 currentMembers 캐시 상태는 stale도 아니게 돼서 다시 요청도 하지 않는 원리)


### 개선 결과

불필요한 currentMembers 요청을 두 개 줄이게 되어 get 요청을 이전 5번에서 3번으로 api 호출을 줄일 수 있었습니다.

<img src="https://github.com/user-attachments/assets/5cf5bcdd-2c14-45ff-9961-43c981fa5f23" />


## 지출 내역 수정

### 개선 전

내역 수정 후 지출 내역을 추가할 때 비효율이 발생합니다.
지출 내역을 수정하는 것은 현재 참여 인원의 변동을 일으키지 않습니다. 금액과 차등 정산만 가능하기 때문입니다.
하지만 지출 내역을 수정할 때 currentMembers 캐시 데이터를 무효화해서 지출 내역을 추가할 때 다시 api를 호출합니다.


### 해결 방법
put과, put detail hook onSuccess 아래 코드를 제거했습니다.

```ts
queryClient.invalidateQueries({queryKey: [QUERY_KEYS.currentMembers]});
```

### 개선 결과
지출 내역을 수정 후 등록할 때 current api를 새로 보내지 않아도 돼서 current api 호출 수 1개를 줄였습니다.



## 🫡 참고사항
### 지출 내역 삭제할 때 지출 상세 캐시 데이터 삭제
지출 내역이 삭제되면 더 이상 지출 상세 캐시 데이터를 가지고 있을 필요가 없습니다. 더 이상 호출될 일이 없기 때문입니다.
그래서 캐시 데이터를 삭제하는 removeQueries를 호출하여 캐시 데이터를 지웠습니다.

