### PR TITLE
[FE] 계좌번호 입력 제한 글자 수 세는 정책 변경

### DIFF
--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -15,7 +15,8 @@ type UseAccountArgs = {
 const canEditAccountNumber = (newAccountNumber: string) => {
   return (
     newAccountNumber === '' ||
-    (newAccountNumber.length <= RULE.maxAccountNumberLength && REGEXP.accountNumber.test(newAccountNumber))
+    (newAccountNumber.replace(/[-\s]/g, '').length <= RULE.maxAccountNumberLength &&
+      REGEXP.accountNumber.test(newAccountNumber))
   );
 };
 

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 
-import validateAccountNumber from '@utils/validate/validateAccountNumber';
+import validateAccountNumber, {cleanedFormatAccountNumber} from '@utils/validate/validateAccountNumber';
 import {BankAccount, BankName} from 'types/serviceType';
 
 import RULE from '@constants/rule';
@@ -15,7 +15,7 @@ type UseAccountArgs = {
 const canEditAccountNumber = (newAccountNumber: string) => {
   return (
     newAccountNumber === '' ||
-    (newAccountNumber.replace(/[-\s]/g, '').length <= RULE.maxAccountNumberLength &&
+    (cleanedFormatAccountNumber(newAccountNumber).length <= RULE.maxAccountNumberLength &&
       REGEXP.accountNumber.test(newAccountNumber))
   );
 };

--- a/client/src/utils/validate/validateAccountNumber.ts
+++ b/client/src/utils/validate/validateAccountNumber.ts
@@ -4,18 +4,17 @@ import RULE from '@constants/rule';
 
 import {ValidateResult} from './type';
 
+export const cleanedFormatAccountNumber = (accountNumber: string) => accountNumber.replace(/[-\s]/g, '');
+
 const validateAccountNumber = (accountNumber: string): Pick<ValidateResult, 'errorMessage'> => {
-  const sanitizedAccountNumber = accountNumber.replace(/[-\s]/g, '');
+  const accountNumberLength = cleanedFormatAccountNumber(accountNumber).length;
 
   const isValidateFormat = () => {
     return REGEXP.accountNumber.test(accountNumber);
   };
 
   const isValidateLength = () => {
-    return (
-      sanitizedAccountNumber.length >= RULE.minAccountNumberLength &&
-      sanitizedAccountNumber.length <= RULE.maxAccountNumberLength
-    );
+    return accountNumberLength >= RULE.minAccountNumberLength && accountNumberLength <= RULE.maxAccountNumberLength;
   };
 
   const getErrorMessage = () => {

--- a/client/src/utils/validate/validateAccountNumber.ts
+++ b/client/src/utils/validate/validateAccountNumber.ts
@@ -5,7 +5,7 @@ import RULE from '@constants/rule';
 import {ValidateResult} from './type';
 
 const validateAccountNumber = (accountNumber: string): Pick<ValidateResult, 'errorMessage'> => {
-  const slicedAccountNumber = accountNumber.slice(0, RULE.maxAccountNumberLength);
+  const sanitizedAccountNumber = accountNumber.replace(/[-\s]/g, '');
 
   const isValidateFormat = () => {
     return REGEXP.accountNumber.test(accountNumber);
@@ -13,8 +13,8 @@ const validateAccountNumber = (accountNumber: string): Pick<ValidateResult, 'err
 
   const isValidateLength = () => {
     return (
-      slicedAccountNumber.length >= RULE.minAccountNumberLength &&
-      slicedAccountNumber.length <= RULE.maxAccountNumberLength
+      sanitizedAccountNumber.length >= RULE.minAccountNumberLength &&
+      sanitizedAccountNumber.length <= RULE.maxAccountNumberLength
     );
   };
 


### PR DESCRIPTION
## issue
- close #657 

## 구현 사항

validate 길이를 체크하는 함수에서 공백과 대시를 제거해서 세도록 변경했습니다.
아주 오래된 이슈를 털었어요 드디어ㅋㅋㅋ

        
| 30자 이상이어도 대시가 포함되면 정상             | 8자여도 대시가 포함되면 오류 메시지              | 공백도 위와 동일                           |
|--------------------------------------|--------------------------------------|--------------------------------------|
| ![image1](https://github.com/user-attachments/assets/1c40bc4f-f762-4050-8d9c-00592d37c256) | ![image2](https://github.com/user-attachments/assets/688df640-805b-4055-a7ac-54d3683d368a) | ![image3](https://github.com/user-attachments/assets/5a1c1d42-c1d5-4ee1-a9dc-b389a8ae5c0f) |



## 🫡 참고사항
