### PR TITLE
[FE] webpack build, buld-dev 속도 개선

### DIFF
--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -26,6 +26,24 @@ jobs:
         with:
           node-version: "20.15.1"
 
+      # 노드모듈스 캐싱
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      # 웹팩 캐싱(패키지락과 프로드웹팩컨픽이 바뀌지 않으면 캐시 사용)
+      - name: Cache Webpack
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache
+          key: ${{ runner.os }}-webpack-${{ hashFiles('package-lock.json', 'webpack.prod.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-webpack-
+              
       # 3. 의존성 설치
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -26,6 +26,19 @@ jobs:
         with:
           node-version: "20.15.1"
 
+      # 웹팩 캐싱(패키지락과 프로드웹팩컨픽이 바뀌지 않으면 캐시 사용)
+      - name: Cache Webpack
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache
+          key: ${{ runner.os }}-webpack-${{ hashFiles('package-lock.json', 'webpack.prod.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-webpack-
+            
+      # 5. Prod 환경으로 빌드
+      - name: Build for Prod environment
+        run: npm run build
+
       # 3. 의존성 설치
       - name: Install Dependencies
         run: npm install
@@ -40,9 +53,14 @@ jobs:
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env.prod
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.prod
 
-      # 5. Prod 환경으로 빌드
-      - name: Build for Prod environment
-        run: npm run build
+      # 노드모듈스 캐싱
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       # 6. AWS 인증 설정
       - name: Configure AWS credentials

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           node-version: "20.15.1"
 
+      # 노드모듈스 캐싱
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       # 웹팩 캐싱(패키지락과 프로드웹팩컨픽이 바뀌지 않으면 캐시 사용)
       - name: Cache Webpack
         uses: actions/cache@v4
@@ -52,15 +61,6 @@ jobs:
           echo "IMAGE_URL=${{ secrets.IMAGE_URL }}" >> .env.prod
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env.prod
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.prod
-
-      # 노드모듈스 캐싱
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       # 6. AWS 인증 설정
       - name: Configure AWS credentials

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,8 +49,8 @@
         "@types/react-copy-to-clipboard": "^5.0.7",
         "@types/react-dom": "^18.3.0",
         "@types/testing-library__jest-dom": "^6.0.0",
-        "@typescript-eslint/eslint-plugin": "^7.16.0",
-        "@typescript-eslint/parser": "^7.16.0",
+        "@typescript-eslint/eslint-plugin": "^8.26.1",
+        "@typescript-eslint/parser": "^8.26.1",
         "cypress": "^13.13.2",
         "dotenv-webpack": "^8.1.0",
         "eslint": "^9.6.0",
@@ -7637,64 +7637,297 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.1.tgz",
+      "integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/type-utils": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/type-utils": "8.26.1",
+        "@typescript-eslint/utils": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
+      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
+      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
+      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
+      "integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
+      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.1.tgz",
+      "integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
+      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
+      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
+      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
+      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -7715,30 +7948,158 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.1.tgz",
+      "integrity": "sha512-Kcj/TagJLwoY/5w9JGEFV0dclQdyqw9+VMndxOJKtoFSjfZhLXhYjzsQEeyza03rwHx2vFEGvrJWJBXKleRvZg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/typescript-estree": "8.26.1",
+        "@typescript-eslint/utils": "8.26.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
+      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
+      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
+      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
+      "integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
+      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.26.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -22478,6 +22839,94 @@
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "@typescript-eslint/utils": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "build-dev": "NODE_ENV=development webpack --config webpack.dev.mjs",
     "build-storybook": "storybook build",
     "storybook": "storybook dev -p 6006",
-    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
     "cypress-open": "cypress open",
     "cypress-run": "cypress run",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {RouterProvider} from 'react-router-dom';
-import * as Sentry from '@sentry/react';
+// import * as Sentry from '@sentry/react';
 
 import router from './router';
 
-Sentry.init({
-  dsn: 'https://81685591a3234c689be8c48959b04c88@o4507739935997952.ingest.us.sentry.io/4507739943272448',
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
-  // Performance Monitoring
-  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ['localhost', /^https:\/\/api\.haengdong\.pro/],
-  // Session Replay
-  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-});
+// Sentry.init({
+//   dsn: 'https://81685591a3234c689be8c48959b04c88@o4507739935997952.ingest.us.sentry.io/4507739943272448',
+//   integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+//   // Performance Monitoring
+//   tracesSampleRate: 1.0, //  Capture 100% of the transactions
+//   // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+//   tracePropagationTargets: ['localhost', /^https:\/\/api\.haengdong\.pro/],
+//   // Session Replay
+//   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+//   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+// });
 
 // MSW 모킹을 사용하려면 아래 주석을 해제하고 save해주세요.
 // async function enableMocking() {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -20,7 +20,7 @@
     // "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "types": ["jest", "@testing-library/jest-dom", "node", "cypress"],
+    "types": ["jest", "@testing-library/jest-dom", "node", "cypress", "@emotion/react/types/css-prop"],
     "esModuleInterop": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,

--- a/client/webpack.common.mjs
+++ b/client/webpack.common.mjs
@@ -70,6 +70,5 @@ export default {
       hash: true,
       favicon: path.resolve(__dirname, 'public/favicon.ico'),
     }),
-   
   ],
 };

--- a/client/webpack.common.mjs
+++ b/client/webpack.common.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import {ModifySourcePlugin, ConcatOperation} from 'modify-source-webpack-plugin';
+// import {ModifySourcePlugin, ConcatOperation} from 'modify-source-webpack-plugin';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/client/webpack.common.mjs
+++ b/client/webpack.common.mjs
@@ -1,6 +1,7 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-// import {ModifySourcePlugin, ConcatOperation} from 'modify-source-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import {ModifySourcePlugin, ConcatOperation} from 'modify-source-webpack-plugin';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/client/webpack.common.mjs
+++ b/client/webpack.common.mjs
@@ -70,5 +70,6 @@ export default {
       hash: true,
       favicon: path.resolve(__dirname, 'public/favicon.ico'),
     }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
 };

--- a/client/webpack.common.mjs
+++ b/client/webpack.common.mjs
@@ -1,6 +1,5 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import {ModifySourcePlugin, ConcatOperation} from 'modify-source-webpack-plugin';
 import {fileURLToPath} from 'url';
 
@@ -37,6 +36,9 @@ export default {
         test: /\.tsx?$/,
         loader: 'ts-loader',
         exclude: /node_modules/,
+        options: {
+          transpileOnly: true,
+        },
       },
       {
         test: /\.svg$/,
@@ -51,7 +53,6 @@ export default {
                     active: false, // viewBox 유지
                   },
                 ],
-                icon: true, // `symbol` 방식으로 출력
               },
             },
           },
@@ -69,14 +70,6 @@ export default {
       hash: true,
       favicon: path.resolve(__dirname, 'public/favicon.ico'),
     }),
-    new ForkTsCheckerWebpackPlugin(),
-    new ModifySourcePlugin({
-      rules: [
-        {
-          test: /\.tsx$/i,
-          operations: [new ConcatOperation('start', '/** @jsxImportSource @emotion/react */\n\n')],
-        },
-      ],
-    }),
+   
   ],
 };

--- a/client/webpack.dev.mjs
+++ b/client/webpack.dev.mjs
@@ -31,5 +31,4 @@ export default merge(common, {
     }),
     new ForkTsCheckerWebpackPlugin(),
   ],
-  
 });

--- a/client/webpack.dev.mjs
+++ b/client/webpack.dev.mjs
@@ -3,7 +3,7 @@ import {merge} from 'webpack-merge';
 import Dotenv from 'dotenv-webpack';
 import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
-import TerserPlugin from 'terser-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -15,7 +15,6 @@ export default merge(common, {
     chunkFilename: '[id].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
-    publicPath: '/',
   },
   devtool: 'eval-source-map',
   devServer: {
@@ -30,26 +29,7 @@ export default merge(common, {
     new Dotenv({
       path: '.env.dev',
     }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          compress: {
-            // 가능한 모든 코드를 압축
-            drop_console: true, // 콘솔 로그를 제거하여 파일 크기 감소
-            drop_debugger: true, // 디버거 코드 제거
-            pure_funcs: ['console.info'], // 특정 함수 호출 제거
-          },
-          mangle: true, // 변수 및 함수 이름을 짧게 변경
-          output: {
-            comments: false, // 주석을 제거
-          },
-        },
-        extractComments: false, // 별도의 파일로 주석을 추출하지 않음
-        parallel: true, // 멀티 프로세스를 사용하여 빌드 속도 향상
-      }),
-    ],
-  },
+  
 });

--- a/client/webpack.dev.mjs
+++ b/client/webpack.dev.mjs
@@ -3,7 +3,6 @@ import {merge} from 'webpack-merge';
 import Dotenv from 'dotenv-webpack';
 import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,6 +29,5 @@ export default merge(common, {
     new Dotenv({
       path: '.env.dev',
     }),
-    new ForkTsCheckerWebpackPlugin(),
   ],
 });

--- a/client/webpack.dev.mjs
+++ b/client/webpack.dev.mjs
@@ -15,6 +15,7 @@ export default merge(common, {
     chunkFilename: '[id].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
+    publicPath: '/',
   },
   devtool: 'eval-source-map',
   devServer: {

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -16,9 +16,8 @@ export default merge(common, {
     chunkFilename: '[id].[contenthash].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
-    publicPath: '/',
   },
-  devtool: 'source-map',
+  devtool: 'nosources-source-map',
   plugins: [
     new Dotenv({
       path: '.env.prod',

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -11,8 +11,8 @@ const __dirname = path.dirname(__filename);
 export default merge(common, {
   mode: 'production',
   output: {
-    filename: '[name].[hash].js',
-    chunkFilename: '[id].[hash].chunk.js',
+    filename: '[name].[contenthash].js',
+    chunkFilename: '[id].[contenthash].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
     publicPath: '/',

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -3,7 +3,8 @@ import {merge} from 'webpack-merge';
 import Dotenv from 'dotenv-webpack';
 import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
-import {sentryWebpackPlugin} from '@sentry/webpack-plugin';
+// import {sentryWebpackPlugin} from '@sentry/webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,13 +23,32 @@ export default merge(common, {
     new Dotenv({
       path: '.env.prod',
     }),
-    sentryWebpackPlugin({
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: 'wtc-o6',
-      project: 'javascript-react',
-      sourcemaps: {
-        filesToDeleteAfterUpload: ['**/*.js.map', '**/*.css.map', '**/*.LICENSE.txt'],
-      },
-    }),
+    // sentryWebpackPlugin({
+    //   authToken: process.env.SENTRY_AUTH_TOKEN,
+    //   org: 'wtc-o6',
+    //   project: 'javascript-react',
+    //   sourcemaps: {
+    //     filesToDeleteAfterUpload: ['**/*.js.map', '**/*.css.map', '**/*.LICENSE.txt'],
+    //   },
+    // }),
   ],
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          compress: {
+            // 가능한 모든 코드를 압축
+            drop_console: true, // 콘솔 로그를 제거하여 파일 크기 감소
+          },
+          mangle: true, // 변수 및 함수 이름을 짧게 변경
+          output: {
+            comments: false, // 주석을 제거
+          },
+        },
+        extractComments: false, // 별도의 파일로 주석을 추출하지 않음
+        parallel: true, // 멀티 프로세스를 사용하여 빌드 속도 향상
+      }),
+    ],
+  },
 });

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -5,7 +5,6 @@ import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
 // import {sentryWebpackPlugin} from '@sentry/webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,7 +23,6 @@ export default merge(common, {
     new Dotenv({
       path: '.env.prod',
     }),
-    new ForkTsCheckerWebpackPlugin(),
     // sentryWebpackPlugin({
     //   authToken: process.env.SENTRY_AUTH_TOKEN,
     //   org: 'wtc-o6',

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -17,6 +17,7 @@ export default merge(common, {
     chunkFilename: '[id].[contenthash].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
+    publicPath: '/',
   },
   devtool: 'nosources-source-map',
   plugins: [

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -5,6 +5,7 @@ import common from './webpack.common.mjs';
 import {fileURLToPath} from 'url';
 // import {sentryWebpackPlugin} from '@sentry/webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,6 +23,7 @@ export default merge(common, {
     new Dotenv({
       path: '.env.prod',
     }),
+    new ForkTsCheckerWebpackPlugin(),
     // sentryWebpackPlugin({
     //   authToken: process.env.SENTRY_AUTH_TOKEN,
     //   org: 'wtc-o6',

--- a/client/webpack.prod.mjs
+++ b/client/webpack.prod.mjs
@@ -31,6 +31,9 @@ export default merge(common, {
     //   },
     // }),
   ],
+  cache: {
+    type: 'filesystem',
+  },
   optimization: {
     minimize: true,
     minimizer: [


### PR DESCRIPTION
## issue
- close #1000
(영광의 1000번째 브랜치!!! 다들 1000번까지 달리느라 고생많았습니다..)
 
## 구현 목적
- 3회 측정 후 평균낸 값 기준으로는 빌드 시간이 build: 27초, build-dev: 13초로 많이 느립니다. 배포 결과 확인이 느려서 불편할 정도입니다. 
- 웹팩 말고도 전반적으로 빌드 속도에 영향이 미치는 부분을 수정했습니다.
- webpack dev 빌드 세팅에 터서 최적화가 적용되어 있습니다. dev모드에서는 큰 의미가 없는 최적화입니다.
- prod에서 불필요하게 소스맵이 공개되고 있습니다.
- 그 외 이런저런 불필요한 옵션이나 쓰면 좋을 옵션들을 추가하려 합니다.

## 구현 사항
**목차**
[1] webpack prod 환경에서의 빌드 최적화
[2] 환경 별로 올바르게 소스맵 규칙 수정
[3] [hash] deprecated 오류 제거
[4] emotion pragma 삽입 코드 제거
[5] workflow에서 node_modules 캐싱
[6] sentry제거
[7] terser optimization

### [1] webpack prod 환경에서의 빌드 최적화
prod 환경에서 적용할 수 있는 빌드 최적화 방법은 다음과 같습니다. 

#### [1.1] 중복 타입 검사 제거
현재 ts-loader, ForkTsCheckerWebpackPlugin 에 의해 타입이 중복 검사되고 있습니다.

ts-loader는 트랜스 파일링 용도로만 사용하고 타입 검사는 사용하지 않도록 합니다. 타입 검사에는 ForkTsCheckerWebpackPlugin만 사용하도록 수정했습니다.

그럼 ts-loader만 사용하고 ForkTsCheckerWebpackPlugin은 깔지 않아도 되지 않냐고 할 수 있는데, 별도의 프로세스로 분리되어 동시에 병렬 작업이 가능해 시간 단축이 됩니다. 애초에 ForkTsCheckerWebpackPlugin의 존재 의미 또한 "Webpack plugin that runs TypeScript type checker on a separate process."입니다. 내부적으로 리눅스 fork()같이 자식 프로세스를 만드는 로직을 실행시켜 별도의 프로세스에서 작업됩니다. 

그러면 ts-loader도 똑같이 fork 쓰면 되지 않나 생각이 들 수 있는데, 다양한 이유가 있으나 가장 핵심적인건 크게 두가지 입니다. loader의 책임을 벗어남 + 파일(모듈) 단위 실행입니다.
웹팩에서 로더는 파일(모듈) 단위 트리거 -> 변환 의 연속입니다. 그러나 이 파일 단위에 fork가 끼게 되면 이 자식 프로세스 수거까지도 일이 되기 때문에 책임을 벗어납니다. 
그리고 파일 단위로 실행이 되기 때문에 파일 100개면 fork 100개 되서 오버헤드가 너무 커집니다.

플러그인은 기본적으로는 파일 단위가 아니라 전체 단위로도 실행이 가능하기 떄문에 하나의 포크로도 충분합니다.

#### [1.2] 파일시스템 캐싱 + prod build 워크플로우 수정
사실 이게 유의미하려면 빌드돌리는 컴퓨터가 유지되어야 합니다. 파일시스템 캐싱이라는건 파일 시스템에 캐싱파일 저장을 기반으로하여 동작됩니다.

그런데 지금 행동대장 빌드는 깃헙 액션에서 수행되고 있고 여기서는 필요할 때마다 vm을 만들어서 새걸 주기 때문에 캐싱 데이터가 유지되지 못합니다.

그래서 캐싱 데이터를 저장하는 경로인 node_modules/.cache를 캐싱하도록 워크플로우에 추가했습니다. (참고: vm이 유지되는 방식은 아니고 깃헙 클라우드 어딘가에 저장이 되었다가 복원해 사용하는 방식입니다.)

### [2] 환경 별로 올바르게 소스맵 규칙 수정
기존에는 prod환경에서 소스맵이 그대로 노출되고 있었습니다. 소스맵을 노출시키는건 prod 환경의 일반 사용자에겐 의미가 없으므로 제거합니다.

또한 원본 소스를 첨부하는 source-map옵션보다 변경된 nosources-source-map옵션으로 변경할 경우 소스맵에 소스코드를 쓸 필요가 없으므로 빌드 속도 향상에 효과가 있을 것이라 예상됩니다.

그러나 실제 결과는 유의미한 차이는 없었습니다.

dev환경에서는 빈번한 재빌드에 빠른 소스맵을 사용하도록 source-map -> eval-source-map으로 변경했습니다.

### [3] [hash] deprecated 오류 제거
이제는 지원하지 않는 [hash]를 제거하고 [contenthash]로 수정합니다. 파일 단위로 해시가 갱신됩니다. 청크해시도 있지만 지금 파일 스플리팅이 되고 있기 때문에 큰 의미는 없습니다.

### [4] emotion pragma 삽입 코드 제거
emotion을 사용하기 위해 파일 상단에 적어주는 pragma가 있습니다. 
ModifySourcePlugin를 사용해 해당 pragma를 로더단에서 강제로 주입해서(시간을씀) 개발자는 pragma를 안써도 되도록 했었는데요. 

이 로더 자체를 제거하여도 프라그마 없이 충분히 emotion을 사용할 수 있으므로 제거했습니다.

모든 파일(모듈) 진입 후 코드 추가하는 과정에 걸리는 시간은 파일 개수 와 비례하여 선형 증가합니다.

### [5] workflow에서 node_modules 캐싱
npm i는 전체적인 빌드과정에서 많은 시간을 차지하고 있습니다.
워크플로우에서 캐싱해 시간을 줄이려고 합니다.

### [6] sentry제거
최근까지는 치명적인 오류가 발생하지 않았기 때문에 유의미하게 사용되지 않고 빌드 시간만 차지해서 제거했습니다.

그러나 얼마 전에 서비스 사용에 지장을 주는 이미지 업로드같은 오류가 발생하였습니다. 지금처럼... 사용자나 개발자가 수동으로 발견하지 않으면 안되는 현재의 상황을 해결하기 위해 금방 돌려놓고 오류 노티 시스템을 구축할 생각입니다.

### [7] terser optimization
주석 제거, 코드 압축, 이름 축약으로 코드 양 축소 용도
현재 이 터서 최적화가 dev환경에 적용되어 있으므로 prod 환경으로 이전하였습니다. 빌드 시간에 큰 영향을 미치는 것은 아니나, 불필요하므로 ..

## 결과
모든 시간은 3회 실행 후 평균을 내어 산정되었습니다. 모두 맥 os환경이고 파워 연결없이 측정되었습니다. (파워 연결 차이가 커서 더 안좋은 환경에서 측정)

사용 환경에 따라 시간이 매우 유동적이므로 시간 차이보다는 개선율에 의미가 있습니다.

| Build Type         | 개선 전 | 개선 후 | 개선율 (%)       |
|-------------------|------------|------------|--------------|
| build            | 27s       | 17s (수정량에 따라 1s~) | ▼ 37.0%  |
| build(sentry제거) | 22s        | -          | -            |
| build-dev        | 12s        | 7s         | ▼ 41.7%  |

주된 개선 항목은 프라그마 부착이 1~2초, 타입 중복 체크가 1~2초 입니다.

## 🫡 참고사항
- npm run lint -- --fix로 린팅하실텐데 npm run lint만 쓰면 되도록 스크립트 수정했습니다. (자꾸까먹어요)

