### PR TITLE
[FE] 로그인 후 행사 생성이 아닌 메인 페이지로 이동

### DIFF
--- a/client/src/pages/login/LoginRedirectPage.tsx
+++ b/client/src/pages/login/LoginRedirectPage.tsx
@@ -40,7 +40,7 @@ const LoginRedirectPage = () => {
       if (previousUrlForLogin) {
         navigate(previousUrlForLogin, {replace: true});
       } else {
-        navigate(ROUTER_URLS.createUserEvent);
+        navigate(ROUTER_URLS.main);
       }
     };
 


### PR DESCRIPTION
## issue
- close #986 

## 구현 사항
### 플로우 변경으로 로그인 후 행사 생성 페이지가 아니라 메인 페이지로 이동

LoginRedirectPage의 route 설정을 `navigate(ROUTER_URLS.createUserEvent)`에서 `navigate(ROUTER_URLS.main)`으로 변경했습니다.

## 🫡 참고사항
