### PR TITLE
[FE] 이름 변경 글자수 서버 에러 메시지 버그 + 다양한 서버 에러 메세지 수정

### DIFF
--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -29,7 +29,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
 
   // 계좌 관련 에러 코드
   BANK_NAME_INVALID: '지원하지 않는 은행이에요. 다른 은행을 입력해주세요.',
-  ACCOUNT_LENGTH_INVALID: `계좌 번호는 8자 이상 ${RULE.maxAccountNumberLength}자 이하로 입력 가능해요.`,
+  ACCOUNT_LENGTH_INVALID: `계좌 번호는  ${RULE.minAccountNumberLength}자 이상 ${RULE.maxAccountNumberLength}자 이하로 입력 가능해요.`,
 
   // 로그인 관련 에러 코드
   TOKEN_NOT_FOUND: '로그인이 필요한 서비스에요.',

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -10,7 +10,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   EVENT_NOT_FOUND: '존재하지 않는 행사에요. 링크가 올바른지 확인해주세요.',
 
   // 멤버 관련 에러 코드
-  MEMBER_NAME_LENGTH_INVALID: `멤버 이름은 한글 ${RULE.maxEventNameLength}자까지, 영어 ${RULE.maxEventNameLength * 2}자까지 입력 가능해요.`,
+  MEMBER_NAME_LENGTH_INVALID: `참여자 이름은 ${RULE.minMemberNameLength}자 이상 ${RULE.maxMemberNameLength}자 이하만 입력 가능합니다.`,
 
   MEMBER_NAME_CHANGE_DUPLICATE: '요청 본문에 중복된 이름이 존재해요. \n(ex. [이상, 이상, 감자, 백호])',
   MEMBER_NAME_DUPLICATE: '요청 본문에 중복된 이름이 존재해요. \n(ex. [이상, 이상, 감자, 백호])',

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -31,6 +31,10 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   BANK_NAME_INVALID: '지원하지 않는 은행이에요. 다른 은행을 입력해주세요.',
   ACCOUNT_LENGTH_INVALID: `계좌 번호는  ${RULE.minAccountNumberLength}자 이상 ${RULE.maxAccountNumberLength}자 이하로 입력 가능해요.`,
 
+  // 이미지 관련 에러 코드
+  // TODO:(@soha) FOUND 오타가 존재해서 서버측 확인 후 수정해야 함
+  IMAGE_NOT_FOUNT: '존재하지 않는 이미지에요.',
+
   // 로그인 관련 에러 코드
   TOKEN_NOT_FOUND: '로그인이 필요한 서비스에요.',
   TOKEN_EXPIRED: '로그인이 만료되었어요. 다시 로그인해주세요.',

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -21,7 +21,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
 
   // 지출 관련 에러 코드
   BILL_NOT_FOUND: '존재하지 않는 지출 액션이에요.',
-  BILL_TITLE_INVALID: `지출 내역 이름은 1자 이상 ${RULE.maxBillNameLength} 이하여야 해요.`,
+  BILL_TITLE_INVALID: `지출 내역 이름은 ${RULE.minBillNameLength}자 이상 ${RULE.maxBillNameLength} 이하여야 해요.`,
   BILL_PRICE_INVALID: `지출 금액은 ${RULE.maxPrice.toLocaleString('ko-KR')} 이하의 자연수여야 해요.`,
   BILL_DETAIL_NOT_FOUND: '존재하지 않는 참여자 지출입니다.',
   BILL_PRICE_NOT_MATCHED: '지출 총액이 일치하지 않아요.',

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -23,8 +23,9 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   BILL_NOT_FOUND: '존재하지 않는 지출 액션이에요.',
   BILL_TITLE_INVALID: `지출 내역 이름은 ${RULE.minBillNameLength}자 이상 ${RULE.maxBillNameLength} 이하여야 해요.`,
   BILL_PRICE_INVALID: `지출 금액은 ${RULE.maxPrice.toLocaleString('ko-KR')} 이하의 자연수여야 해요.`,
-  BILL_DETAIL_NOT_FOUND: '존재하지 않는 참여자 지출입니다.',
+  BILL_DETAIL_NOT_FOUND: '존재하지 않는 참여자 지출이에요.',
   BILL_PRICE_NOT_MATCHED: '지출 총액이 일치하지 않아요.',
+
   DIFFERENT_STEP_MEMBERS: '회원 목록이 일치하지 않아요.',
 
   // 계좌 관련 에러 코드

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -33,8 +33,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   ACCOUNT_LENGTH_INVALID: `계좌 번호는  ${RULE.minAccountNumberLength}자 이상 ${RULE.maxAccountNumberLength}자 이하로 입력 가능해요.`,
 
   // 이미지 관련 에러 코드
-  // TODO:(@soha) FOUND 오타가 존재해서 서버측 확인 후 수정해야 함
-  IMAGE_NOT_FOUNT: '존재하지 않는 이미지에요.',
+  IMAGE_NOT_FOUND: '존재하지 않는 이미지에요.',
 
   // 로그인 관련 에러 코드
   TOKEN_NOT_FOUND: '로그인이 필요한 서비스에요.',

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -10,7 +10,7 @@ export const SERVER_ERROR_MESSAGES: ErrorMessage = {
   EVENT_NOT_FOUND: '존재하지 않는 행사에요. 링크가 올바른지 확인해주세요.',
 
   // 멤버 관련 에러 코드
-  MEMBER_NAME_LENGTH_INVALID: `참여자 이름은 ${RULE.minMemberNameLength}자 이상 ${RULE.maxMemberNameLength}자 이하만 입력 가능합니다.`,
+  MEMBER_NAME_LENGTH_INVALID: `참여자 이름은 ${RULE.minMemberNameLength}자 이상 ${RULE.maxMemberNameLength}자 이하만 입력 가능해요.`,
 
   MEMBER_NAME_CHANGE_DUPLICATE: '요청 본문에 중복된 이름이 존재해요. \n(ex. [이상, 이상, 감자, 백호])',
   MEMBER_NAME_DUPLICATE: '요청 본문에 중복된 이름이 존재해요. \n(ex. [이상, 이상, 감자, 백호])',

--- a/client/src/constants/rule.ts
+++ b/client/src/constants/rule.ts
@@ -3,6 +3,7 @@ const EVENT_PASSWORD_LENGTH = 4;
 const RULE = {
   maxEventNameLength: 30,
   maxEventPasswordLength: EVENT_PASSWORD_LENGTH,
+  minMemberNameLength: 1,
   maxMemberNameLength: 8,
   maxPrice: 10000000,
   maxBillNameLength: 30,

--- a/client/src/constants/rule.ts
+++ b/client/src/constants/rule.ts
@@ -6,6 +6,7 @@ const RULE = {
   minMemberNameLength: 1,
   maxMemberNameLength: 8,
   maxPrice: 10000000,
+  minBillNameLength: 1,
   maxBillNameLength: 30,
   minAccountNumberLength: 8,
   maxAccountNumberLength: 30,

--- a/client/src/constants/rule.ts
+++ b/client/src/constants/rule.ts
@@ -1,7 +1,7 @@
 const EVENT_PASSWORD_LENGTH = 4;
 
 const RULE = {
-  maxEventNameLength: 30,
+  maxEventNameLength: 20,
   maxEventPasswordLength: EVENT_PASSWORD_LENGTH,
   minMemberNameLength: 1,
   maxMemberNameLength: 8,


### PR DESCRIPTION
## issue
- close #966

## 버그 발생 상황

이름 변경을 시도할 때, 제한한 글자수(8자)를 넘겨서 서버에 전송할 경우 서버에서 에러 메세지를 넘겨줍니다.
이때 토스트로 출력되는 에러 메세지는 "멤버 이름은 한글 30자까지, 영어 60자까지 입력이 가능해요." 입니다.
이 메세지는 현재 우리 서비스 정책과 맞지 않습니다.

https://github.com/user-attachments/assets/2058559b-3000-42e4-905c-e9e101015fd2


## 버그 발생 원인

이 에러 메세지는 프론트 측에서 서버 측에서 넘겨주는 에러 코드를 확인하여 이에 맞는 에러 메세지를 가지고 있다가 유저에게 토스트로 출력해주는 것이었습니다. 즉, 프론트측에서 해당 코드와는 맞지 않은 메세지를 가지고 있던 것이었습니다.

## 버그 해결

### MEMBER_NAME_LENGTH_INVALID를 서버와 동일하게 수정

에러 메세지 문구를 동일하게 수정했습니다.

https://github.com/user-attachments/assets/cf6f1fa4-d677-4c64-b694-66f086fb46ae

### RULE.maxEventNameLength을 서버와 동일하게 수정

프론트는 maxEventNameLength의 값이 30이었습니다. 그런데 서버는 maxEventNameLength가 20이었습니다. 따라서 행사 이름이 20글자 넘게 입력이 가능했고 그 상태로 변경을 요청했을 경우 서버측에서 에러를 발생시켰습니다.

따라서 프론트측도 서버와 동일하게 maxEventNameLength의 값을 20으로 수정했습니다.

### 이 외에도 다양한 에러 메세지 값들 상수화 및 어투 변경 작업 진행
