### PR TITLE
[FE] 링크 공유 시 참여자 이름 넣기

### DIFF
--- a/client/src/hooks/useEventPageLayout.ts
+++ b/client/src/hooks/useEventPageLayout.ts
@@ -35,6 +35,7 @@ const useEventPageLayout = () => {
     isAdmin,
     event,
     eventSummary,
+    allMembers: members,
   };
 };
 

--- a/client/src/hooks/useShareEvent.ts
+++ b/client/src/hooks/useShareEvent.ts
@@ -1,5 +1,6 @@
 import getEventIdByUrl from '@utils/getEventIdByUrl';
 import getEventPageUrlByEnvironment from '@utils/getEventPageUrlByEnvironment';
+import getImageUrl from '@utils/getImageUrl';
 
 type UserShareEventProps = {
   eventName: string;
@@ -28,8 +29,7 @@ const useShareEvent = ({eventName, allMembers}: UserShareEventProps) => {
       content: {
         title: shareInfo.title,
         description: shareInfo.text,
-        imageUrl:
-          'https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%9B%A8%EB%94%94%286%EA%B8%B0%29/g583lirp8yg.jpg',
+        imageUrl: getImageUrl('share-image', 'png'),
         link: {
           mobileWebUrl: url,
           webUrl: url,

--- a/client/src/hooks/useShareEvent.ts
+++ b/client/src/hooks/useShareEvent.ts
@@ -12,7 +12,7 @@ const useShareEvent = ({eventName, allMembers}: UserShareEventProps) => {
   const url = getEventPageUrlByEnvironment(eventId, 'home');
 
   const shareInfo = {
-    title: `${allMembers.join(', ')}\n행동대장이 ${eventName}에 대한 정산을 요청했어요 :)`,
+    title: `참여자: ${allMembers.join(', ')}\n\n행동대장이 ${eventName}에 대한 정산을 요청했어요 :)`,
     text: '아래 링크에 접속해서 정산 내역을 확인해 주세요!',
     url,
   };

--- a/client/src/hooks/useShareEvent.ts
+++ b/client/src/hooks/useShareEvent.ts
@@ -3,14 +3,15 @@ import getEventPageUrlByEnvironment from '@utils/getEventPageUrlByEnvironment';
 
 type UserShareEventProps = {
   eventName: string;
+  allMembers: string[];
 };
 
-const useShareEvent = ({eventName}: UserShareEventProps) => {
+const useShareEvent = ({eventName, allMembers}: UserShareEventProps) => {
   const eventId = getEventIdByUrl();
   const url = getEventPageUrlByEnvironment(eventId, 'home');
 
   const shareInfo = {
-    title: `행동대장이 ${eventName}에\n대한 정산을 요청했어요 :)`,
+    title: `${allMembers.join(', ')}\n행동대장이 ${eventName}에 대한 정산을 요청했어요 :)`,
     text: '아래 링크에 접속해서 정산 내역을 확인해 주세요!',
     url,
   };

--- a/client/src/pages/event/[eventId]/EventPageLayout.tsx
+++ b/client/src/pages/event/[eventId]/EventPageLayout.tsx
@@ -25,7 +25,7 @@ export type EventPageContextProps = Event & {
 };
 
 const EventPageLayout = () => {
-  const {event, eventId, eventSummary} = useEventPageLayout();
+  const {event, eventId, eventSummary, allMembers} = useEventPageLayout();
   const {isGuest} = event.userInfo;
 
   const navigate = useNavigate();
@@ -36,7 +36,10 @@ const EventPageLayout = () => {
   };
 
   const isMobile = isMobileDevice();
-  const {kakaoShare, copyShare} = useShareEvent({eventName: event.eventName});
+  const {kakaoShare, copyShare} = useShareEvent({
+    eventName: event.eventName,
+    allMembers: allMembers.map(member => member.name),
+  });
 
   const trackLinkShare = async () => {
     trackShareEvent({...eventSummary, shareMethod: 'link'});


### PR DESCRIPTION
## issue
- close #995 

## 구현 사항
### 링크 공유 시 참여자 이름이 보이도록 추가
![image](https://github.com/user-attachments/assets/387b4b4e-fc44-40e8-b407-4c69fd74eee7)

링크 공유할 때 참여자 이름을 추가해서 쉽게 언급할 수 있도록 했습니다.

### image url s3의 이미지로 교체
크루위키 문서 속 이미지를 가져오는 방식이 아닌, 우리 서비스 내에서 가져오도록 바꿨습니다.

## 🫡 참고사항
