### PR TITLE
[BE] 인원 수정 및 삭제 API 통합

### DIFF
--- a/server/src/main/java/haengdong/event/application/EventMemberService.java
+++ b/server/src/main/java/haengdong/event/application/EventMemberService.java
@@ -71,7 +71,17 @@ public class EventMemberService {
         List<EventMember> originEventMembers = eventMemberRepository.findAllByEvent(event);
 
         updatedMembers.validateUpdatable(originEventMembers);
+
+        deleteMembers(token, originEventMembers, updatedMembers);
         eventMemberRepository.saveAll(updatedMembers.getMembers());
+    }
+
+    private void deleteMembers(String token, List<EventMember> originEventMembers, UpdatedMembers updatedMembers) {
+        for (EventMember originEventMember : originEventMembers) {
+            if (!updatedMembers.contain(originEventMember)) {
+                deleteMember(token, originEventMember);
+            }
+        }
     }
 
     @Transactional

--- a/server/src/main/java/haengdong/event/domain/event/member/UpdatedMembers.java
+++ b/server/src/main/java/haengdong/event/domain/event/member/UpdatedMembers.java
@@ -36,6 +36,7 @@ public class UpdatedMembers {
     public void validateUpdatable(List<EventMember> originEventMembers) {
         Set<EventMember> uniqueEventMembers = Set.copyOf(originEventMembers);
         validateUpdatedNamesUnique(uniqueEventMembers);
+        validateId(uniqueEventMembers);
     }
 
     private void validateUpdatedNamesUnique(Set<EventMember> originEventMembers) {
@@ -51,6 +52,15 @@ public class UpdatedMembers {
         return this.eventMembers.stream()
                 .filter(member -> !member.getId().equals(originMembers.getId()))
                 .anyMatch(member -> member.hasName(originMembers.getName()));
+    }
+
+    private void validateId(Set<EventMember> originEventMembers) {
+        boolean isNotCorrectId = this.eventMembers.stream()
+                .anyMatch(member -> !originEventMembers.contains(member));
+
+        if (isNotCorrectId) {
+            throw new HaengdongException(HaengdongErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 
     public List<EventMember> getMembers() {

--- a/server/src/main/java/haengdong/event/domain/event/member/UpdatedMembers.java
+++ b/server/src/main/java/haengdong/event/domain/event/member/UpdatedMembers.java
@@ -35,14 +35,7 @@ public class UpdatedMembers {
 
     public void validateUpdatable(List<EventMember> originEventMembers) {
         Set<EventMember> uniqueEventMembers = Set.copyOf(originEventMembers);
-        validateUpdatedMembersExist(uniqueEventMembers);
         validateUpdatedNamesUnique(uniqueEventMembers);
-    }
-
-    private void validateUpdatedMembersExist(Set<EventMember> originEventMembers) {
-        if (!this.eventMembers.equals(originEventMembers)) {
-            throw new HaengdongException(HaengdongErrorCode.MEMBER_UPDATE_MISMATCH);
-        }
     }
 
     private void validateUpdatedNamesUnique(Set<EventMember> originEventMembers) {
@@ -62,6 +55,10 @@ public class UpdatedMembers {
 
     public List<EventMember> getMembers() {
         return eventMembers.stream().toList();
+    }
+
+    public boolean contain(EventMember eventMember) {
+        return eventMembers.contains(eventMember);
     }
 }
 

--- a/server/src/test/java/haengdong/domain/eventmember/UpdatedMembersTest.java
+++ b/server/src/test/java/haengdong/domain/eventmember/UpdatedMembersTest.java
@@ -57,27 +57,6 @@ class UpdatedMembersTest {
                 .containsExactlyInAnyOrder(eventMember1, eventMember2, eventMember3);
     }
 
-    @DisplayName("이벤트의 참여자들 전체가 존재하지 않으면 업데이트할 수 없다.")
-    @Test
-    void validateUpdatedMembersExist() {
-        Event event = Event.createByGuest("행동대장 회식", "1231415jaksdf", 1L);
-        EventMember eventMember1 = new EventMember(1L, event, "고구마", false);
-        EventMember eventMember2 = new EventMember(2L, event, "감자", false);
-        EventMember eventMember3 = new EventMember(3L, event, "당근", false);
-        EventMember eventMember4 = new EventMember(4L, event, "양파", false);
-        List<EventMember> eventMembers = List.of(eventMember1, eventMember2, eventMember3, eventMember4);
-
-        EventMember updateEventMember1 = new EventMember(1L, event, "토다리", false);
-        EventMember updateEventMember2 = new EventMember(2L, event, "쿠키", false);
-        EventMember updateEventMember3 = new EventMember(3L, event, "백호", false);
-        UpdatedMembers updatedMembers = new UpdatedMembers(List.of(
-                updateEventMember1, updateEventMember2, updateEventMember3));
-
-        assertThatThrownBy(() -> updatedMembers.validateUpdatable(eventMembers))
-                .isInstanceOf(HaengdongException.class)
-                .hasMessage("업데이트 요청된 참여자 ID 목록과 기존 행사 참여자 ID 목록이 일치하지 않습니다.");
-    }
-
     @DisplayName("업데이트할 이름 중에 기존 이벤트의 참여자들의 이름과 중복되면 업데이트할 수 없다.")
     @Test
     void validateUpdatedNamesUnique() {


### PR DESCRIPTION
## issue
- close #963

### API
/api/admin/events/{eventId}/members

### Request
```json
{
	"members" : [ 
		{ 
			"id" : 1, 
			"name" : "토다리", 
			"isDeposited": true 
		},
		{ 
			"id" : 2, 
			"name" : "망쵸", 
			"isDeposited": false 
		}
	]
}
```

### 구현 사항
멤버 정보 수정 API 호출시 누락된 member는 자동으로 삭제 됩니다. 
(id 1,2,3 인 멤버가 존재하는 경우 id 1,2 만 수정 요청시 id 3은 삭제됨)