### PR TITLE
[FE] 지출 내역 인원 변동 step으로 들어갈 때 provider 오류

### DIFF
--- a/client/src/hooks/useMembersStep.ts
+++ b/client/src/hooks/useMembersStep.ts
@@ -17,7 +17,7 @@ import {BillStep} from './useAddBillFunnel';
 import useRequestGetAllMembers from './queries/member/useRequestGetAllMembers';
 import useAmplitude from './useAmplitude';
 import useMemberName from './useMemberName';
-import useEventDataContext from './useEventDataContext';
+import useRequestGetEvent from './queries/event/useRequestGetEvent';
 
 interface Props {
   billInfo: BillInfo;
@@ -38,7 +38,7 @@ const useMembersStep = ({billInfo, setBillInfo, setStep}: Props) => {
   const {postBill, isSuccess: isSuccessPostBill, isPending: isPendingPostBill} = useRequestPostBill();
   const navigate = useNavigate();
   const eventId = getEventIdByUrl();
-  const {eventName} = useEventDataContext();
+  const {eventName} = useRequestGetEvent();
 
   const {name, handleNameChange, clearMemberName, errorMessage} = useMemberName();
 


### PR DESCRIPTION
## issue
- close #944 

## 구현 사항
### useEventDataContext 문제 수정

eventName을 가져오기 위해 useEventDataContext를 사용했지만 실제로 context로 감싸지지 않아서 오류가 발생했습니다.
그래서 useRequestGetEvent를 사용해서 데이터를 불러오는 방식으로 변경했어요.

이 오류를 보면서 router.tsx도 같이 정리가 됐으면 하는 바람도 있습니다.
원래는 행사 페이지 안에 지출 내역 추가가 있지만 router.tsx에는 그렇지 않아서요..

## 🫡 참고사항
