### PR TITLE
[FE] 메인 페이지에 TopNav 적용

### DIFF
--- a/client/src/components/Design/components/ContentItem/ContentItem.tsx
+++ b/client/src/components/Design/components/ContentItem/ContentItem.tsx
@@ -24,7 +24,7 @@ const ContentItem = ({labels, onEditClick, children}: ContentItemProps) => {
       {children}
       {onEditClick && (
         <button onClick={onEditClick} css={iconStyle}>
-          <IconEdit />
+          <IconEdit size={16} />
         </button>
       )}
     </VStack>

--- a/client/src/pages/main/MainPage.tsx
+++ b/client/src/pages/main/MainPage.tsx
@@ -11,10 +11,12 @@ import useRequestGetCreatedEvents from '@hooks/queries/event/useRequestGetCreate
 import VStack from '@components/Design/components/Stack/VStack';
 import {CreatedEventView} from '@components/Design/components/CreatedEventItem/CreatedEventView';
 import EventEmptyFallback from '@pages/fallback/EventEmptyFallback';
+import {IconHeundeut} from '@components/Design/components/Icons/Icons/IconHeundeut';
+import {IconSetting} from '@components/Design/components/Icons/Icons/IconSetting';
 
 import useUserInfoContext from '@hooks/useUserInfoContext';
 
-import {FixedButton, MainLayout, Text} from '@components/Design';
+import {FixedButton, MainLayout, Text, TopNav} from '@components/Design';
 
 import getImageUrl from '@utils/getImageUrl';
 
@@ -95,9 +97,30 @@ const MainPage = () => {
     navigate(ROUTER_URLS.createUserEvent);
   };
 
+  const navigateSettingPage = () => {
+    navigate(ROUTER_URLS.setting);
+  };
+
   return (
     <MainLayout backgroundColor="gray">
-      {/* top nav 추가해야 함 */}
+      <TopNav
+        left={
+          <>
+            <TopNav.Icon routePath="/" aria-label="행동대장 로고" component={<IconHeundeut />} />
+            <TopNav.Text routePath="/" textSize="subTitle" isEmphasis={true}>
+              행동대장
+            </TopNav.Text>
+          </>
+        }
+        right={
+          <TopNav.Icon
+            routePath="/"
+            aria-label="행동대장 로고"
+            component={<IconSetting size={24} />}
+            onClick={navigateSettingPage}
+          />
+        }
+      />
       <VStack gap="0.5rem" p="1rem" css={{width: '100%'}}>
         <ErrorBoundary fallback={<MainPageError />}>
           <Suspense fallback={<MainPageLoading />}>


### PR DESCRIPTION
## issue
- close #975 

## 구현 사항
MainPage에 TopNav를 적용합니다.

<img width="417" alt="image" src="https://github.com/user-attachments/assets/4e8e0e79-b520-47cf-a154-fedcb1824d04" />

톱니바퀴를 누르면 /setting으로 이동합니다.

## 🫡 참고사항
editIcon에 size를 사용하지 않고 있길래 수정했어요!
