### PR TITLE
[FE] 전체 참여자 관리 : 참여자 이름이 1개 남았을 경우 지울 수 없는 버그

### DIFF
--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -2,6 +2,7 @@ import {useEffect, useState, useCallback, useMemo} from 'react';
 
 import {Report} from 'types/serviceType';
 import validateMemberName from '@utils/validate/validateMemberName';
+import {ReturnUseEventMember} from '@pages/event/[eventId]/admin/members/MemberPageType';
 
 import MESSAGE from '@constants/message';
 
@@ -9,15 +10,6 @@ import toast from './useToast/toast';
 import useRequestDeleteMember from './queries/member/useRequestDeleteMember';
 import useRequestPutMembers from './queries/member/useRequestPutMembers';
 import useRequestGetReports from './queries/report/useRequestGetReports';
-
-interface ReturnUseEventMember {
-  reports: Report[];
-  canSubmit: boolean;
-  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
-  toggleDepositStatus: (memberId: number) => void;
-  handleDeleteMember: (memberId: number) => void;
-  updateMembersOnServer: () => void;
-}
 
 const useEventMember = (): ReturnUseEventMember => {
   const {reports: initialReports} = useRequestGetReports();

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -13,7 +13,7 @@ import useRequestGetReports from './queries/report/useRequestGetReports';
 interface ReturnUseEventMember {
   reports: Report[];
   canSubmit: boolean;
-  changeMemberName: (memberId: number, newName: string) => void;
+  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
   toggleDepositStatus: (memberId: number) => void;
   handleDeleteMember: (memberId: number) => void;
   updateMembersOnServer: () => void;
@@ -61,7 +61,8 @@ const useEventMember = (): ReturnUseEventMember => {
   }, [reports, initialReports, deleteMembers]);
 
   const changeMemberName = useCallback(
-    (memberId: number, newName: string) => {
+    (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => {
+      const newName = e.target.value;
       // 유효성 검사
       if (!validateMemberName(newName).isValid && newName.length !== 0) {
         return;

--- a/client/src/hooks/useEventMember.ts
+++ b/client/src/hooks/useEventMember.ts
@@ -62,8 +62,8 @@ const useEventMember = (): ReturnUseEventMember => {
 
   const changeMemberName = useCallback(
     (memberId: number, newName: string) => {
-      // 유효성 검사 (4자 이하)
-      if (!validateMemberName(newName).isValid) {
+      // 유효성 검사
+      if (!validateMemberName(newName).isValid && newName.length !== 0) {
         return;
       }
 

--- a/client/src/pages/event/[eventId]/admin/members/MemberPageType.ts
+++ b/client/src/pages/event/[eventId]/admin/members/MemberPageType.ts
@@ -1,0 +1,17 @@
+import {Report} from 'types/serviceType';
+
+interface MemberActions {
+  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
+  toggleDepositStatus: (memberId: number) => void;
+  handleDeleteMember: (memberId: number) => void;
+}
+
+export interface ReturnUseEventMember extends MemberActions {
+  reports: Report[];
+  canSubmit: boolean;
+  updateMembersOnServer: () => void;
+}
+
+export interface MemberProps extends MemberActions {
+  member: Report;
+}

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
@@ -53,6 +53,10 @@ export const memberEditInput = (theme: Theme) =>
     '&:has(input:focus)': {
       borderBottom: `1px solid ${theme.colors.primary}`,
     },
+
+    '&:placeholder': {
+      color: theme.colors.darkGray,
+    },
   });
 
 export const deleteButtonStyle = css({

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
@@ -47,6 +47,7 @@ export const memberEditInput = (theme: Theme) =>
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    color: theme.colors.black,
     borderBottom: `1px solid ${theme.colors.tertiary}`,
     ...TYPOGRAPHY.bodyBold,
 

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
@@ -66,7 +66,7 @@ const MembersPage = () => {
 
 interface MemberProps {
   member: Report;
-  changeMemberName: (memberId: number, newName: string) => void;
+  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
   handleDeleteMember: (memberId: number) => void;
   toggleDepositStatus: (memberId: number) => void;
 }
@@ -77,11 +77,7 @@ const Member = ({member, changeMemberName, handleDeleteMember, toggleDepositStat
   return (
     <div css={eventMember} id={`${member.memberId}`}>
       <div css={memberEditInput(theme)}>
-        <input
-          type="text"
-          value={member.memberName}
-          onChange={e => changeMemberName(member.memberId, e.target.value)}
-        />
+        <input type="text" value={member.memberName} onChange={e => changeMemberName(member.memberId, e)} />
         <IconEdit size={14} />
       </div>
       <div style={{display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem'}}>

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
@@ -71,7 +71,12 @@ const Member = ({member, changeMemberName, handleDeleteMember, toggleDepositStat
   return (
     <div css={eventMember} id={`${member.memberId}`}>
       <div css={memberEditInput(theme)}>
-        <input type="text" value={member.memberName} onChange={e => changeMemberName(member.memberId, e)} />
+        <input
+          type="text"
+          value={member.memberName}
+          onChange={e => changeMemberName(member.memberId, e)}
+          placeholder="행댕이"
+        />
         <IconEdit size={14} />
       </div>
       <div style={{display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem'}}>

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
@@ -74,14 +74,14 @@ interface MemberProps {
 const Member = ({member, changeMemberName, handleDeleteMember, toggleDepositStatus}: MemberProps) => {
   const {theme} = useTheme();
 
-  const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    changeMemberName(member.memberId, e.target.value);
-  };
-
   return (
     <div css={eventMember} id={`${member.memberId}`}>
       <div css={memberEditInput(theme)}>
-        <input type="text" value={member.memberName} onChange={e => handleChangeName(e)} />
+        <input
+          type="text"
+          value={member.memberName}
+          onChange={e => changeMemberName(member.memberId, e.target.value)}
+        />
         <IconEdit size={14} />
       </div>
       <div style={{display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem'}}>

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import {Report} from 'types/serviceType';
+
 import {useTheme} from '@components/Design/theme/HDesignProvider';
 import {IconEdit} from '@components/Design/components/Icons/Icons/IconEdit';
 import {IconTrash} from '@components/Design/components/Icons/Icons/IconTrash';
@@ -8,6 +8,7 @@ import useEventMember from '@hooks/useEventMember';
 
 import {MainLayout, TopNav, Top, Amount, DepositToggle, IconButton, FixedButton, Text} from '@components/Design';
 
+import {MemberProps} from './MemberPageType';
 import {
   eventMemberStyle,
   memberList,
@@ -63,13 +64,6 @@ const MembersPage = () => {
     </MainLayout>
   );
 };
-
-interface MemberProps {
-  member: Report;
-  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleDeleteMember: (memberId: number) => void;
-  toggleDepositStatus: (memberId: number) => void;
-}
 
 const Member = ({member, changeMemberName, handleDeleteMember, toggleDepositStatus}: MemberProps) => {
   const {theme} = useTheme();


### PR DESCRIPTION
## issue
- close #934

## 버그 발생 상황

- 버그 발생 페이지 : 전체 참여자 관리
- 버그 발생 상황: 참여자 이름 변경을 위해 input에 값을 지울 경우
- 버그: 글자가 1개 남았을 경우 더이상 값이 지워지지 않음
- 예상 정상 작동 결과: input에 값이 모두 지워지고 placeholder 문구가 보여야 함

https://github.com/user-attachments/assets/eb9db413-f221-4e6b-9dd6-1716a7211c3e

## 버그 원인

4주전 task에서 validateMemberName 함수에서 member의 글자수를 체크하는 validateLength의 범위가 변경되었습니다.

- 기존 (0도 포함)
    
    ```tsx
     const validateLength = () => {
        return slicedName.length >= 0;
      };
    ```
    
- 변경 (0 미포함)
    
    ```tsx
     const validateLength = () => {
        return slicedName.length > 0;
      };
    ```
    

이전에는 제가 구현하면서 글자수 범위를 0도 포함하도록 구현했었습니다. validateMemberName을 사용하는 곳에서 0일 경우 버튼 submit이 불가능하도록 막았습니다.

이런 방식은 validate라는 이름이 붙은 함수와는 부적합하다는 것을 이번 버그를 해결하는 과정에서 느꼈습니다.
0을 포함하여 validate 함수를 구현했기 때문에 추후 다른 작업에서 validateMemberName을 사용하면서 혼동을 야기했습니다.

## 버그 해결 과정

validateMemberName에서의 validateLength는 변경되었던 것처럼 0을 미포함하도록 그대로 두었습니다.

### 실패 | 기존에 존재하던 useMemberName을 활용하는 방식으로 변경하기

useMemberName 훅은 회원의 이름을 변경하는 곳과 비회원의 관리자 이름을 생성하는 곳, 지출내역을 추가할 때 member의 이름을 입력하는 step에서 사용하고 있습니다.

전체 참여자 관리 페이지 또한 동일한 회원 이름 방식을 사용하고 있기 때문에 회원의 이름을 변경하는 로직에는 useMemberName을 활용하도록 수정하고 싶었습니다만…

위에서 언급한 useMemberName을 사용하는 3곳은 모두 Input이 하나인 곳입니다. 그러나 전체 참여자 관리 페이지는 input이 여러 개인 곳이죠. 
이곳에서 useMemberName을 사용하기 위해 MemberPage 혹은 useEventMember hook에서 도저언..해보았으나 다른 버그가 발생하거나 사용할 수가 없는 등의 문제가 발생하여… useMemberName을 사용하는 것을 포기했습니다.. 따흙

### 성공 | useEventMember의 changeMemberName에 조건문 추가하기

changeMemberName은 각 참여자 input의 값을 변경시키기 위한 함수입니다.

```
 const changeMemberName = useCallback(
    (memberId: number, newName: string) => {
      // 유효성 검사
      if (!validateMemberName(newName).isValid && newName.length !== 0) {
        return;
      }

      setReports(prevReports =>
        prevReports.map(report => (report.memberId === memberId ? {...report, memberName: newName} : report)),
      );
    },
    [setReports, validateMemberName],
  );
```

useMemberName을 사용하는 것 대신에 조건문을 추가하였습니다.

입력된 값이 유효하지 않을 경우(이때, 값의 길이가 0일 경우도 포함) 곧바로 return을 하도록 하여, 길이가 0일 경우 input에서 값을 지울 수 없었습니다. 이 부분을 수정하기 위해 `유효하지 않고 길이가 0이 아닐 경우` return하도록 조건을 추가하였습니다.

## 그외 리팩토링

### 중복되는 type 재활용

아래 두 인터페이스는 각각 useEvetMember와 MembersPage에서 사용되고 있습니다. 두 인터페이스를 보면 중복적으로 사용하는 타입이 보입니다.

```tsx
export interface ReturnUseEventMember {
  reports: Report[];
  canSubmit: boolean;
  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
  toggleDepositStatus: (memberId: number) => void;
  handleDeleteMember: (memberId: number) => void;
  updateMembersOnServer: () => void;
}

interface MemberProps {
  member: Report;
  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
  handleDeleteMember: (memberId: number) => void;
  toggleDepositStatus: (memberId: number) => void;
}
```

중복되는 타입 사용으로 인해 한 쪽에서 변경이 발생할 경우 다른 쪽의 interface에서도 동일하게 변경을 해줘야 합니다. 이 작업은.. 생각보다 번거로운 일이었습니다.

그래서 저는 MemberPage가 존재하는 폴더에 MemberPageType 파일을 생성하여 useEvetMember와 MembersPage에서 사용되는 타입을 관리해줬습니다.

해당 페이지에서 중복적으로 사용하는 타입을 MemberActions라는 인터페이스로 만들었고, 해당 인터페이스를 extends하여 각각의 인터페이스를 만들어 사용했습니다.

```tsx
import {Report} from 'types/serviceType';

interface MemberActions {
  changeMemberName: (memberId: number, e: React.ChangeEvent<HTMLInputElement>) => void;
  toggleDepositStatus: (memberId: number) => void;
  handleDeleteMember: (memberId: number) => void;
}

export interface ReturnUseEventMember extends MemberActions {
  reports: Report[];
  canSubmit: boolean;
  updateMembersOnServer: () => void;
}

export interface MemberProps extends MemberActions {
  member: Report;
}
```

위와 같이 변경되면서 한 곳에서 타입을 관리할 수 있어 코드를 관리하는데 더욱 편리해졌습니다.

### input에 placeholder추가

### input의 color를 theme의 black으로 변경

## 결과

https://github.com/user-attachments/assets/a00c6650-1567-4579-9de1-253e7756fb7f


## 논의하고 싶은 사항(선택)

위에서 제가 실패했던 useMemberName을 useEventMember에서도 재활용가능하게 할 수 있는 방법이 뭐가 있을까요..?

