### PR TITLE
[FE] 계좌번호 복사 붙여넣기 기능이 작동하지 않는 버그 해결

### DIFF
--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import validateAccountNumber, {cleanedFormatAccountNumber} from '@utils/validate/validateAccountNumber';
 import {BankAccount, BankName} from 'types/serviceType';
@@ -26,7 +26,7 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
 
   const [accountNumberErrorMessage, setAccountNumberErrorMessage] = useState<string | null>(null);
   const [canSubmit, setCanSubmit] = useState(false);
-  const [isPasting, setIsPasting] = useState(false);
+  const isPasting = useRef(false);
 
   const selectBank = (name: BankName) => {
     setBankName(name);
@@ -41,14 +41,14 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
   };
 
   const handleAccountOnTyping = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (isPasting) return;
+    if (isPasting.current) return;
 
     const newAccountNumber = event.target.value;
     handleAccount(newAccountNumber);
   };
 
   const handleAccountOnPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
-    setIsPasting(true);
+    isPasting.current = true;
 
     const newAccountNumber = `${accountNumber}${event.clipboardData.getData('text')}`;
     const validAccountNumber = newAccountNumber
@@ -57,7 +57,9 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
       .trim();
 
     setAccountNumber(validAccountNumber);
-    setTimeout(() => setIsPasting(false), 0);
+    setTimeout(() => {
+      isPasting.current = false;
+    }, 0);
   };
 
   const enrollAccount = async () => {

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -52,8 +52,8 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
 
     const newAccountNumber = `${accountNumber}${event.clipboardData.getData('text')}`;
     const validAccountNumber = newAccountNumber
-      .replace(/[^\d\s\-]/g, '')
-      .replace(/\s+/g, ' ')
+      .replace(/[^\d\s\-]/g, '') // 숫자 공백 하이픈(-)이 아닌 문자 ''으로 대체
+      .replace(/\s+/g, ' ') // 공백이 여러 개 연속이라면 공백 한 개로 대체
       .trim();
 
     setAccountNumber(validAccountNumber);

--- a/client/src/hooks/useAccount.ts
+++ b/client/src/hooks/useAccount.ts
@@ -37,7 +37,6 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
     setAccountNumberErrorMessage(errorMessage);
 
     const canEdit = canEditAccountNumber(newAccountNumber);
-
     if (canEdit) setAccountNumber(newAccountNumber);
   };
 
@@ -52,8 +51,12 @@ const useAccount = ({accountNumber: defaultAccountNumber, bankName: defaultBankN
     setIsPasting(true);
 
     const newAccountNumber = `${accountNumber}${event.clipboardData.getData('text')}`;
-    handleAccount(newAccountNumber);
+    const validAccountNumber = newAccountNumber
+      .replace(/[^\d\s\-]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
 
+    setAccountNumber(validAccountNumber);
     setTimeout(() => setIsPasting(false), 0);
   };
 


### PR DESCRIPTION
## issue
- close #1016 

## 구현 사항
### paste 이벤트가 일어났을 때 handleAccount의 조건 때문에 붙여 넣지 못했던 문제

#634 이 이슈에서 구현한 기능(신한은행 1021-12312-1123 문자열이 붙여넣기 될 때 1021-12312-1123만 남는 기능 구현)이 작동하지 않는다는 것을 확인했습니다.

paste 콜백 안에서 handleAccount를 사용해 정제하려고 했지만 정규식에 맞지 않는 문자열이 들어올 경우 '신한 1231-123123' canEditAccountNumber(newAccountNumber)가 false여서 accountNumber를 갱신하지 않는 문제가 있었습니다. 즉, 붙여넣은 값이 canEditAccountNumber의 조건을 통과하지 못하면 input에 표시되지 않게 되는 버그가 있었습니다.

### paste는 따로 정규식을 적용해서 숫자 공백 하이픈이 아닌 문자열 지우고 trim으로 필요한 문자만 남기도록 구현
아래처럼 clipboardData.getData 해온 값을 정규식에 맞지 않는 문자를 대체하고 set해주는 방식으로 붙여넣기가 지원되도록 고쳤습니다.

```ts
    const newAccountNumber = `${accountNumber}${event.clipboardData.getData('text')}`;
    const validAccountNumber = newAccountNumber
      .replace(/[^\d\s\-]/g, '')
      .replace(/\s+/g, ' ')
      .trim();

    setAccountNumber(validAccountNumber);
```

### isPasting 락을 세운 이유
붙여넣기 이벤트가 발생할 때 `onPaste`가 먼저 실행되고 뒤이어 `onChange`가 실행됩니다.
![image](https://github.com/user-attachments/assets/6f3f0b80-bd7a-4a2b-b4c7-8e5e9b164056)

그래서 복사 붙여넣기가 되고 바로 onChange가 실행되어 정규식에 맞는지 검사를 하게 되며 이 때 change의 value는 가공된 값이 아닌 가공되기 전으로 비교하기 때문에 올바르게 입력됐음에도 오류라고 안내하게 됩니다.
![image](https://github.com/user-attachments/assets/f765a4e2-0f96-4546-b205-653567e17675)

그래서 isPasting을 사용해서 paste가 실행 중일 땐 change가 실행되지 않도록 락을 세웠습니다.

### setTimeout을 사용해서 상태를 바꾼 이유
그렇다면 왜 단순히 함수 마지막에 `isPasting = false`을 사용하지 않고 setTimeout을 사용했는지를 설명하겠습니다.
먼저 요약하자면 `setter 작업 완료를 보장받고 락을 해제하고 싶었기 때문`입니다.

paste 이벤트가 일어나면 handleAccountOnPaste 함수 내부에서 isPasting 락을 걸고 setAccountNumber를 호출하고 락을 해제합니다. 이 때 useState의 setter인 setAccountNumber가 비동기 함수라는 점에 주목했습니다.

setter가 불리게 되면 내부 React의 스케쥴링 큐에 의해 accountNumber 상태를 바꿔줍니다. 이 작업이 완료됨을 보장 받고 isPasting을 false로 바꿔주어야 안전하다고 생각해서 setTimeout을 사용했습니다. setTimeout 함수의 특징은 실행되면 내부 콜백(isPasting.current = false)이 브라우저의 태스크 큐에 들어가게 되고 콜스택이 비었을 때 내부 콜백이 실행됩니다.

전체 흐름 : 락 설정 -> setter 실행 -> 락 해제 예약 -> 상태 변경 완료 -> 락 해제


### useState 방식에서 useRef로 isPasting 가드 변수 관리 방식 변경
isPasting 상태는 렌더링에 연관을 주는 상태가 아닙니다. 단지 복사 붙여넣기 이벤트가 실행될 때 change 이벤트를 막기 위함이었는데 state를 사용해서 리렌더링을 유발했습니다. 그래서 리렌더링에 영향을 주지 않고 관리할 수 있는 useRef를 사용하는 방식으로 바꿨습니다.
  
```ts
const isPasting = useRef(false);

const handleAccountOnTyping = (event: React.ChangeEvent<HTMLInputElement>) => {
    if (isPasting.current) return;

    const newAccountNumber = event.target.value;
    handleAccount(newAccountNumber);
  };

const handleAccountOnPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
    isPasting.current = true;
   ...
    setTimeout(() => {
      isPasting.current = false;
    }, 0);
  };
```

## 구현결과

https://github.com/user-attachments/assets/3bb7a5fc-1960-400d-b21d-1049304882a8


## 🫡 참고사항
- 작동 테스트를 아래 배포 링크 코멘트를 클릭하면 바로 확인할 수 있습니다 :)

