### PR TITLE
[FE] Github PR create, close 할 때 관련 이슈 status 조정

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,16 @@
+# Reviewer 자동 할당 설정
+addReviewers: true
+
+# Assignee를 Author로 설정
+addAssignees: author
+
+# Reviewer 추가할 사용자 목록
+reviewers:
+  - jinhokim98
+  - pakxe
+  - soi-ha
+  - Todari
+
+# 추가할 리뷰어 수
+# 0으로 설정하면 그룹 내 모든 리뷰어를 추가합니다 (기본값: 0)
+numberOfReviewers: 0

--- a/.github/workflows/frontend-sync-issue-to-pr.yml
+++ b/.github/workflows/frontend-sync-issue-to-pr.yml
@@ -2,7 +2,7 @@ name: Frontend Sync Issue Info to PR
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     branches: [fe-dev]
 
 jobs:

--- a/.github/workflows/frontend-sync-issue-to-pr.yml
+++ b/.github/workflows/frontend-sync-issue-to-pr.yml
@@ -1,0 +1,137 @@
+name: Frontend Sync Issue Info to PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [fe-dev]
+
+jobs:
+  sync-issue-info:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      # 1. Git 리포지토리 체크아웃
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      # 2. 브랜치 이름 추출 (#123 -> 123)
+      - name: Extract issue number from PR body
+        id: extract_issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
+        run: |
+          # Fetch PR body
+          PR_BODY=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}" \
+            | jq -r '.body')
+          # Extract issue number from PR body using regex (customize if needed)
+          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oP '#\d+' | head -1 | sed 's/#//')
+          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
+
+      # 3. Assignees는 actor로 Reviewer는 Frontend team member로 설정
+      - name: Add Assignees and Reviewers
+        uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: ".github/auto_assign.yml"
+
+      # 4. Issue에 설정되어있는 Labels와 Milestone을 PR에 추가
+      - name: Add Labels and Milestone From Issue
+        if: env.ISSUE_NUMBER != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
+        run: |
+          response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ env.ISSUE_NUMBER }})
+
+          # Extract issue_labels
+          issue_labels=$(echo "$response" | jq -r '.labels // [] | map(.name) | @json')
+
+          # Extract milestone
+          issue_milestone=$(echo "$response" | jq -r '.milestone.number // empty')
+
+          # Assign labels to PR
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d "$(jq -n --argjson labels "$issue_labels" '{"labels": $labels}')"
+
+          # Assign milestone to PR
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }} \
+            -d "$(jq -n --argjson milestone "$issue_milestone" '{"milestone": $milestone}')"
+
+      - name: Link Project and Issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
+          ORGANIZATION: "woowacourse-teams"
+          PROJECT_NUMBER: 53
+
+        run: |
+          # 조직 Project Node ID 가져오기
+          ORG_PROJECT_NODE_ID=$(curl -s -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            --url https://api.github.com/graphql \
+            --data '{"query":"query { organization(login: \"'$ORGANIZATION'\") { projectV2(number: '$PROJECT_NUMBER') { id } } }"}' \
+            | jq -r '.data.organization.projectV2.id')
+
+          # 현재 PR의 contentId 가져오기
+          PR_NODE_ID=$(curl -s -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            --url https://api.github.com/graphql \
+            --data '{"query":"query { repository(owner: \"'${{ github.repository_owner }}'\", name: \"'${{ github.event.repository.name }}'\") { pullRequest(number: '${{ github.event.pull_request.number }}') { id } } }"}' \
+            | jq -r '.data.repository.pullRequest.id')
+
+          # 특정 이슈의 contentId 가져오기
+          ISSUE_NODE_ID=$(curl -s -X POST \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Content-Type: application/json" \
+          --url https://api.github.com/graphql \
+          --data '{"query":"query { repository(owner: \"'${{ github.repository_owner }}'\", name: \"'${{ github.event.repository.name }}'\") { issue(number: '${{ env.ISSUE_NUMBER }}') { id } } }"}' \
+          | jq -r '.data.repository.issue.id')
+
+          # PR을 프로젝트에 추가
+          PR_RESPONSE=$(curl -s -X POST \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Content-Type: application/json" \
+          --url https://api.github.com/graphql \
+          --data '{"query":"mutation { addProjectV2ItemById(input: { projectId: \"'$ORG_PROJECT_NODE_ID'\", contentId: \"'$PR_NODE_ID'\" }) { item { id } } }"}')
+
+          # pr-item-id 추출
+          PR_ITEM_ID=$(echo "$PR_RESPONSE" | jq -r '.data.addProjectV2ItemById.item.id')
+          echo "PR_ITEM_ID=$PR_ITEM_ID" >> $GITHUB_ENV
+
+          # issue를 프로젝트에 추가 (이미 추가되어있지만 id를 알아내기 위함)
+          ISSUE_RESPONSE=$(curl -s -X POST \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Content-Type: application/json" \
+          --url https://api.github.com/graphql \
+          --data '{"query":"mutation { addProjectV2ItemById(input: { projectId: \"'$ORG_PROJECT_NODE_ID'\", contentId: \"'$ISSUE_NODE_ID'\" }) { item { id } } }"}')
+
+          # issue-item-id 추출
+          ISSUE_ITEM_ID=$(echo "$ISSUE_RESPONSE" | jq -r '.data.addProjectV2ItemById.item.id')
+          echo "ISSUE_ITEM_ID=$ISSUE_ITEM_ID" >> $GITHUB_ENV
+
+      - name: Set PR Status "🤼 In Review"
+        uses: kalgurn/update-project-item-status@main
+        with:
+          project-url: https://github.com/orgs/woowacourse-teams/projects/53
+          github-token: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
+          item-id: ${{ env.PR_ITEM_ID }}
+          status: "🤼 In Review"
+
+      - name: Set Issue Status "🤼 In Review"
+        uses: kalgurn/update-project-item-status@main
+        with:
+          project-url: https://github.com/orgs/woowacourse-teams/projects/53
+          github-token: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
+          item-id: ${{ env.ISSUE_ITEM_ID }}
+          status: "🤼 In Review"


### PR DESCRIPTION
## issue
- close #953 

### PR close action이 작동하지 않던 문제 해결
이전에 잘 돌아가던 action이 어느 순간부터 돌아가지 않게 되어 문제를 분석한 결과 secret의 CONFIG_SUBMODULE_TOKEN이 만료된 것이 원인이라는 것을 알게 되었습니다.

이를 새로 발급 받아 넣어줬을 때 정상 작동함을 확인했습니다. 여기서 이슈를 끝내기 아쉬워서 지금까지 불편하다고 생각했던 것을 이왕에 개선해보기로 했습니다.

**불편한 점: PR을 만들고 난 뒤 손수 Reviewers, Assignees, Labels, Projects, Milestone, Project status In Review 설정, issue In Review 설정을 해줘야 한다는 것이 너무 번거로움**

이것을 자동으로 해줄 수 있다면 너무 편해지지 않을까 해서 개선을 시도했습니다.

### PR이 생성될 때 자동으로 Assignees, Reviewers, Labels, Projects, Milestone을 설정
#### 1. Reviewers와 Assignees를 자동으로 설정

marketplace의 [kentaro-m/auto-assign-action@v2.0.0](https://github.com/kentaro-m/auto-assign-action/tree/v2.0.0/)을 사용하여 구현했습니다.

./github/auto_assign.yml에서 설정을 수정할 수 있습니다.

PR이 생성될 때 자동으로 Reviewer를 달고 그 목록을 우리 프론트엔드 멤버로 구성했습니다. 
또한 assignees는 PR을 생성하는 사람으로 설정했습니다. 예로 제가 PR을 생성하면 Assignees에는 제가 할당되고, Reviewer에는 토다리, 웨디, 소하가 설정됩니다. 너무 편하겠죠~ㅋㅋ

```yml
# Reviewer 자동 할당 설정
addReviewers: true

# Assignee를 Author로 설정
addAssignees: author

# Reviewer 추가할 사용자 목록
reviewers:
  - jinhokim98
  - pakxe
  - soi-ha
  - Todari

# 추가할 리뷰어 수
# 0으로 설정하면 그룹 내 모든 리뷰어를 추가합니다 (기본값: 0)
numberOfReviewers: 0
```

#### 2. 이슈에 설정되어있는 Labels, Miliestone을 PR에 동기화하기
이 PR의 브랜치인 feature/#953에 설정되어있는 Labels, Milestone을 이 PR에 동기화한다는 의미입니다.
이를 구현하기 위해 이슈 번호부터 가져와야 하는데, PR 본문 첫 번째에 close 하고 이슈 번호를 적도록 설정한 것을 이용하면 가져올 수 있습니다. 

그 다음으로 github api를 사용하여 해당 이슈의 정보를 얻어온 뒤 labels와 milestone 정보를 가져오면 됩니다.
```yml
response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-H "Accept: application/vnd.github+json" \
https://api.github.com/repos/${{ github.repository }}/issues/${{ env.ISSUE_NUMBER }})

# Extract issue_labels
issue_labels=$(echo "$response" | jq -r '.labels // [] | map(.name) | @json')

# Extract milestone
issue_milestone=$(echo "$response" | jq -r '.milestone.number // empty')
```

response의 결과로 아래 json을 받아볼 수 있고 여기서 labels와 milestone을 가져오게 되는 것입니다.

```yml
...
 "labels": [
    {
      "name": "a",
      "color": "BFD4F2",
       ...
    }
  ],
"milestone": {
    "id": 0000000,
    "node_id": "~~~"
    ...
  },
```

그 뒤로 생성된 PR에 Labels와 Milestone을 설정하기 위해 아래 CURL POST 요청을 하면 됩니다.
이 때 생성된 PR의 숫자는 github.event.pull_request.number 으로 얻어올 수 있습니다.

``` yml
# Assign labels to PR
curl -X POST \
  -H "Authorization: token $GITHUB_TOKEN" \
  -H "Accept: application/vnd.github+json" \
  https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
  -d "$(jq -n --argjson labels "$issue_labels" '{"labels": $labels}')"

... milestone은 생략
```

이 과정을 거쳐서 Labels과 Milestone을 자동으로 연동할 수 있습니다.

#### 3. Project 연결
위의 Labels와 Milestone과는 달리 Project는 비슷하게 접근할 수가 없습니다. 위에 api.github.com/repo/~~issues의 결과를 봤을 때 Project에 대한 데이터가 없기 때문입니다. Project에 접근하기 위해서는 다르게 접근해야 합니다.

[API를 사용하여 Projects 관리](https://docs.github.com/ko/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects)에 자세히 설명되어있고 여기서 조직 프로젝트의 노드 ID와 프로젝트에 이슈 추가를 사용했습니다.

우선 프로젝트에 접근하기 위해서 token의 권한 중 read:project가 활성화 되어있어야 합니다. (제 토큰을 사용할 때 이 권한을 설정해뒀습니다.)

![image](https://github.com/user-attachments/assets/29cc3bf2-22fc-486a-9e02-bbed1b3156e2)

그 다음으로 조직 안에 있는 특정 프로젝트(우리 프로젝트)의 ID를 알아와야 합니다.
docs에 설명되어 있는 대로 organization 이름과 project number를 사용하여 ID를 얻어올 수 있습니다.
우리의 organization 이름은 woowacourse-teams, project number는 53이므로 이 값을 채워서 요청하면 우리 프로젝트의 ID를 받아올 수 있습니다.

```yml
ORG_PROJECT_NODE_ID=$(curl -s -X POST \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  -H "Content-Type: application/json" \
  --url https://api.github.com/graphql \
  --data '{"query":"query { organization(login: \"'$ORGANIZATION'\") { projectV2(number: '$PROJECT_NUMBER') { id } } }"}' \
  | jq -r '.data.organization.projectV2.id')
```

이제 프로젝트 ID를 가져왔으니 프로젝트에 이 PR을 추가하면 됩니다. 

```yml
PR_RESPONSE=$(curl -s -X POST \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  -H "Content-Type: application/json" \
  --url https://api.github.com/graphql \
  --data '{"query":"mutation { addProjectV2ItemById(input: { projectId: \"'$ORG_PROJECT_NODE_ID'\", contentId: \"'$PR_NODE_ID'\" }) { item { id } } }"}')
```

여기서 필요한 정보는 projectId, contentID입니다.

[docs](https://docs.github.com/ko/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects#adding-a-draft-issue-to-a-project)의 설명을 보면

> 다음 예제에서는 프로젝트에 이슈 또는 끌어오기 요청을 추가합니다. PROJECT_ID를 프로젝트의 노드 ID로 바꿉니다. 추가하려는 이슈 또는 끌어오기 요청의 노드 ID로 CONTENT_ID를 바꿉니다.

project id는 전 단계에서 가져왔지만 content id는 가져오지 못했습니다. 그러면 추가 전 단계에서 현재 PR의 contentId를 가져온 후에 추가 명령을 실행하면 됩니다.

현재 PR의 content id 가져오기
```yml
PR_NODE_ID=$(curl -s -X POST \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  -H "Content-Type: application/json" \
  --url https://api.github.com/graphql \
  --data '{"query":"query { repository(owner: \"'${{ github.repository_owner }}'\", name: \"'${{ github.event.repository.name }}'\") { pullRequest(number: '${{ github.event.pull_request.number }}') { id } } }"}' \
  | jq -r '.data.repository.pullRequest.id')
```

프로젝트에 PR을 추가했다면 그 뒤에는 status를 In Review로 설정해야 합니다. 또한 연결된 이슈도 같이 status를 In Review로 설정해야 합니다. 이 내용은 다음에 이어서

#### 4. 이슈와 PR의 status를 In Review로 설정
프로젝트에 내용을 추가할 때 github는 프로젝트에 생성된 항목의 node id를 반환하게 됩니다. 그 형태는 아래와 같습니다.
```json
{
  "data": {
    "addProjectV2ItemById": {
      "item": {
        "id": "PVTI_lADOANN5s84ACbL0zgBVd94"
      }
    }
  }
}
```

여기서 item id를 알아와서 이 아이템의 status를 In Review로 설정하면 됩니다.

그러면 여기서 해야 하는 일이 두 가지가 있습니다.
- 1. PR의 이슈를 In Review로 설정하기
- 2. 연결된 이슈를 In Review로 설정하기

1번은 3, 4의 과정을 거쳐서 프로젝트에 pr이 등록됐고 item id를 받아왔습니다.
2번은 아직 하지 않았으므로 3, 4의 과정을 거쳐서 연결된 이슈도 프로젝트에 추가하여 item id를 받아오면 됩니다. 여기서 연결된 이슈는 이미 프로젝트에 등록이 되어 중복으로 추가되는 것이 아닌지 생각이 들 수 있지만 docs를 보면 이미 등록된 항목이라면 등록되어있는 항목의 item id를 반환한다고 합니다.

item_id를 가져왔다면 아래 과정을 거쳐서 issue와 pr의 status를 In Review로 바꾸면 됩니다.
이번에는 [kalgurn/update-project-item-status@main](https://github.com/kalgurn/update-project-item-status/tree/main/)을 사용해서 status를 변경했습니다.

```yml
- name: Set PR Status "🤼 In Review"
   uses: kalgurn/update-project-item-status@main
   with:
     project-url: https://github.com/orgs/woowacourse-teams/projects/53
     github-token: ${{ secrets.CONFIG_SUBMODULE_TOKEN }}
     item-id: ${{ env.PR_ITEM_ID }}
     status: "🤼 In Review"

... issue는 생략
```

여기서 다른 워크플로우를 가져오는 것이 아쉽지만 옮기기 위해 Project id, Item id 이외에 field id, option id등 불러와야 하는 것이 많아서 이 과정은 update-project-item-status을 사용했습니다.

이렇게 설정한 뒤에 PR을 생성하게 되면 이슈에 설정되어있는 값들을 자동으로 PR에 옮겨주어 수동으로 매 번 작업해줘야 했던 번거로움을 해소할 수 있게 됩니다.

## Action 실행 전
| 이슈                                                      | PR                                                       |
|----------------------------------------------------------|----------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/c4e668db-15e4-475e-bce4-1d366db25edb) | ![image](https://github.com/user-attachments/assets/b44bced1-5136-4ba8-b2be-a0fb38dc7529) |


### Action 실행 후
| 이슈                                                      | PR                                                       |
|----------------------------------------------------------|----------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/f3c1e40f-25d7-41fb-9d8c-b312b1699543) | ![image](https://github.com/user-attachments/assets/fa338880-86b0-424e-b6e5-3a72f5af43cb) |


딸깍하면 다 변하니 너무 편하지 않나요?ㅋㅋㅋㅋ

## 🫡 참고사항
위 설정에 대해서 궁금한 점이 있다면 알려드리겠습니다~~
