### PR TITLE
[FE] api 호출 개선 : 이벤트 페이지 진입 시 같은 api 7개씩 호출되는 문제

### DIFF
--- a/client/src/components/Loader/EventData/EventDataLoader.tsx
+++ b/client/src/components/Loader/EventData/EventDataLoader.tsx
@@ -7,6 +7,10 @@ import EventDataProvider from './EventDataProvider';
 const EventDataLoader = () => {
   const eventData = useEventLoader();
 
+  if (eventData.isFetching) {
+    return null;
+  }
+
   return (
     <EventDataProvider {...eventData}>
       <Outlet />

--- a/client/src/components/Loader/EventData/EventDataProvider.tsx
+++ b/client/src/components/Loader/EventData/EventDataProvider.tsx
@@ -1,15 +1,14 @@
 import {createContext, PropsWithChildren} from 'react';
 
-import {Event, EventId} from 'types/serviceType';
+import useEventLoader from '@hooks/useEventLoader';
 
 import {useAuthStore} from '@store/authStore';
 
-type EventDataContextType = Event & {
-  eventToken: EventId;
+type EventDataContextType = ReturnType<typeof useEventLoader> & {
   isAdmin: boolean;
 };
 
-type EventDataProviderProps = PropsWithChildren<Omit<EventDataContextType, 'isAdmin'>>;
+type EventDataProviderProps = Omit<PropsWithChildren<EventDataContextType>, 'isAdmin'>;
 
 export const EventDataContext = createContext<EventDataContextType | null>(null);
 

--- a/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
+++ b/client/src/hooks/queries/auth/useRequestPostAuthentication.ts
@@ -3,6 +3,8 @@ import {useNavigate} from 'react-router-dom';
 
 import {requestPostAuthentication} from '@apis/request/auth';
 
+import useEventDataContext from '@hooks/useEventDataContext';
+
 import {useAuthStore} from '@store/authStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
@@ -11,14 +13,12 @@ import SessionStorage from '@utils/SessionStorage';
 import SESSION_STORAGE_KEYS from '@constants/sessionStorageKeys';
 import {ROUTER_URLS} from '@constants/routerUrls';
 
-import useRequestGetEvent from '../event/useRequestGetEvent';
-
 const useRequestPostAuthentication = () => {
   const eventId = getEventIdByUrl();
   const navigate = useNavigate();
   const {updateAuth} = useAuthStore();
 
-  const {createdByGuest} = useRequestGetEvent();
+  const {createdByGuest} = useEventDataContext();
 
   const isSecondEncounteredOnError = () => {
     return window.location.pathname.includes('/login/guest') || window.location.pathname.includes('/login/user');

--- a/client/src/hooks/useAdminPage.ts
+++ b/client/src/hooks/useAdminPage.ts
@@ -2,17 +2,14 @@ import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
-import useRequestGetSteps from './queries/step/useRequestGetSteps';
 import useBanner from './useBanner';
 import useEventDataContext from './useEventDataContext';
 
 const useAdminPage = () => {
   const eventId = getEventIdByUrl();
-  const {isAdmin, bankName, accountNumber, eventName, createdByGuest} = useEventDataContext();
+  const {isAdmin, bankName, accountNumber, eventName, createdByGuest, steps} = useEventDataContext();
 
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
-
-  const {steps} = useRequestGetSteps();
 
   const {isShowAccountBanner, onDeleteAccount, isShowDepositStateBanner, onDeleteDepositState} = useBanner({
     eventId,

--- a/client/src/hooks/useEventLoader.ts
+++ b/client/src/hooks/useEventLoader.ts
@@ -23,24 +23,37 @@ const useEventLoader = () => {
 
   const queries = useSuspenseQueries({
     queries: [
-      {queryKey: [QUERY_KEYS.event, eventId], queryFn: () => requestGetEvent({eventId})},
+      {
+        queryKey: [QUERY_KEYS.event, eventId],
+        queryFn: () => requestGetEvent({eventId}),
+        initialData: {eventName: '', bankName: 'KB국민은행', accountNumber: '', createdByGuest: true},
+        initialDataUpdatedAt: 0,
+      },
       {
         queryKey: [QUERY_KEYS.reports, eventId],
         queryFn: () => requestGetReports({eventId}),
+        initialData: {reports: []},
+        initialDataUpdatedAt: 0,
       },
       {
         queryKey: [QUERY_KEYS.steps, eventId],
         queryFn: () => requestGetSteps({eventId}),
+        initialData: [],
+        initialDataUpdatedAt: 0,
       },
       {
         queryKey: [QUERY_KEYS.allMembers, eventId],
         queryFn: () => requestGetAllMembers({eventId}),
+        initialData: {members: []},
+        initialDataUpdatedAt: 0,
       },
     ],
   });
 
   const [eventData, reportsData, stepsData, membersData] = queries;
   const {data, isSuccess} = stepsData;
+
+  const isFetching = queries.some(query => query.isFetching);
 
   useEffect(() => {
     if (isSuccess && data) {
@@ -56,6 +69,10 @@ const useEventLoader = () => {
     accountNumber,
     createdByGuest,
     eventToken: eventId,
+    steps: stepsData.data,
+    reports: reportsData.data.reports,
+    members: membersData.data.members,
+    isFetching,
   };
 };
 

--- a/client/src/hooks/useEventPageLayout.ts
+++ b/client/src/hooks/useEventPageLayout.ts
@@ -2,17 +2,14 @@ import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 
-import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
-import useRequestGetSteps from './queries/step/useRequestGetSteps';
 import useRequestGetUserInfo from './queries/auth/useRequestGetUserInfo';
 import useEventDataContext from './useEventDataContext';
 
 const useEventPageLayout = () => {
   const eventId = getEventIdByUrl();
-  const {isAdmin, eventName, bankName, accountNumber, createdByGuest} = useEventDataContext();
+  const {isAdmin, eventName, bankName, accountNumber, createdByGuest, steps, members} = useEventDataContext();
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
-  const {members} = useRequestGetAllMembers();
-  const {steps} = useRequestGetSteps();
+
   const {userInfo} = useRequestGetUserInfo();
   const billsCount = steps.flatMap(step => [...step.bills]).length;
 

--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -16,8 +16,8 @@ import useRequestPostBill from './queries/bill/useRequestPostBill';
 import {BillStep} from './useAddBillFunnel';
 import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
 import useAmplitude from './useAmplitude';
-import useRequestGetEvent from './queries/event/useRequestGetEvent';
 import useMemberName from './useMemberName';
+import useEventDataContext from './useEventDataContext';
 
 interface Props {
   billInfo: BillInfo;
@@ -38,7 +38,7 @@ const useMembersStep = ({billInfo, setBillInfo, setStep}: Props) => {
   const {postBill, isSuccess: isSuccessPostBill, isPending: isPendingPostBill} = useRequestPostBill();
   const navigate = useNavigate();
   const eventId = getEventIdByUrl();
-  const {eventName} = useRequestGetEvent();
+  const {eventName} = useEventDataContext();
 
   const {name, handleNameChange, clearMemberName, errorMessage} = useMemberName();
 

--- a/client/src/pages/event/[eventId]/home/HomePage.tsx
+++ b/client/src/pages/event/[eventId]/home/HomePage.tsx
@@ -1,7 +1,6 @@
 import {useLocation, useMatch, useNavigate} from 'react-router-dom';
 
 import StepList from '@components/StepList/Steps';
-import useRequestGetSteps from '@hooks/queries/step/useRequestGetSteps';
 import Reports from '@components/Reports/Reports';
 import useRequestGetImages from '@hooks/queries/images/useRequestGetImages';
 import {IconPictureSquare} from '@components/Design/components/Icons/Icons/IconPictureSquare';
@@ -20,10 +19,9 @@ import {receiptStyle} from './HomePage.style';
 
 const HomePage = () => {
   const location = useLocation();
-  const {isAdmin, eventName} = useEventDataContext();
+  const {isAdmin, eventName, steps} = useEventDataContext();
   const isInHomePage = useMatch(ROUTER_URLS.home) !== null;
 
-  const {steps} = useRequestGetSteps();
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
   const {images} = useRequestGetImages();
   const navigate = useNavigate();


### PR DESCRIPTION
## issue
- close #922 

### 문제 상황
이벤트 페이지 접속 시 같은 api 요청이 7~8번씩 발생하는 문제가 있었습니다.
event, steps, reports, all members 요청이 반복적으로 실행되어 초기에 30번 이상 요청을 보내는 모습을 보고 경악을;;;;;;

다행이 원인을 발견하였고, SuspenseQueries의 initialData를 설정해주지 않아서였습니다.... 

### 해결 방법
suspenseQueries 옵션으로 initialData를 설정하고 initialDataUpdatedAt: 0을 설정했습니다.
initialDataUpdatedAt: 0을 설정한 이유는 이를 설정하지 않으면 초기 데이터를 화면에 보여주고 api 요청을 보내지 않게 되기 때문입니다.

```tsx
{
  queryKey: [QUERY_KEYS.event, eventId],
  queryFn: () => requestGetEvent({eventId}),
  initialData: {eventName: '', bankName: 'KB국민은행', accountNumber: '', createdByGuest: true},
  initialDataUpdatedAt: 0,
},
```

이렇게 하고 끝났을 때 문제가 하나 생겼습니다. 바로 Suspense의 Fallback 컴포넌트가 보이지 않게 된 것이었습니다.
SuspenseQueries를 적용한 이유가 로딩 화면을 선언적으로 보여주기 위함인데 이렇게 되어버리면 Suspense를 적용하는 의미가 없어진다고 생각했습니다.

https://github.com/user-attachments/assets/9189b6dc-108e-4806-836e-3d36c409f7cc

그래서 생각해낸 대안으로 queries 반환 값인 isFetching을 사용하는 것입니다.

```ts
const isFetching = queries.some(query => query.isFetching);
```

isFetching이 모두 false가 될 때까지 isFetching은 true가 되고 이 값이 true일 때 return null을 주어 데이터 fetching 중에는 하위 컴포넌트가 렌더링 되지 않도록 막았습니다. 이로써 fallback 컴포넌트가 보이면서 initial data가 보이는 현상을 막을 수 있었습니다.

https://github.com/user-attachments/assets/c2de311d-080f-481b-bf43-60799003d644


### 아쉬운 점
initial data를 넣어주지 않았을 때 왜 같은 요청이 7번씩 발생하는지 원인을 찾지 못 했어요. 어쩌다 보니 해결이 되었지만 원인을 명확하게 파악 후 해결한 것이 아니라 찜찜합니다..


## 🫡 참고사항
