### PR TITLE
[FE] 컴포넌트 접근성 검수 (Carousel, BottomSheet)

### DIFF
--- a/client/.storybook/preview.tsx
+++ b/client/.storybook/preview.tsx
@@ -3,7 +3,7 @@
 import type {Preview} from '@storybook/react';
 import {HDesignProvider} from '../src/components/Design';
 import {css, Global} from '@emotion/react';
-
+import {GlobalStyle} from '../src/GlobalStyle';
 const preview: Preview = {
   parameters: {
     controls: {
@@ -35,12 +35,15 @@ const preview: Preview = {
       return (
         <div>
           <Global
-            styles={css`
-              @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
-              body {
-                font-family: 'Pretendard', sans-serif;
-              }
-            `}
+            styles={[
+              css`
+                @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+                body {
+                  font-family: 'Pretendard', sans-serif;
+                }
+              `,
+              GlobalStyle,
+            ]}
           />
           <HDesignProvider>
             <Story />

--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -29,12 +29,10 @@ export const GlobalStyle = css`
     cursor: revert;
     line-height: 0;
   }
-
   a:focus-visible,
   button:focus-visible {
     outline: 2px solid ${COLORS.primary};
     outline-offset: 2px;
-    border-radius: 0.75rem;
   }
 
   button:disabled {

--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -1,5 +1,7 @@
 import {css} from '@emotion/react';
 
+import {COLORS} from '@token/colors';
+
 // reset css -> index css
 export const GlobalStyle = css`
   *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
@@ -26,6 +28,13 @@ export const GlobalStyle = css`
   button {
     cursor: revert;
     line-height: 0;
+  }
+
+  a:focus-visible,
+  button:focus-visible {
+    outline: 2px solid ${COLORS.primary};
+    outline-offset: 2px;
+    border-radius: 0.75rem;
   }
 
   button:disabled {

--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -29,7 +29,9 @@ export const GlobalStyle = css`
     cursor: revert;
     line-height: 0;
   }
-  a:focus-visible,
+  [href]:focus-visible,
+  [tabindex]:not([tabindex='-1']):focus-visible,
+  select:focus-visible,
   button:focus-visible {
     outline: 2px solid ${COLORS.primary};
     outline-offset: 2px;

--- a/client/src/GlobalStyle.ts
+++ b/client/src/GlobalStyle.ts
@@ -33,6 +33,7 @@ export const GlobalStyle = css`
   button:focus-visible {
     outline: 2px solid ${COLORS.primary};
     outline-offset: 2px;
+    opacity: 1;
   }
 
   button:disabled {

--- a/client/src/components/Design/components/Carousel/Carousel.stories.tsx
+++ b/client/src/components/Design/components/Carousel/Carousel.stories.tsx
@@ -2,6 +2,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 
 import Box from '../Box/Box';
+
 import Carousel from './Carousel';
 
 const meta = {

--- a/client/src/components/Design/components/Carousel/Carousel.stories.tsx
+++ b/client/src/components/Design/components/Carousel/Carousel.stories.tsx
@@ -1,22 +1,62 @@
 /** @jsxImportSource @emotion/react */
 import type {Meta, StoryObj} from '@storybook/react';
 
+import Box from '../Box/Box';
 import Carousel from './Carousel';
 
 const meta = {
   title: 'Components/Carousel',
   component: Carousel,
-  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
-    width: 430,
+    viewport: {
+      defaultViewport: {
+        width: 430,
+        height: 930,
+      },
+    },
+    docs: {
+      description: {
+        component: `
+Carousel 컴포넌트는 이미지들을 슬라이드 형태로 보여주는 컴포넌트입니다.
+
+### 주요 기능
+- 이미지 슬라이드 기능
+- 드래그로 이미지 전환 가능
+- 이미지 삭제 기능 (선택적)
+- 이미지 인디케이터
+- 좌우 이동 버튼
+
+### 사용 예시
+\`\`\`jsx
+<Carousel 
+  urls={[
+    'image1.jpg',
+    'image2.jpg',
+    'image3.jpg'
+  ]}
+  onClickDelete={(index) => handleDelete(index)} // 선택적
+/>
+\`\`\`
+`,
+      },
+    },
   },
-  argTypes: {},
+  tags: ['autodocs'],
+  argTypes: {
+    urls: {
+      description: '캐러셀에 표시할 이미지 URL 배열',
+    },
+    onClickDelete: {
+      description: '이미지 삭제 핸들러 (선택적)',
+    },
+  },
   args: {
     urls: [
-      'https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%BF%A0%ED%82%A4(6%EA%B8%B0)/image.png',
-      'https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%BF%A0%ED%82%A4%286%EA%B8%B0%29/4tyq1x19rsn.jpg',
-      'https://img.danawa.com/images/descFiles/5/896/4895281_1_16376712347542321.gif',
+      'https://d1f4hb6ir36p4s.cloudfront.net/images/todari.png',
+      'https://d1f4hb6ir36p4s.cloudfront.net/images/cookie.png',
+      'https://d1f4hb6ir36p4s.cloudfront.net/images/weadie.png',
+      'https://d1f4hb6ir36p4s.cloudfront.net/images/soha.png',
     ],
   },
 } satisfies Meta<typeof Carousel>;
@@ -25,4 +65,20 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {};
+export const Default: Story = {
+  render: args => {
+    return (
+      <Box w={480} h={930} bg="#ffffff" p={16} b="1px solid #eee" br={8}>
+        <Carousel {...args} />
+      </Box>
+    );
+  },
+};
+
+export const WithDeleteButton: Story = {
+  render: args => (
+    <Box w={480} h={930} bg="#ffffff" p={16} b="1px solid #eee" br={8}>
+      <Carousel {...args} onClickDelete={index => alert(`Delete image at index ${index}`)} />
+    </Box>
+  ),
+};

--- a/client/src/components/Design/components/Carousel/Carousel.style.ts
+++ b/client/src/components/Design/components/Carousel/Carousel.style.ts
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 
 import {Theme} from '@components/Design/theme/theme.type';
+
 import {Direction} from '../Icons/Icon.type';
 
 export const carouselWrapperStyle = css`

--- a/client/src/components/Design/components/Carousel/Carousel.style.ts
+++ b/client/src/components/Design/components/Carousel/Carousel.style.ts
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 
 import {Theme} from '@components/Design/theme/theme.type';
+import {Direction} from '../Icons/Icon.type';
 
 export const carouselWrapperStyle = css`
   position: relative;
@@ -13,6 +14,7 @@ interface ImageCardContainerStyleProps {
   length: number;
   translateX: number;
   isDragging: boolean;
+  parentWidth: number;
 }
 
 export const imageCardContainerStyle = ({
@@ -20,31 +22,37 @@ export const imageCardContainerStyle = ({
   length,
   translateX,
   isDragging,
+  parentWidth,
 }: ImageCardContainerStyleProps) => css`
   display: flex;
   gap: 1rem;
   margin-inline: 2rem;
-  transform: translateX(
+  transform: translate3d(
     calc(
-      (100vw - 3rem) * ${-currentIndex} +
+      (${parentWidth}px - 3rem) * ${-currentIndex} +
         ${(currentIndex === 0 && translateX > 0) || (currentIndex === length - 1 && translateX < 0) ? 0 : translateX}px
-    )
+    ),
+    0,
+    0
   );
+  will-change: transform;
+  backface-visibility: hidden;
   transition: ${isDragging ? 'none' : '0.2s'};
   transition-timing-function: cubic-bezier(0.7, 0.62, 0.62, 1.16);
 `;
 
 interface ImageCardStyleProps {
   theme: Theme;
+  parentWidth: number;
 }
 
-export const imageCardStyle = ({theme}: ImageCardStyleProps) => css`
+export const imageCardStyle = ({theme, parentWidth}: ImageCardStyleProps) => css`
   position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
   clip-path: inset(0 round 1rem);
-  max-width: calc(768px - 4rem);
+  width: ${parentWidth ? `calc(${parentWidth}px - 4rem)` : 'calc(430px - 4rem)'};
   background-color: ${theme.colors.gray};
 `;
 
@@ -92,4 +100,18 @@ export const indicatorStyle = ({index, currentIndex, theme}: IndicatorStyleProps
   transition: 0.2s;
   transition-timing-function: cubic-bezier(0.7, 0.62, 0.62, 1.16);
   content: ' ';
+`;
+
+export const changeButtonStyle = (direction: Direction) => css`
+  position: absolute;
+  ${direction === ('left' as Direction) ? 'left' : 'right'}: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0.5rem;
+  opacity: 0.48;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;

--- a/client/src/components/Design/components/Carousel/Carousel.tsx
+++ b/client/src/components/Design/components/Carousel/Carousel.tsx
@@ -4,27 +4,79 @@ import CarouselIndicator from './CarouselIndicator';
 import CarouselDeleteButton from './CarouselDeleteButton';
 import {carouselWrapperStyle, imageCardContainerStyle, imageCardStyle, imageStyle} from './Carousel.style';
 import useCarousel from './useCarousel';
+import {CarouselChangeButton} from './CarouselChangeButton';
 
 const Carousel = ({urls, onClickDelete}: CarouselProps) => {
-  const {handleDragStart, handleDrag, handleDragEnd, theme, currentIndex, translateX, isDragging, handleClickDelete} =
-    useCarousel({urls, onClickDelete});
+  const {
+    handleDragStart,
+    handleDrag,
+    handleDragEnd,
+    theme,
+    currentIndex,
+    translateX,
+    isDragging,
+    handleClickDelete,
+    handlePreventDrag,
+    handleToPrev,
+    handleToNext,
+    handleKeyDown,
+    parentWidth,
+    wrapperRef,
+  } = useCarousel({urls, onClickDelete});
 
   return (
-    <div css={carouselWrapperStyle}>
+    <div
+      css={carouselWrapperStyle}
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="이미지 캐러샐"
+      onKeyDown={handleKeyDown}
+      ref={wrapperRef}
+    >
       <div
-        css={imageCardContainerStyle({currentIndex, length: urls.length, translateX, isDragging})}
+        css={imageCardContainerStyle({currentIndex, length: urls.length, translateX, isDragging, parentWidth})}
         onMouseDown={handleDragStart}
         onMouseMove={handleDrag}
         onMouseUp={handleDragEnd}
         onTouchStart={handleDragStart}
         onTouchMove={handleDrag}
         onTouchEnd={handleDragEnd}
+        role="group"
+        aria-roledescription="slide"
+        aria-label={`전체 ${urls.length}장 중 ${currentIndex + 1}번째 이미지`}
       >
         {urls &&
           urls.map((url, index) => (
-            <div key={url} css={imageCardStyle({theme})}>
-              <img src={url} alt={`업로드된 이미지 ${index + 1}`} css={imageStyle} />
-              {onClickDelete && <CarouselDeleteButton onClick={() => handleClickDelete(index)} />}
+            <div key={url} css={imageCardStyle({theme, parentWidth})}>
+              <img
+                src={url}
+                alt={`업로드된 이미지 ${index + 1}`}
+                loading="lazy"
+                decoding="async"
+                css={imageStyle}
+                onDragStart={handlePreventDrag}
+                onDragEnd={handlePreventDrag}
+              />
+              {index !== 0 && (
+                <CarouselChangeButton
+                  direction="left"
+                  onClick={handleToPrev}
+                  tabIndex={currentIndex === index ? 0 : -1}
+                />
+              )}
+              {index !== urls.length - 1 && (
+                <CarouselChangeButton
+                  direction="right"
+                  onClick={handleToNext}
+                  tabIndex={currentIndex === index ? 0 : -1}
+                />
+              )}
+              {onClickDelete && (
+                <CarouselDeleteButton
+                  onClick={() => handleClickDelete(index)}
+                  tabIndex={currentIndex === index ? 0 : -1}
+                />
+              )}
             </div>
           ))}
       </div>

--- a/client/src/components/Design/components/Carousel/CarouselChangeButton.tsx
+++ b/client/src/components/Design/components/Carousel/CarouselChangeButton.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import {Direction} from '../Icons/Icon.type';
 import {IconChevron} from '../Icons/Icons/IconChevron';
+
 import {changeButtonStyle} from './Carousel.style';
 
 interface Props {

--- a/client/src/components/Design/components/Carousel/CarouselChangeButton.tsx
+++ b/client/src/components/Design/components/Carousel/CarouselChangeButton.tsx
@@ -1,0 +1,18 @@
+/** @jsxImportSource @emotion/react */
+import {Direction} from '../Icons/Icon.type';
+import {IconChevron} from '../Icons/Icons/IconChevron';
+import {changeButtonStyle} from './Carousel.style';
+
+interface Props {
+  direction: Direction;
+  onClick: () => void;
+  tabIndex: number;
+}
+
+export const CarouselChangeButton = ({direction, onClick, tabIndex}: Props) => {
+  return (
+    <button onClick={onClick} css={changeButtonStyle(direction)} tabIndex={tabIndex}>
+      <IconChevron size={16} direction={direction} />
+    </button>
+  );
+};

--- a/client/src/components/Design/components/Carousel/CarouselDeleteButton.tsx
+++ b/client/src/components/Design/components/Carousel/CarouselDeleteButton.tsx
@@ -5,11 +5,12 @@ import {deleteButtonStyle} from './Carousel.style';
 
 interface Props {
   onClick: () => void;
+  tabIndex: number;
 }
 
-const CarouselDeleteButton = ({onClick}: Props) => {
+const CarouselDeleteButton = ({onClick, tabIndex}: Props) => {
   return (
-    <button css={deleteButtonStyle} onClick={onClick}>
+    <button css={deleteButtonStyle} onClick={onClick} tabIndex={tabIndex}>
       <IconX />
     </button>
   );

--- a/client/src/components/Design/components/Icons/Svg.tsx
+++ b/client/src/components/Design/components/Icons/Svg.tsx
@@ -36,13 +36,13 @@ const Svg: React.FC<SvgProps> = ({children, color, size, width, height, directio
   const getRotation = () => {
     switch (direction) {
       case 'up':
-        return 180;
+        return '180deg';
       case 'left':
-        return 90;
+        return '90deg';
       case 'right':
-        return 270;
+        return '270deg';
       default:
-        return 0;
+        return '0deg';
     }
   };
 
@@ -54,7 +54,7 @@ const Svg: React.FC<SvgProps> = ({children, color, size, width, height, directio
         color={color ? theme.colors[color] : 'currentColor'}
         viewBox={viewBox}
         xmlns="http://www.w3.org/2000/svg"
-        transform={`rotate(${getRotation()})`}
+        style={{transform: `rotate(${getRotation()})`}}
         dangerouslySetInnerHTML={{__html: childrenString}}
         {...rest}
       />

--- a/client/src/components/Design/components/Top/Top.tsx
+++ b/client/src/components/Design/components/Top/Top.tsx
@@ -23,7 +23,6 @@ export default function Top({children}: React.PropsWithChildren) {
         flex-direction: column;
       `}
       aria-label={childrenTexts.join(' ')}
-      tabIndex={0}
     >
       {children}
     </div>

--- a/client/src/components/EditAccountPageView.tsx
+++ b/client/src/components/EditAccountPageView.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 
 import BankSelectModal from '@components/Modal/BankSelectModal/BankSelectModal';
@@ -24,6 +24,7 @@ const EditAccountPageView = ({
   const navigate = useNavigate();
 
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const accountInputRef = useRef<HTMLInputElement>(null);
 
   const {
     bankName,
@@ -44,6 +45,13 @@ const EditAccountPageView = ({
     await enrollAccount();
 
     navigate(redirectUrlOnSubmit);
+  };
+
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetOpen(false);
+    if (document.activeElement?.tagName !== 'BODY') {
+      accountInputRef.current?.focus();
+    }
   };
 
   return (
@@ -68,9 +76,10 @@ const EditAccountPageView = ({
             errorText={null}
             autoFocus={false}
             readOnly
-            onClick={() => setIsBottomSheetOpen(true)}
+            onFocus={() => setIsBottomSheetOpen(true)}
           />
           <Input
+            ref={accountInputRef}
             labelText="계좌번호"
             placeholder="ex) 030302-04-191806"
             errorText={accountNumberErrorMessage}
@@ -80,13 +89,11 @@ const EditAccountPageView = ({
             onPaste={handleAccountOnPaste}
             autoFocus={false}
           />
-          {isBottomSheetOpen && (
-            <BankSelectModal
-              isBottomSheetOpened={isBottomSheetOpen}
-              setIsBottomSheetOpened={setIsBottomSheetOpen}
-              selectBank={selectBank}
-            />
-          )}
+          <BankSelectModal
+            isBottomSheetOpened={isBottomSheetOpen}
+            onClose={handleCloseBottomSheet}
+            selectBank={selectBank}
+          />
         </Flex>
       </FunnelLayout>
       <FixedButton disabled={!canSubmit} onClick={enrollAccountAndRedirectTo} onBackClick={() => navigate(-1)}>

--- a/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
+++ b/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
@@ -15,7 +15,6 @@ type BankSelectProps = {
 
 const BankSelectModal = ({isBottomSheetOpened, onClose, selectBank}: BankSelectProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const selectBankAndClose = (name: BankName) => {
     selectBank(name);
@@ -29,9 +28,6 @@ const BankSelectModal = ({isBottomSheetOpened, onClose, selectBank}: BankSelectP
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     );
     const firstFocusable = focusableElements?.[0] as HTMLElement;
-    if (document.activeElement !== firstFocusable) {
-      (focusableElements?.[1] as HTMLElement).focus();
-    }
     const lastFocusable = focusableElements?.[focusableElements.length - 1] as HTMLElement;
 
     const handleTabKey = (e: KeyboardEvent) => {
@@ -50,11 +46,20 @@ const BankSelectModal = ({isBottomSheetOpened, onClose, selectBank}: BankSelectP
       }
     };
 
+    const handleFocusChange = () => {
+      const isModalElement = Array.from(focusableElements ?? []).some(element => element === document.activeElement);
+
+      if (!isModalElement) {
+        (focusableElements?.[1] as HTMLElement)?.focus();
+      }
+    };
+
     document.addEventListener('keydown', handleTabKey);
-    closeButtonRef.current?.focus();
+    document.addEventListener('focusin', handleFocusChange);
 
     return () => {
       document.removeEventListener('keydown', handleTabKey);
+      document.removeEventListener('focusin', handleFocusChange);
     };
   }, [isBottomSheetOpened]);
 

--- a/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
+++ b/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
@@ -1,26 +1,70 @@
 import {BankName} from 'types/serviceType';
+import {useEffect, useRef} from 'react';
 
 import {BankSelect, BottomSheet, Text} from '@HDesign/index';
 
 import {bottomSheetHeaderStyle, bottomSheetStyle, inputContainerStyle} from './BankSelectModal.style';
+import {IconX} from '@components/Design/components/Icons/Icons/IconX';
 
 type BankSelectProps = {
   isBottomSheetOpened: boolean;
-  setIsBottomSheetOpened: React.Dispatch<React.SetStateAction<boolean>>;
+  onClose: () => void;
   selectBank: (name: BankName) => void;
 };
 
-const BankSelectModal = ({isBottomSheetOpened, setIsBottomSheetOpened, selectBank}: BankSelectProps) => {
+const BankSelectModal = ({isBottomSheetOpened, onClose, selectBank}: BankSelectProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
   const selectBankAndClose = (name: BankName) => {
     selectBank(name);
-    setIsBottomSheetOpened(false);
+    onClose();
   };
 
+  useEffect(() => {
+    if (!isBottomSheetOpened) return;
+
+    const focusableElements = modalRef.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const firstFocusable = focusableElements?.[0] as HTMLElement;
+    if (document.activeElement !== firstFocusable) {
+      (focusableElements?.[1] as HTMLElement).focus();
+    }
+    const lastFocusable = focusableElements?.[focusableElements.length - 1] as HTMLElement;
+
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstFocusable) {
+          e.preventDefault();
+          lastFocusable?.focus();
+        }
+      } else {
+        if (document.activeElement === lastFocusable) {
+          e.preventDefault();
+          firstFocusable?.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTabKey);
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', handleTabKey);
+    };
+  }, [isBottomSheetOpened]);
+
   return (
-    <BottomSheet isOpened={isBottomSheetOpened} onClose={() => setIsBottomSheetOpened(false)}>
-      <div css={bottomSheetStyle}>
+    <BottomSheet isOpened={isBottomSheetOpened} onClose={onClose}>
+      <div css={bottomSheetStyle} ref={modalRef}>
         <h2 css={bottomSheetHeaderStyle}>
           <Text size="bodyBold">은행을 선택해주세요</Text>
+          <button onClick={onClose} aria-label="바텀시트 닫기">
+            <IconX size={24} aria-hidden="true" />
+          </button>
         </h2>
         <fieldset css={inputContainerStyle}>
           <BankSelect onSelect={selectBankAndClose} />

--- a/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
+++ b/client/src/components/Modal/BankSelectModal/BankSelectModal.tsx
@@ -1,10 +1,11 @@
-import {BankName} from 'types/serviceType';
 import {useEffect, useRef} from 'react';
+
+import {BankName} from 'types/serviceType';
+import {IconX} from '@components/Design/components/Icons/Icons/IconX';
 
 import {BankSelect, BottomSheet, Text} from '@HDesign/index';
 
 import {bottomSheetHeaderStyle, bottomSheetStyle, inputContainerStyle} from './BankSelectModal.style';
-import {IconX} from '@components/Design/components/Icons/Icons/IconX';
 
 type BankSelectProps = {
   isBottomSheetOpened: boolean;


### PR DESCRIPTION
## issue
- close #982 

## 구현 목적
#893  issue 작업을 진행하던 중 접근성이 고려가 되지 않은 component들을 발견하여 해당 작업을 진행하고자 했습니다.

### 1. GlobalStyle에 focus-visible 이 존재하지 않음

https://github.com/user-attachments/assets/7ef20f8e-1a89-4b44-8c80-33eb3a5edf25

focus 상태에 대한 style을 별도로 만들어 준 input을 제외하고, tab 키를 이용해서 focus를 변경하였을 때,
focus가 어디에 존재하는지 확인할 수 없는 것을 확인할 수 있었습니다.
이에 대한 작업을 진행하여 키보드 및 tab키만을 이용하여 서비스를 사용할 수 있도록 합니다.

### 2. IOS 환경에서 SVG Icon component의 direction이 제대로 적용되지 않는 문제

- safari에서 확인한 경우 (ios 환경도 동일하게 적용)
![image](https://github.com/user-attachments/assets/3236ae19-ccf2-46d9-99b4-bf53daefdff3)

- chrome 기반에서 확인한 경우
![image](https://github.com/user-attachments/assets/cba0496e-c028-49cd-8c18-8335a302f435)

### 3. Carousel component가 768px 이상의 경우에서 제대로 드래그 되지 않는 문제

https://github.com/user-attachments/assets/d2f4f633-ba52-46ee-abfa-8b912c15a739

768px 이하의 해상도에선 정상 작동 하지만, 위의 영상과 같이 768px 이상에서 제대로 작동하지 않음

### 4. Carousel component를 드래그 및 터치무브로밖에 사용할 수 없는 문제

현재 carousel은 드래그 및 터치무브 이벤트만 가능하기 때문에, 키보드 및 스크린리더로 사용할 수 없는 문제가 있습니다.

### 5. 계좌등록 - 은행선택 과정에서 키보드 및 스크린리더를 사용할 수 없는 문제

현재 은행 선택에서 클릭을 통해서만 바텀시트를 열수 있어 키보드 및 스크린리더로 사용할 수 없는 문제가 있습니다.

## 구현 사항

### 1. GlobalStyle에 focus-visible 이 존재하지 않음

```tsx
// Globalstyle.ts
// ...
  [href]:focus-visible,
  [tabindex]:not([tabindex='-1']):focus-visible,
  select:focus-visible,
  button:focus-visible {
    outline: 2px solid ${COLORS.primary};
    outline-offset: 2px;
    opacity: 1;
  }
// ...
```
`focus-visible` 속성을 추가하여 focusible element에 focus 강조 효과를 추가하였습니다.
위와 같이 속성을 추가하면 `href`와 `tabIndex` attribute를 가진 모든 element들에 focus-visible이 적용되는데,
현재 `Top` component 에 불필요한 `tabIndex={0}`이 적용되어 있어 이를 제거하였습니다.

### 2. IOS 환경에서 SVG Icon component의 direction이 제대로 적용되지 않는 문제

ios(safari) 환경과 그렇지 않은 환경에서 attribute 값에 단위가 제대로 적혀있지 않을 떄, 기본적으로 처리하는 방법이 달라서 발생하는 문제입니다.
기존에는 direction에 대해서 90, 180 과 같이 값만 적혀 있어 ios 환경에서 이를 제대로 적용시키지 못했지만,
deg 단위를 추가하여 두 환경에서 모두 정상작동 할 수 있도록 변경하였습니다.

```tsx
// Svg.tsx
// ...
  const getRotation = () => {
    switch (direction) {
      case 'up':
        return '180deg';
      case 'left':
        return '90deg';
      case 'right':
        return '270deg';
      default:
        return '0deg';
    }
  };
// ...
```

### 3. Carousel component가 768px 이상의 경우에서 제대로 드래그 되지 않는 문제

```tsx
// Carousel.tsx
// ...
  transform: translateX(
    calc(
      (100vw - 3rem) * ${-currentIndex} +
        ${(currentIndex === 0 && translateX > 0) || (currentIndex === length - 1 && translateX < 0) ? 0 : translateX}px
    )
  );
// ...
```
기존 carousel wrapper에서 transform을 100vw 기준으로 변경하였습니다.
768px 이하의 경우 100%로 확장되기 때문에 문제가 없지만, 768px 이상의 경우 100vw 크기와 앱의 전체 크기 (768px) 사이의 오류가 생겨 발생하는 문제입니다.
이에 Carousel component의 부모 요소 너비를 받아 해당 요소까지 넓어질 수 있도록 하였습니다.

```tsx
// useCarousel.ts
// ...
  const wrapperRef = useRef<HTMLDivElement | null>(null);
  const parentWidth = useRef(0);
// ...
  useEffect(() => {
    const handleResize = () => {
      if (wrapperRef.current) {
        const parentElement = wrapperRef.current.parentElement;
        parentWidth.current = parentElement?.clientWidth ?? 0;
      }
    };

    handleResize();
    window.addEventListener('resize', handleResize);

    return () => {
      window.removeEventListener('resize', handleResize);
    };
  }, [wrapperRef, window.innerWidth]);
// ...
```

```tsx
// Carousel.tsx
// ...
  transform: translate3d(
    calc(
      (${parentWidth}px - 3rem) * ${-currentIndex} +
        ${(currentIndex === 0 && translateX > 0) || (currentIndex === length - 1 && translateX < 0) ? 0 : translateX}px
    ),
    0,
    0
  );
// ...
```
또한, 기존의 `translateX`를 `translate3D`로 변경한 이유는 GPU 가속을 이용하여 애니메이션의 품질이 떨어지지 않도록 하기 위함입니다.

### 4. Carousel component를 드래그 및 터치무브로밖에 사용할 수 없는 문제

```tsx
// Carousel.tsx
// ...
        {urls &&
          urls.map((url, index) => (
            <div key={url} css={imageCardStyle({theme, parentWidth})}>
              <img
                src={url}
                alt={`업로드된 이미지 ${index + 1}`}
                loading="lazy"
                decoding="async"
                css={imageStyle}
                onDragStart={handlePreventDrag}
                onDragEnd={handlePreventDrag}
              />
              {index !== 0 && (
                <CarouselChangeButton
                  direction="left"
                  onClick={handleToPrev}
                  tabIndex={currentIndex === index ? 0 : -1}
                />
              )}
              {index !== urls.length - 1 && (
                <CarouselChangeButton
                  direction="right"
                  onClick={handleToNext}
                  tabIndex={currentIndex === index ? 0 : -1}
                />
              )}
              {onClickDelete && (
                <CarouselDeleteButton
                  onClick={() => handleClickDelete(index)}
                  tabIndex={currentIndex === index ? 0 : -1}
                />
              )}
            </div>
          ))}
// ...
```

carousel에서 좌우로 넘길 수 있는 버튼을 추가하여 키보드 및 스크린 리더로도 좌우로  넘길 수 있도록 변경하였습니다.
`tabIndex={currentIndex === index ? 0 : -1}` 를 사용한 이유는, 현재 보이는 캐러셀이 아닌 부분의 버튼들은 접근할 수 없도록 하기 위함입니다.
좌우 button을 사용하는 것 외에도, 키보드 화살표 좌 우 버튼을 통해서도 사진을 넘길 수 있습니다.

- tab과 button을 이용하여 carousel을 사용하는 영상

https://github.com/user-attachments/assets/298776dc-c872-4d55-9247-35907dac6b36

- 좌우 화살표를 이용하여 carousel을 사용하는 영상

https://github.com/user-attachments/assets/97431449-600c-4825-a96f-efdecb75f85d

### 5. 계좌등록 - 은행선택 과정에서 키보드 및 스크린리더를 사용할 수 없는 문제
```tsx
// EditAccountView.tsx
// ...
          <Input
            labelText="은행"
            placeholder="은행을 선택해주세요"
            value={bankName ?? ''}
            errorText={null}
            autoFocus={false}
            readOnly
            onFocus={() => setIsBottomSheetOpen(true)}
          />
// ...
```
기존에 `onClick` prop으로 있던 setter를 `onFocus`로 변경함으로써 클릭 뿐 아니라, 키보드 및 스크린 리더로도 bottomSheet를 열수 있도록 하였습니다.
또한, 열린 bottomSheet를 다시 닫기 위해서 닫는 버튼을 추가하였습니다.

바텀시트가 열린 후, 바텀시트 내부에서 tab이 순환하도록 focusTrap을 구현하였습니다.
```tsx
// BankSelectModal.tsx
// ...
  useEffect(() => {
    if (!isBottomSheetOpened) return;

    const focusableElements = modalRef.current?.querySelectorAll(
      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
    );
    const firstFocusable = focusableElements?.[0] as HTMLElement;
    const lastFocusable = focusableElements?.[focusableElements.length - 1] as HTMLElement;

    const handleTabKey = (e: KeyboardEvent) => {
      if (e.key !== 'Tab') return;

      if (e.shiftKey) {
        if (document.activeElement === firstFocusable) {
          e.preventDefault();
          lastFocusable?.focus();
        }
      } else {
        if (document.activeElement === lastFocusable) {
          e.preventDefault();
          firstFocusable?.focus();
        }
      }
    };

    const handleFocusChange = () => {
      const isModalElement = Array.from(focusableElements ?? []).some(element => element === document.activeElement);

      if (!isModalElement) {
        (focusableElements?.[1] as HTMLElement)?.focus();
      }
    };

    document.addEventListener('keydown', handleTabKey);
    document.addEventListener('focusin', handleFocusChange);

    return () => {
      document.removeEventListener('keydown', handleTabKey);
      document.removeEventListener('focusin', handleFocusChange);
    };
  }, [isBottomSheetOpened]);
// ...
```

- 구현 전 (키보드 및 스크린 리더 사용 불가)

https://github.com/user-attachments/assets/2729f2f2-293d-4be6-9d07-373778510a20

- 구현 후 (키보드 사용)

https://github.com/user-attachments/assets/0c53f9d0-64ea-4bbb-b5fb-b009ccdb037a

Uploading 화면 기록 2025-01-30 오후 5.29.22.mov…


## 참고 사항

해당 작업을 진행 중 bottomSheet의 접근성과 사용성을 향상시킬 수 있는 방법이 있을 것 같아
시간이 나면 이를 마저 적용시켜보도록 하겠습니다.
또한 작업을 하다 생각난 것인데, 우리는 모바일 퍼스트이다보니 키보드 접근성을 높은 우선순위로 생각했어야 하나 하는 생각이 드네요....
이런 작업들을 토대로 스크린리더 또한 시도해 보고자 합니다~!
서로 연관있는 것들이 많아 함께 작업하다 보니 변경사항이 너무 커져버렸네요....
태스크를 나눠서 작업하는 것도 굉장히 중요하고 어려운 것 같습니디...... 으아악









