### PR TITLE
[FE] 다양한 상황에서도 TopNav를 사용할 수 있도록 수정

### DIFF
--- a/client/src/components/Design/components/TopNav/NavIcon.tsx
+++ b/client/src/components/Design/components/TopNav/NavIcon.tsx
@@ -1,0 +1,34 @@
+import {ReactElement} from 'react';
+
+import useNavItem from '@hooks/useNavItem';
+
+import IconButton from '../IconButton/IconButton';
+import Svg from '../Icons/Svg';
+import {IconButtonProps} from '../IconButton/IconButton.type';
+
+import {NavItemProps} from './NavItem.type';
+import NavItem from './NavItem';
+
+type NavIconProps = Omit<NavItemProps, 'children'> &
+  Partial<IconButtonProps> & {
+    component: ReactElement<typeof Svg>;
+
+    onClick?: () => void;
+  };
+
+/**
+ * onClick를 넘겨주었으면 routePath는 무시됩니다.
+ */
+const NavIcon = ({component, routePath, onClick, ...iconButtonProps}: NavIconProps) => {
+  const {handleClick} = useNavItem({onClick, routePath});
+
+  return (
+    <NavItem>
+      <IconButton onClick={handleClick} {...iconButtonProps} variants="none">
+        {component}
+      </IconButton>
+    </NavItem>
+  );
+};
+
+export default NavIcon;

--- a/client/src/components/Design/components/TopNav/NavItem.tsx
+++ b/client/src/components/Design/components/TopNav/NavItem.tsx
@@ -1,55 +1,8 @@
-/** @jsxImportSource @emotion/react */
-import type {NavItemProps} from './NavItem.type';
-
-import {useLocation, useNavigate} from 'react-router-dom';
-
-import getEventBaseUrl from '@utils/getEventBaseUrl';
-
-import TextButton from '../TextButton/TextButton';
-
 import {navItemStyle} from './NavItem.style';
+import {NavItemProps} from './NavItem.type';
 
-const NavItem = ({displayName, routePath, onHandleRouteInFunnel, noEmphasis = false, children}: NavItemProps) => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const matchPath = location.pathname.includes(routePath);
-
-  const handleNavigation = () => {
-    if (onHandleRouteInFunnel) {
-      onHandleRouteInFunnel();
-      return;
-    }
-
-    switch (routePath) {
-      case '/':
-        navigate('/');
-        break;
-      case '-1':
-        navigate(-1);
-        break;
-      default:
-        navigate(`/${getEventBaseUrl(location.pathname)}${routePath}`);
-        break;
-    }
-  };
-
-  const getTextColor = () => {
-    if (noEmphasis) return 'gray';
-
-    return matchPath ? 'onTertiary' : 'gray';
-  };
-
-  return (
-    <li css={navItemStyle} onClick={handleNavigation}>
-      {children ? (
-        children
-      ) : (
-        <TextButton textColor={getTextColor()} textSize="bodyBold">
-          {displayName}
-        </TextButton>
-      )}
-    </li>
-  );
+const NavItem = ({children}: NavItemProps) => {
+  return <li css={navItemStyle}>{children}</li>;
 };
 
 export default NavItem;

--- a/client/src/components/Design/components/TopNav/NavItem.type.ts
+++ b/client/src/components/Design/components/TopNav/NavItem.type.ts
@@ -1,14 +1,5 @@
-export type NavItemOptionProps = {
-  displayName?: string;
-  onHandleRouteInFunnel?: () => void;
-};
+import {PropsWithChildren} from 'react';
 
-export type NavItemRequireProps = {
-  routePath: string;
+export type NavItemProps = PropsWithChildren & {
+  routePath?: string;
 };
-
-export type NavItemStyleProps = {
-  noEmphasis?: boolean;
-};
-
-export type NavItemProps = NavItemRequireProps & NavItemOptionProps & NavItemStyleProps & React.PropsWithChildren;

--- a/client/src/components/Design/components/TopNav/NavText.tsx
+++ b/client/src/components/Design/components/TopNav/NavText.tsx
@@ -1,0 +1,47 @@
+import {Location, useLocation} from 'react-router-dom';
+
+import useNavItem from '@hooks/useNavItem';
+
+import TextButton from '../TextButton/TextButton';
+import {TextButtonProps} from '../TextButton/TextButton.type';
+
+import NavItem from './NavItem';
+import {NavItemProps} from './NavItem.type';
+
+const getTextColor = (isMatchPath: boolean, isEmphasis?: boolean) => {
+  if (isEmphasis === undefined) {
+    return isMatchPath ? 'onTertiary' : 'gray';
+  }
+
+  return isEmphasis ? 'onTertiary' : 'gray';
+};
+
+type NavTextProps = Omit<NavItemProps, 'children'> &
+  Partial<TextButtonProps> & {
+    isEmphasis?: boolean;
+
+    children: string;
+    onClick?: () => void;
+  };
+
+/**
+ * onClick를 넘겨주었으면 routePath는 무시됩니다.
+ */
+const NavText = ({isEmphasis, children, routePath = '', onClick, ...textButtonProps}: NavTextProps) => {
+  const {isPathMatch, handleClick} = useNavItem({onClick, routePath});
+
+  return (
+    <NavItem>
+      <TextButton
+        {...textButtonProps}
+        onClick={handleClick}
+        textColor={getTextColor(isPathMatch, isEmphasis)}
+        textSize={textButtonProps.textSize ?? 'bodyBold'}
+      >
+        {children}
+      </TextButton>
+    </NavItem>
+  );
+};
+
+export default NavText;

--- a/client/src/components/Design/components/TopNav/TopNav.style.ts
+++ b/client/src/components/Design/components/TopNav/TopNav.style.ts
@@ -6,3 +6,8 @@ export const topNavStyle = css({
   alignItems: 'center',
   width: '100%',
 });
+
+export const topNavWrapperStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+});

--- a/client/src/components/Design/components/TopNav/TopNav.tsx
+++ b/client/src/components/Design/components/TopNav/TopNav.tsx
@@ -1,19 +1,33 @@
-/** @jsxImportSource @emotion/react */
-import NavItem from './NavItem';
-import {topNavStyle} from './TopNav.style';
+import {ReactNode} from 'react';
 
-type TopNavProps = React.PropsWithChildren & {
-  Element?: React.ReactNode;
+import {topNavStyle, topNavWrapperStyle} from './TopNav.style';
+import NavText from './NavText';
+import NavIcon from './NavIcon';
+
+type TopNavProps = {
+  left?: ReactNode;
+  right?: ReactNode;
 };
 
-const TopNav = ({children}: TopNavProps) => {
+const TopNav = ({left, right}: TopNavProps) => {
   return (
     <nav style={{margin: '0 1rem'}}>
-      <ul css={topNavStyle}>{children}</ul>
+      <ul css={topNavStyle}>
+        <div css={topNavWrapperStyle}>{left}</div>
+        <div css={topNavWrapperStyle}>{right}</div>
+      </ul>
     </nav>
   );
 };
 
-TopNav.Item = NavItem;
+/**
+ * onClick를 넘겨주었으면 routePath는 무시됩니다.
+ */
+TopNav.Text = NavText;
+
+/**
+ * onClick를 넘겨주었으면 routePath는 무시됩니다.
+ */
+TopNav.Icon = NavIcon;
 
 export default TopNav;

--- a/client/src/components/EditAccountPageView.tsx
+++ b/client/src/components/EditAccountPageView.tsx
@@ -48,9 +48,13 @@ const EditAccountPageView = ({
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <Top>
           <Top.Line text="행사 정산 금액은" />

--- a/client/src/constants/routerUrls.ts
+++ b/client/src/constants/routerUrls.ts
@@ -2,13 +2,18 @@ const EVENT = '/event';
 const EVENT_WITH_EVENT_ID = `${EVENT}/:eventId`;
 const MY_PAGE = '/mypage';
 
+export const PATHS = {
+  home: '/home',
+  admin: '/admin',
+};
+
 export const ROUTER_URLS = {
   main: '/',
   event: EVENT,
   createGuestEvent: `${EVENT}/create/guest`,
   createUserEvent: `${EVENT}/create/user`,
-  eventManage: `${EVENT_WITH_EVENT_ID}/admin`,
-  home: `${EVENT_WITH_EVENT_ID}/home`,
+  eventManage: `${EVENT_WITH_EVENT_ID}${PATHS.admin}`,
+  home: `${EVENT_WITH_EVENT_ID}${PATHS.home}`,
   members: `${EVENT_WITH_EVENT_ID}/admin/members`,
   addBill: `${EVENT_WITH_EVENT_ID}/admin/add-bill`,
   editBill: `${EVENT_WITH_EVENT_ID}/admin/edit-bill`,

--- a/client/src/hooks/useNavItem.ts
+++ b/client/src/hooks/useNavItem.ts
@@ -1,0 +1,42 @@
+import {Location, useLocation, useNavigate} from 'react-router-dom';
+
+import getEventBaseUrl from '@utils/getEventBaseUrl';
+
+type Props = {
+  onClick?: () => void;
+  routePath?: string;
+};
+
+const getUrl = (routePath: string, location: Location): string => {
+  if (routePath === '/') return '/';
+
+  return `/${getEventBaseUrl(location.pathname)}${routePath}`;
+};
+
+const useNavItem = ({onClick, routePath = ''}: Props) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+      return;
+    }
+
+    const url = getUrl(routePath, location);
+
+    if (routePath === '-1') {
+      // navigate가 오버로드로 구현되어 있기 때문에 삼항 연산자 불가능.
+      navigate(-1);
+    } else {
+      navigate(url);
+    }
+  };
+
+  return {
+    handleClick,
+    isPathMatch: location.pathname.includes(routePath),
+  };
+};
+
+export default useNavItem;

--- a/client/src/pages/event/[eventId]/EventPageLayout.tsx
+++ b/client/src/pages/event/[eventId]/EventPageLayout.tsx
@@ -19,7 +19,7 @@ import {isMobileDevice} from '@utils/detectDevice';
 import {updateMetaTag} from '@utils/udpateMetaTag';
 import getImageUrl from '@utils/getImageUrl';
 
-import {ROUTER_URLS} from '@constants/routerUrls';
+import {PATHS, ROUTER_URLS} from '@constants/routerUrls';
 
 export type EventPageContextProps = Event & {
   isAdmin: boolean;
@@ -58,15 +58,15 @@ const EventPageLayout = () => {
   return (
     <MainLayout backgroundColor="gray">
       <Flex justifyContent="spaceBetween" alignItems="center">
-        <TopNav>
-          <TopNav.Item routePath="/">
-            <IconButton variants="none">
-              <IconHeundeut />
-            </IconButton>
-          </TopNav.Item>
-          <TopNav.Item displayName="홈" routePath="/home" />
-          <TopNav.Item displayName="관리" routePath="/admin" />
-        </TopNav>
+        <TopNav
+          left={
+            <>
+              <TopNav.Icon routePath="/" component={<IconHeundeut />} />
+              <TopNav.Text routePath={PATHS.home}>홈</TopNav.Text>
+              <TopNav.Text routePath={PATHS.admin}>관리</TopNav.Text>
+            </>
+          }
+        ></TopNav>
         <Flex alignItems="center" gap="0.75rem" margin="0 1rem 0 0">
           {isMobile ? (
             <MobileShareEventButton copyShare={trackLinkShare} kakaoShare={trackKakaoShare} />

--- a/client/src/pages/event/[eventId]/admin/add-bill/AddBillFunnel.tsx
+++ b/client/src/pages/event/[eventId]/admin/add-bill/AddBillFunnel.tsx
@@ -19,9 +19,13 @@ const AddBillFunnel = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       {step === 'price' && <PriceStep billInfo={billInfo} setBillInfo={setBillInfo} setStep={setStep} />}
       {step === 'title' && <TitleStep billInfo={billInfo} setBillInfo={setBillInfo} setStep={setStep} />}
       {step === 'members' && (

--- a/client/src/pages/event/[eventId]/admin/add-images/AddImagesPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/add-images/AddImagesPage.tsx
@@ -12,9 +12,13 @@ const AddImagesPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <div
         css={css`
           display: flex;

--- a/client/src/pages/event/[eventId]/admin/edit-bill/EditBillPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/edit-bill/EditBillPage.tsx
@@ -31,9 +31,13 @@ const EditBillPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <div
         css={css`
           display: flex;

--- a/client/src/pages/event/[eventId]/admin/edit-event-name/EditEventNamePage.tsx
+++ b/client/src/pages/event/[eventId]/admin/edit-event-name/EditEventNamePage.tsx
@@ -35,9 +35,13 @@ const EditEventNamePage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <Top>
           <Top.Line text="변경하려는" />

--- a/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
+++ b/client/src/pages/event/[eventId]/admin/members/MembersPage.tsx
@@ -13,9 +13,13 @@ const MembersPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <section css={eventMemberStyle}>
         <Top>
           <Top.Line text="전체 참여자 관리" emphasize={['전체 참여자 관리']}></Top.Line>

--- a/client/src/pages/event/[eventId]/home/bill-detail/BillDetailPage.tsx
+++ b/client/src/pages/event/[eventId]/home/bill-detail/BillDetailPage.tsx
@@ -25,9 +25,13 @@ const BillDetailPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <div
         css={css`
           display: flex;

--- a/client/src/pages/event/[eventId]/home/send/SendPage.tsx
+++ b/client/src/pages/event/[eventId]/home/send/SendPage.tsx
@@ -13,9 +13,13 @@ const SendPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <Top>
           <Top.Line text={accountText} />

--- a/client/src/pages/event/[eventId]/images/ImagesPage.tsx
+++ b/client/src/pages/event/[eventId]/images/ImagesPage.tsx
@@ -19,9 +19,13 @@ const ImagesPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <div
         css={css`
           display: flex;

--- a/client/src/pages/event/[eventId]/qrcode/QRCodePage.tsx
+++ b/client/src/pages/event/[eventId]/qrcode/QRCodePage.tsx
@@ -15,9 +15,13 @@ const QRCodePage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <div
         css={css`
           display: flex;

--- a/client/src/pages/event/create/guest/CreateGuestEventFunnel.tsx
+++ b/client/src/pages/event/create/guest/CreateGuestEventFunnel.tsx
@@ -34,11 +34,15 @@ const CreateGuestEventFunnel = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        {step !== STEP_SEQUENCE[STEP_SEQUENCE.length - 1] && (
-          <TopNav.Item displayName="뒤로가기" noEmphasis routePath="" onHandleRouteInFunnel={handleBack} />
-        )}
-      </TopNav>
+      <TopNav
+        left={
+          step !== STEP_SEQUENCE[STEP_SEQUENCE.length - 1] && (
+            <TopNav.Text isEmphasis={false} onClick={handleBack}>
+              뒤로가기
+            </TopNav.Text>
+          )
+        }
+      ></TopNav>
       <Funnel step={step}>
         <Funnel.Step name="eventName">
           <SetGuestEventNameStep moveToNextStep={moveToNextStep} {...eventNameProps} />

--- a/client/src/pages/event/create/user/CreateUserEventFunnel.tsx
+++ b/client/src/pages/event/create/user/CreateUserEventFunnel.tsx
@@ -31,11 +31,15 @@ const CreateUserEventFunnel = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        {step !== STEP_SEQUENCE[STEP_SEQUENCE.length - 1] && (
-          <TopNav.Item displayName="뒤로가기" noEmphasis routePath="" onHandleRouteInFunnel={handleBack} />
-        )}
-      </TopNav>
+      <TopNav
+        left={
+          step !== STEP_SEQUENCE[STEP_SEQUENCE.length - 1] && (
+            <TopNav.Text isEmphasis={false} onClick={handleBack}>
+              뒤로가기
+            </TopNav.Text>
+          )
+        }
+      ></TopNav>
       <Funnel step={step}>
         <Funnel.Step name="eventName">
           <SetMemberEventNameStep moveToNextStep={moveToNextStep} setEventToken={setEventToken} />

--- a/client/src/pages/fallback/EventPageLoading.tsx
+++ b/client/src/pages/fallback/EventPageLoading.tsx
@@ -3,20 +3,20 @@ import {IconHeundeut} from '@components/Design/components/Icons/Icons/IconHeunde
 import {Flex, IconButton, MainLayout, TopNav} from '@components/Design';
 import {Footer} from '@components/Footer';
 
+import {PATHS} from '@constants/routerUrls';
+
 const EventPageLoading = () => {
   return (
     <MainLayout backgroundColor="gray">
-      <Flex justifyContent="spaceBetween" alignItems="center">
-        <TopNav>
-          <TopNav.Item routePath="/">
-            <IconButton variants="none">
-              <IconHeundeut />
-            </IconButton>
-          </TopNav.Item>
-          <TopNav.Item displayName="홈" routePath="/home" />
-          <TopNav.Item displayName="관리" routePath="/admin" />
-        </TopNav>
-      </Flex>
+      <TopNav
+        left={
+          <>
+            <TopNav.Icon routePath="/" component={<IconHeundeut />} />
+            <TopNav.Text routePath="/">홈</TopNav.Text>
+            <TopNav.Text routePath={PATHS.admin}>관리</TopNav.Text>
+          </>
+        }
+      />
       <Footer />
     </MainLayout>
   );

--- a/client/src/pages/login/LoginPage.tsx
+++ b/client/src/pages/login/LoginPage.tsx
@@ -18,9 +18,13 @@ const LoginPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <Flex flexDirection="column" justifyContent="spaceBetween" height="100%">
           <Flex flexDirection="column" justifyContent="center" alignItems="center" gap="1rem" margin="0 0 6rem 0">

--- a/client/src/pages/main/Nav/Nav.tsx
+++ b/client/src/pages/main/Nav/Nav.tsx
@@ -21,21 +21,21 @@ const Nav = ({isGuest}: NavProps) => {
   return (
     <div css={navFixedStyle}>
       <div css={navWrapperStyle}>
-        <header css={navStyle}>
-          <TopNav>
-            <TopNav.Item routePath="/">
-              <IconButton variants="none" aria-label="행동대장 로고">
-                <IconHeundeut />
-              </IconButton>
-            </TopNav.Item>
-            <TopNav.Item routePath="/">
-              <Text size="subTitle">행동대장</Text>
-            </TopNav.Item>
-          </TopNav>
-          <Button size="medium" variants="tertiary" onClick={goLogin} style={{marginRight: '1rem'}}>
-            정산 시작하기
-          </Button>
-        </header>
+        <TopNav
+          left={
+            <>
+              <TopNav.Icon routePath="/" aria-label="행동대장 로고" component={<IconHeundeut />} />
+              <TopNav.Text routePath="/" textSize="subTitle" isEmphasis={true}>
+                행동대장
+              </TopNav.Text>
+            </>
+          }
+          right={
+            <Button size="medium" variants="tertiary" onClick={goLogin}>
+              정산 시작하기
+            </Button>
+          }
+        />
       </div>
     </div>
   );

--- a/client/src/pages/mypage/MyPage.tsx
+++ b/client/src/pages/mypage/MyPage.tsx
@@ -72,9 +72,13 @@ const SettingSection = () => {
 const MyPage = () => {
   return (
     <MainLayout backgroundColor="gray">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <ErrorBoundary fallback={<MyPageError />}>
           <Suspense fallback={<MyPageLoading />}>

--- a/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
+++ b/client/src/pages/mypage/edit-nickname/EditUserNicknamePage.tsx
@@ -31,9 +31,13 @@ const EditUserNicknamePage = () => {
   };
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      ></TopNav>
       <FunnelLayout>
         <Top>
           <Top.Line text="행사에서 사용할" />

--- a/client/src/pages/mypage/events/CreatedEventsPage.tsx
+++ b/client/src/pages/mypage/events/CreatedEventsPage.tsx
@@ -24,14 +24,20 @@ const PageInner = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        <TopNav.Item displayName="뒤로가기" noEmphasis routePath="-1" />
-        {mode === 'view' && (
-          <TextButton textColor="gray" textSize="bodyBold" onClick={() => handleMode('edit')}>
-            편집하기
-          </TextButton>
-        )}
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+        right={
+          mode === 'view' && (
+            <TopNav.Text textColor="gray" textSize="bodyBold" onClick={() => handleMode('edit')}>
+              편집하기
+            </TopNav.Text>
+          )
+        }
+      ></TopNav>
       <FunnelLayout>
         <Top>
           <Top.Line text="지금까지 주최했던 행사를" emphasize={['주최했던 행사']} />

--- a/client/src/pages/mypage/withdraw/WithdrawPage.tsx
+++ b/client/src/pages/mypage/withdraw/WithdrawPage.tsx
@@ -14,9 +14,13 @@ const WithdrawPage = () => {
 
   return (
     <MainLayout backgroundColor="white">
-      <TopNav>
-        {step !== 'withdrawalCompleted' && <TopNav.Item displayName={'뒤로가기'} noEmphasis routePath="-1" />}
-      </TopNav>
+      <TopNav
+        left={
+          <TopNav.Text routePath="-1" isEmphasis={false}>
+            뒤로가기
+          </TopNav.Text>
+        }
+      />
       {/* TODO: (@soha) 탈퇴 사유를 입력받기 위한 step. 당장 사용하지 않으므로 주석. */}
       {/* {step === 'withdrawReason' && <ReasonStep handleMoveStep={handleMoveStep} />}
       {step === 'notUseService' && <NotUseServiceStep handleMoveStep={handleMoveStep} />}


### PR DESCRIPTION
## issue
- close #956 

## 구현 목적
1. TopNav에 Icon을 사용할 경우 IconButton을 끼워주어야 합니다. 그래서 합성 컴포넌트로 간단하게 사용할 수 있도록 합니다. Text도 마찬가지
```jsx
// 전
<TopNav>
  <IconButton>
    <흔듯콘/>
  </ IconButton>
</TopNav>

// 후
<TopNav.Icon><흔듯콘></TopNav.Icon>
```

2. 좌 우로 벌려져있는 nav일 경우가 기존 컴포넌트에서는 지원되지 않아 이걸 맞춰주기 위해 하드코딩이 필요했습니다. 이제는 left, right prop에 넣어서 사용합니다.

## ✅ 바뀐 사용 방법
아래의 모든 예시는 행동대장 코드를 기반으로 합니다.

```jsx
// 뒤로가기만 있는 경우 -> routePath
<TopNav
  left={
    <TopNav.Text routePath="-1" isEmphasis={false}>
      뒤로가기
    </TopNav.Text>
  }
/>

// 아이콘이 있는 경우 -> TopNav.Icon 사용
<TopNav
  left={
    <>
      <TopNav.Icon routePath="/" component={<IconHeundeut />} />
      <TopNav.Text routePath="/">홈</TopNav.Text>
      <TopNav.Text routePath={PATHS.admin}>관리</TopNav.Text>
    </>
  }
/>

// 좌우로 사용해야하는 경우 -> left, right prop 사용
<TopNav
  left={
    <>
      <TopNav.Icon routePath="/" aria-label="행동대장 로고" component={<IconHeundeut />} />
      <TopNav.Text routePath="/" textSize="subTitle" isEmphasis={true}>
        행동대장
      </TopNav.Text>
    </>
  }
  right={
    <Button size="medium" variants="tertiary" onClick={goLogin}>
      정산 시작하기
    </Button>
  }
/>

// 퍼널같이 뒤로가기를 -1이 아닌 다르게 구현해야하는 경우 -> 만든 onClick 주입
<TopNav 
  left={
    step !== STEP_SEQUENCE[STEP_SEQUENCE.length - 1] && (
      <TopNav.Text isEmphasis={false} onClick={handleBack}>
        뒤로가기
      </TopNav.Text>
    )
  }
/>
```
## 구현 사항

### 1. TopNav.Text, TopNav.Icon구현
네비게이션에서 주로 텍스트와 아이콘이 사용되기 때문에 이를 합성 컴포넌트로 제공하여 사용할 수 있도록 했습니다.

네비게이션의 아이템은 클릭할 수 있어야 하기 때문에 버튼인 TextButton, IconButton로 감쌌습니다.

TopNav,Text만 예로 들어보자면(TopNav.Icon도 매우 유사), props로는 다음 항목을 받습니다. 
1. routePath나 onClick같은 클릭 시 필요한 액션
2. 텍스트 색 하이라이트를 위한 isEmphasis
3. TextButton에 사용되는 props들

```jsx
const NavText = ({isEmphasis, children, routePath = '', onClick, ...textButtonProps}: NavTextProps) => {
  const {isPathMatch, handleClick} = useNavItem({onClick, routePath});

  return (
    <NavItem>
      <TextButton
        {...textButtonProps}
        onClick={handleClick}
        textColor={getTextColor(isPathMatch, isEmphasis)}
        textSize={textButtonProps.textSize ?? 'bodyBold'}
      >
        {children}
      </TextButton>
    </NavItem>
  );
};
```

### 2. TopNav에 left, right prop 추가
좌 우로 사용되어야 하는 ui가 많은데 지금 TopNav는 그걸 지원하지 않아서 현재까지의 페이지는 모두 하드코딩으로 구현되어있었어요.

그래서 left, right를 받아 좌우로 분리된 TopNav를 사용할 수 있도록 했습니다.

```jsx
<TopNav
  left={<TopNav.Icon routePath="/" aria-label="행동대장 로고" component={<IconHeundeut />} />}
  right={
    <TopNav.Text routePath={ROUTER_URLS.home} isEmphasis={false}>
      오른쪽
    </TopNav.Text>
  }
/>
```

## 🫡 참고사항
기존 방법대로 TopNav를 사용하고 있는 곳들은 모두 바뀐 방법으로 사용하도록 수정되었습니다.

## need 의견
TopNav.Text는 children으로 보여질 string을 받고, TopNav.Icon은 "component" prop으로 보여질 아이콘을 받습니다. 둘의 사용 방법을 동일하게 하는게 좋을까요? Text는 children으로 넘겨주는게 직관적이기 때문에 그리했고, Icon은 렌더링할 컴포넌트라는 의미를 더 분명하게 주고싶어서 prop으로 넘기도록 했습니다. 그러나 일치시키는게 더 직관적일 것 같다면 수정할게요~!

그리고 Button도 종종 TopNav에서 사용되는데요. TopNav.Button으로 만들려면 스타일된 li태그인 NavItem으로 감싸는 것 말고는 차이가 없어서 구현안했습니다. 일관되게 사용하는게 좋을 것 같다면 구현할게요. 
