### PR TITLE
[FE] iOS에서 아이콘이 제대로 보이지 않던 문제

### DIFF
--- a/client/src/components/Design/components/Icons/Svg.style.ts
+++ b/client/src/components/Design/components/Icons/Svg.style.ts
@@ -14,8 +14,11 @@ export const svgWrapperStyle = (width?: number, height?: number, size?: number) 
 };
 
 export const svgStyle = css`
+  width: 100%;
+  height: 100%;
+
   svg {
-    width: auto;
-    height: auto;
+    width: 100%;
+    height: 100%;
   }
 `;

--- a/client/src/components/Design/components/Icons/Svg.tsx
+++ b/client/src/components/Design/components/Icons/Svg.tsx
@@ -18,7 +18,7 @@ const Svg: React.FC<SvgProps> = ({children, color, size, width, height, directio
   const heightMatch = xmlString.match(/height="([^"]+)"/);
   const originHeight = heightMatch ? parseInt(heightMatch[1]) : 24;
 
-  const viewBox = `0 0 ${originWidth}px ${originHeight}px`;
+  const viewBox = `0 0 ${originWidth} ${originHeight}`;
 
   const fillMatch = xmlString.match(/fill="([^"]+)"/);
   const originFill = fillMatch ? fillMatch[1] : null;

--- a/client/src/components/Design/components/Icons/Svg.tsx
+++ b/client/src/components/Design/components/Icons/Svg.tsx
@@ -18,7 +18,7 @@ const Svg: React.FC<SvgProps> = ({children, color, size, width, height, directio
   const heightMatch = xmlString.match(/height="([^"]+)"/);
   const originHeight = heightMatch ? parseInt(heightMatch[1]) : 24;
 
-  const viewBox = `0 0 ${originWidth} ${originHeight}`;
+  const viewBox = `0 0 ${originWidth}px ${originHeight}px`;
 
   const fillMatch = xmlString.match(/fill="([^"]+)"/);
   const originFill = fillMatch ? fillMatch[1] : null;


### PR DESCRIPTION
## issue
- close #947 

## 구현 목적
현재 iOS에서 svg아이콘이 제대로 보이지 않는 문제가 있습니다.
이를 바로 잡기 위해 IconComponent를 변경합니다.

## 구현 사항
svg의 크기를 동적으로 조절하기 위해 
```tsx
export const svgStyle = css`
  svg {
    width: auto;
    height: auto;
  }
`;
```
처럼 사용했지만, 크롬에서는 부모의 위치에 맞도록 설정되지만, safari에선 fixed로 되는 것이 기본 설정이기 때문에, os에 따라서 다르게 보이는 문제가 있었습니다.

이에 아래와 같이 변경하였습니다.

```tsx
export const svgStyle = css`
  width: 100%;
  height: 100%;

  svg {
    width: 100%;
    height: 100%;
  }
`;
```

## 중점적으로 리뷰받고 싶은 부분(선택)
어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)
논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
