### PR TITLE
[FE] API_BASE_URL에서 널 병합 연산자 제거

### DIFF
--- a/client/src/apis/request.ts
+++ b/client/src/apis/request.ts
@@ -45,7 +45,7 @@ type FetchType = {
   requestInit: RequestInitWithMethod;
 };
 
-const API_BASE_URL = process.env.API_BASE_URL ?? '';
+const API_BASE_URL = process.env.API_BASE_URL;
 
 export const requestGet = async <T>({
   headers = {},


### PR DESCRIPTION
## issue
- close #702 

## 구현 사항
API_BASE_URL에서 널 병합 연산자 제거했습니다.
global.d.ts에서 env에 대한 타입이 string으로 단언 되었으므로 undefined를 고려하지 않아도 됩니다.


## 🫡 참고사항
