### PR TITLE
[FE] 스타일에 플레이스 홀더가 두개 들어가있는 문제 해결

### DIFF
--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.style.ts
@@ -58,10 +58,6 @@ export const memberEditInput = (theme: Theme, isError: boolean, isEmpty: boolean
     '&:placeholder': {
       color: theme.colors.gray,
     },
-
-    '&:placeholder': {
-      color: theme.colors.darkGray,
-    },
   });
 
 export const deleteButtonStyle = css({


### PR DESCRIPTION
## issue
- close #939 

## 구현 사항
MemberPageStyle에서 플레이스 홀더에 들어가는 폰트 색상에 관한 스타일이 2개 있는 것을 배포과정에서 발견했습니다.
따라서  플레이스홀더 폰트 스타일 색상을 그레이 색상 하나만 적용시켜뒀습니다.

## 🫡 참고사항
