### PR TITLE
[FE] 관리자 계좌번호 미입력시 참여자 Banner 알림

### DIFF
--- a/client/src/components/Design/components/Banner/Banner.tsx
+++ b/client/src/components/Design/components/Banner/Banner.tsx
@@ -38,9 +38,11 @@ const Banner = ({title, description, buttonText, onDelete, ...buttonProps}: Bann
           )}
         </div>
       </Flex>
-      <Button variants="tertiary" size="small" {...buttonProps}>
-        {buttonText}
-      </Button>
+      {buttonText && (
+        <Button variants="tertiary" size="small" {...buttonProps}>
+          {buttonText}
+        </Button>
+      )}
     </Flex>
   );
 };

--- a/client/src/components/Design/components/Banner/Banner.type.ts
+++ b/client/src/components/Design/components/Banner/Banner.type.ts
@@ -2,5 +2,5 @@ export type BannerProps = React.HTMLAttributes<HTMLButtonElement> & {
   onDelete: () => void;
   title: string;
   description?: string;
-  buttonText: string;
+  buttonText?: string;
 };

--- a/client/src/components/Design/components/SendButton/SendButton.tsx
+++ b/client/src/components/Design/components/SendButton/SendButton.tsx
@@ -18,7 +18,7 @@ const SendButton = ({isDeposited = false, canSend = true, ...buttonProps}: BankS
     <button css={sendButtonStyle(theme, isDeposited)} disabled={isDeposited} {...buttonProps}>
       <Flex justifyContent="center" alignItems="center">
         <Text size="tiny" textColor="black">
-          {canSend ? (isDeposited ? '송금완료' : '송금하기') : '금액복사'}
+          {isDeposited ? '송금완료' : canSend ? '송금하기' : '금액복사'}
         </Text>
       </Flex>
     </button>

--- a/client/src/pages/event/[eventId]/home/HomePage.tsx
+++ b/client/src/pages/event/[eventId]/home/HomePage.tsx
@@ -4,9 +4,11 @@ import StepList from '@components/StepList/Steps';
 import Reports from '@components/Reports/Reports';
 import useRequestGetImages from '@hooks/queries/images/useRequestGetImages';
 import {IconPictureSquare} from '@components/Design/components/Icons/Icons/IconPictureSquare';
+import {Banner} from '@components/Design/components/Banner';
 
 import useEventDataContext from '@hooks/useEventDataContext';
 import useAmplitude from '@hooks/useAmplitude';
+import useBanner from '@hooks/useBanner';
 
 import {useTotalExpenseAmountStore} from '@store/totalExpenseAmountStore';
 
@@ -20,13 +22,20 @@ import {receiptStyle} from './HomePage.style';
 
 const HomePage = () => {
   const {trackCheckStepList} = useAmplitude();
-  const {isAdmin, eventName, steps} = useEventDataContext();
+  const {isAdmin, eventName, steps, bankName, accountNumber} = useEventDataContext();
   const isInHomePage = useMatch(ROUTER_URLS.home) !== null;
 
   const {totalExpenseAmount} = useTotalExpenseAmountStore();
   const {images} = useRequestGetImages();
   const navigate = useNavigate();
   const eventId = getEventIdByUrl();
+
+  const {isShowAccountBanner, onDeleteAccount} = useBanner({
+    eventId,
+    bankName,
+    accountNumber,
+    steps,
+  });
 
   return (
     <div css={receiptStyle}>
@@ -41,6 +50,13 @@ const HomePage = () => {
           )
         }
       />
+      {isShowAccountBanner && (
+        <Banner
+          onDelete={onDeleteAccount}
+          title="주최자가 계좌번호를 등록하지 않았어요"
+          description="계좌번호 복사는 불가능해요. 금액만 복사 할 수 있어요."
+        />
+      )}
       <Tabs>
         <Tab label="참여자 별 정산" content={<Reports />} />
         <Tab


### PR DESCRIPTION
## issue
- close #1009 

## 구현 목적

행사의 관리자가 해당 행사의 계좌번호를 입력하지 않았을 경우, 다음과 같이 `금액복사` 버튼이 나타나게 됩니다. 이때, 금액 복사를 클릭할 경우 금액만 복사가 되고 계좌번호는 복사되지 않습니다.

추가로 입금이 완료되었을 경우에는 `금액복사` 버튼이 나타나면서 아무런 상호작용도 존재하지 않습니다.

<img  width="300px" alt="계좌번호_미등록" src="https://github.com/user-attachments/assets/ca7fa95e-620b-4646-ab02-2ff84eabb5b8"/>

<img  width="300px" alt="계좌번호_미등록_참여자" src="https://github.com/user-attachments/assets/96e20f0e-2501-47f8-aac4-ee84e27a48bf"/>

아래는 계좌번호 입력이 완료되었을 경우의 화면입니다.
관리자가 행사의 계좌번호를 입력했을 경우, 참여자는 다음과 같이 `송금완료` 혹은 `송금하기` 버튼이 나타나게 됩니다.

<img  width="300px" alt="계좌번호_등록" src="https://github.com/user-attachments/assets/08103b1c-6204-416b-ac31-c2c6b4f0d66f"/>

<img  width="300px" alt="계좌번호_등록_참여자" src="https://github.com/user-attachments/assets/b04cb53c-28ab-43c8-a360-d4d117c1d1e6"/>

### 현재 기능의 문제점

- 행사에 입력된 계좌번호가 없을 경우에 `참여자는 계좌번호가 존재하지 않음을 인지할 수 없음.`
- 계좌번호를 입력하지 않았고 송금이 완료된 경우에 `금액복사 버튼이 출력됨.` → 이는 송금이 되었는지 혼동을 줄 수 있음.

### 문제점 개선

- 행사에 입력된 계좌번호가 없을 경우, 참여자에게 계좌번호가 존재하지 않음을 인지할 수 있도록 Banner를 활용하여 알림 띄우기.
- 계좌번호가 입력되지 않았고 송금이 완료된 경우에는 `금액복사` 버튼이 아닌 `송금완료` 버튼이 출력되도록 수정하기

## 구현

### 행사 계좌번호가 없을 경우 ‘홈(참여자가 보는)’ 페이지에  Banner 알림 띄우기

행사에 등록된 계좌번호가 없을 경우, 참여자가 주로 보게 되는 ‘홈 페이지’에 Banner를 활용하여 주최자가 계좌번호를 등록하지 않아 금액만 복사가 가능하다는 알림을 띄웁니다.

- Banner 컴포넌트 buttonText 필수 입력을 선택 입력으로 변경
    
    기존에는 Banner 컴포넌트에 버튼이 필수적으로 필요했습니다.

    <img width="327" alt="계좌번호_미등록_배너_버튼필수" src="https://github.com/user-attachments/assets/bda3a5fb-8cd7-4f1e-a0a3-bce6926ec1c4" />
    
    그러나, 참여자가 주로 보는 ‘홈 페이지’에는 Banner를 활용할 때 해당 버튼이 필요 없다고 판단했습니다. 참여자가 주최자에게 계좌번호를 입력해달라고 알람을 보낸다는 등의 기능을 추가할 수 없는 상황이기 때문입니다. 
    
    따라서, buttonText의 입력이 필수적이지 않아도 되겠다고 판단하여 해당 props를 선택적으로 사용할 수 있도록 변경했습니다.
    
    <img width="326" alt="계좌번호_미등록_배너_버튼미필수" src="https://github.com/user-attachments/assets/99c92568-1c0a-4cd8-b7e7-1831d3df4e47" />

- HomePage에 Banner 추가하기
    
    기존의 Banner 컴포넌트와 useBanner 훅을 활용하여 구현했습니다.
    
    기존의 useBanner에 isShowAccountBanner와 onDeleteAccount라는 상태가 존재했습니다. 해당 상태는 계좌번호가 입력 여부에 따라서 Banner를 띄울지 말지를 관리합니다. 해당 페이지에서도 이 상태를 그대로 사용해도 된다고 판단했습니다. 판단 이유는 아래와 같습니다.
    
    1. 계좌번호가 입력되었는지를 판단하여 Banner를 띄울지를 판단하는 상태
    2. sessionStorage를 관리함.
    
    따라서 useBanner 훅을 그대로 사용하여 HomePage에서 조건부 렌더링을 활용하여 Banner를 띄웁니다.
    
    ```tsx
    // pages/event/[eventId]/home/HomePage.tsx
    
    // (생략) ...
    
    const {isShowAccountBanner, onDeleteAccount} = useBanner({
      eventId,
      bankName,
      accountNumber,
      steps,
    });
    
    // (생략) ...
    
     {isShowAccountBanner && (
      <Banner
        onDelete={onDeleteAccount}
        title="주최자가 계좌번호를 등록하지 않았어요"
        description="계좌번호 복사는 불가능해요. 금액만 복사 할 수 있어요."
      />
    )}
    
    // (생략) ...
    ```
    
    **🤔 여기서 하나 우려되는 점**
    
    useBanner에서 가져온 상태는 기존에 행사 주최자(=관리자)가 보는 ‘관리 페이지’에서 계좌번호를 입력해달라는 Banner를 띄우기 위해서 활용했던 상태입니다. 그렇기에 만약 ‘홈 페이지’에서 계좌번호 미입력 Banner를 닫았다면, ‘관리 페이지’에서도 계좌번호를 입력해달라는 Banner가 같이 닫히게 됩니다. 
    
    문제될 점은 아니라고 판단하여 그대로 사용하긴 했습니다. 이유는 아래와 같습니다.
    
    - 관리자가 어느 페이지에서 계좌번호 Banner를 닫았던 일단 `계좌번호가 입력되지 않았음을 인식`했다는 것.
    - 따라서 한 쪽 페이지에서 Banner를 닫아도 다른 쪽 페이지에서 Banner가 닫히는 것이 문제되지는 않음.
    - 결국은 동일한 사용자가 동일한 행사를 본 것이기 때문.
    
    혹시 해당 부분에서 문제가 될 것 같으면 말씀해주세요!
    

### 계좌번호가 없고 송금이 완료됐을 경우, `금액복사` 버튼이 아닌 `송금완료` 버튼 출력하기

현재는 1. 계좌번호가 입력되지 않았고 2. 송금이 완료된 사용자가 존재할 경우 해당 사용자는 ‘홈 페이지’에서 `금액복사` 버튼이 띄워지면서 아무런 상호작용이 일어나지 않습니다. 이는 사용자에게 혼동을 초래할 수 있습니다.

1. 송금이 완료되었는데 `금액복사` 버튼이 여전히 띄워짐.
2. `금액복사` 버튼을 클릭했는데 아무런 상호작용이 존재하지 않음.

위와 같은 혼동을 초래하여 사용자는 서비스에 문제가 있는지 생각하게 될 것입니다. (제가 그랬습니다…)

**따라서 처음에 언급한 조건일 경우 `금액복사` 버튼이 아닌 `송금완료` 버튼이 출력되도록 수정합니다.**

```tsx
 // Design/components/SendButton.tsx
 
 // ... (생략)
 
 <Text size="tiny" textColor="black">
  {isDeposited ? '송금완료' : canSend ? '송금하기' : '금액복사'}
</Text>
```

**송금이 완료**되었을 경우, **계좌번호 입력 여부에 상관없이** `송금완료` 버튼을 출력합니다.
**송금이 완료되지 않았**을 경우, **계좌번호가 입력**되었다면 `송금하기`를 **입력되지 않았**다면 `금액복사`를 출력합니다.

위와 같이 수정함으로 사용자는 혼동을 방지할 수 있을 것입니다.

## 결과

<img width="344" alt="계좌번호_미등록_개선" src="https://github.com/user-attachments/assets/9abc5312-d90e-4ab6-8928-4ac6345ae1b4" />
